### PR TITLE
Add 'See data' link to landscape map page

### DIFF
--- a/landscape-map.html
+++ b/landscape-map.html
@@ -2,11 +2,11 @@
 <html data-wf-page="669a75f83ab442b871be9e93" data-wf-site="65380b51b01b69a63d681e04">
 <head>
   <meta charset="utf-8">
-  <title>Landscape map – AISafety.com</title>
+  <title>Landscape map – AISafety.com</title>
   <meta content="Map displaying the main organizations, projects, and programs currently operating in the AI Safety space." name="description">
-  <meta content="Landscape map – AISafety.com" property="og:title">
+  <meta content="Landscape map – AISafety.com" property="og:title">
   <meta content="Map displaying the main organizations, projects, and programs currently operating in the AI Safety space." property="og:description">
-  <meta content="Landscape map – AISafety.com" property="twitter:title">
+  <meta content="Landscape map – AISafety.com" property="twitter:title">
   <meta content="Map displaying the main organizations, projects, and programs currently operating in the AI Safety space." property="twitter:description">
   <meta property="og:type" content="website">
   <meta content="summary_large_image" name="twitter:card">
@@ -78,7 +78,7 @@
           </a>
           <a id="w-node-_22578ad6-1bf1-a944-da59-8cf47cf10dce-e25e99d3" href="events-and-training.html" class="landing-resource_card_flex w-inline-block"><img src="images/calendar.svg" loading="lazy" id="w-node-_22578ad6-1bf1-a944-da59-8cf47cf10dcf-e25e99d3" alt="">
             <div>
-              <p class="paragraph-large-bold padding-16px">Events &amp; training</p>
+              <p class="paragraph-large-bold padding-16px">Events &amp; training</p>
               <p>Gatherings and training programs, both online and in-person</p>
             </div>
           </a>
@@ -98,7 +98,7 @@
           </a>
           <a id="w-node-_22578ad6-1bf1-a944-da59-8cf47cf10de4-e25e99d3" href="https://aisafety.info/questions/9OGZ/" target="_blank" class="landing-resource_card_flex w-inline-block"><img src="images/letters.svg" loading="lazy" id="w-node-_22578ad6-1bf1-a944-da59-8cf47cf10de5-e25e99d3" alt="">
             <div>
-              <p class="paragraph-large-bold padding-16px">AI Safety guide</p>
+              <p class="paragraph-large-bold padding-16px">AI Safety guide</p>
               <p>A comprehensive introduction to AI Safety, written and curated by our team and affiliates</p>
             </div>
           </a>
@@ -149,13 +149,19 @@
         <div class="flex-horizontal_center">
           <p class="paragraph-default-bold padding-16px">Communities <span class="color-grey">→</span></p>
         </div>
-        <p><span>Browse AI Safety groups based online and locally around the globe</span></p>
+        <p><span>Browse AI Safety groups based online and locally around the globe</span></p>
       </a>
       <a id="w-node-_7f4ccdb5-0da1-c4ed-5080-0efdf9be5c3b-71be9e93" href="funders.html" class="padding-40px hover-opacity hide-mobile w-inline-block">
         <div class="flex-horizontal_center">
           <p class="paragraph-default-bold padding-16px">Funders <span class="color-grey">→</span></p>
         </div>
-        <p><span>See a comprehensive list of organizations funding work related to AI Safety<br></span></p>
+        <p><span>See a comprehensive list of organizations funding work related to AI Safety<br></span></p>
+      </a>
+      <a id="w-node-see-data" href="https://airtable.com/appVkcT88vu8CSBK9/pagsduyIeO61yGzTv" target="_blank" class="padding-40px hover-opacity w-inline-block">
+        <div class="flex-horizontal_center">
+          <p class="paragraph-default-bold padding-16px">See data <span class="color-grey">→</span></p>
+        </div>
+        <p><span>View and download the list of organizations from the map of AI existential safety</span></p>
       </a>
     </div>
   </div>


### PR DESCRIPTION
Per our discussion on March 14 during the "AIsafety.com Team Meeting", we agreed to scope and try to prioritize:
add a link that takes users to the airtable next to the tiles view of the map

see before/after here: https://github.com/StampyAI/AISafety.com/issues/162#issuecomment-2725401899