### PR TITLE
fix(MainPage): bottom margin to cards half width

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -153,7 +153,7 @@ export default function Home() {
         </div>
       </div>
 
-      <div className="cards-grid margin-40px">
+      <div className="cards-grid margin-40px mb-10">
         <div className="card-half-width-1">
           <div className="card-half-width-main-text">
             <p className="paragraph-small-bold padding-12px shadow-text">


### PR DESCRIPTION
https://github.com/StampyAI/AISafety.com/issues/233


There's inconsistency regarding the cards gap on the main page. The first pictures shows the gap on the webflow version:

<img width="1331" height="909" alt="Image" src="https://github.com/user-attachments/assets/50408e9e-097c-4400-af93-d22566b0434b" />

Here's what it looks like on the vercel app:

<img width="1331" height="909" alt="Image" src="https://github.com/user-attachments/assets/66168f70-174a-43a7-9921-b23ee6872ead" />

The gap on the webflow version is `40px`