### PR TITLE
Fix focus outlines on click and center map zoom icons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,7 +87,7 @@ a {
    on page navigation. Smooth scrolling is applied only where needed (e.g.
    anchor links) via the UpButton component. */
 
-*:focus {
+*:focus-visible {
   outline: 2px solid var(--bright-teal-500);
   outline-offset: 2px;
 }

--- a/src/app/map/D3Map.tsx
+++ b/src/app/map/D3Map.tsx
@@ -385,8 +385,6 @@ export default function D3Map({ orgs }: D3MapProps) {
             title="Zoom in"
           >
             <svg
-              width="16"
-              height="16"
               viewBox="0 0 16 16"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
@@ -403,8 +401,6 @@ export default function D3Map({ orgs }: D3MapProps) {
             title="Zoom out"
           >
             <svg
-              width="16"
-              height="16"
               viewBox="0 0 16 16"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
@@ -421,8 +417,6 @@ export default function D3Map({ orgs }: D3MapProps) {
             title="Reset view"
           >
             <svg
-              width="16"
-              height="16"
               viewBox="0 0 16 16"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"

--- a/src/app/map/page.module.css
+++ b/src/app/map/page.module.css
@@ -38,7 +38,7 @@
 }
 
 .map-control-button {
-  width: 40px;
+  width: 100%;
   height: 40px;
   background-color: #0e2628;
   color: white;


### PR DESCRIPTION
- **Focus outlines:** Changed `*:focus` to `*:focus-visible` in globals.css so the teal outlines only show on keyboard navigation, not mouse clicks. This was affecting buttons, cards, checkboxes, and links site-wide.
- **Map zoom icons:** Fixed the +/−/reset icons being slightly off-center in the pill control on /map by using `width: 100%` instead of a hardcoded `40px`, and removing conflicting `width`/`height` attributes from the inline SVGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)