### PR TITLE
signal dark mode to browsers and plugins

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,6 +24,9 @@
    =============================== */
 
 :root {
+  /* Signal dark mode to browsers and plugins (e.g., Dark Reader) */
+  color-scheme: dark;
+
   /* Teal Scale */
   --teal-100: #e3e5e6;
   --teal-200: #c6cccc;


### PR DESCRIPTION
I'm running DarkReader, a darkmode plugin, and it (and others) doesn't automatically detect that it shouldn't modify the webpage. This also allows browsers to change UI elements to match with the page better.