### PR TITLE
Cache airtable images locally, 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# generated at build time
+/public/images/airtable-cache/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,11 +2,3 @@
 # Set PATH to include common Node.js locations for GUI apps like GitHub Desktop
 export PATH="/usr/local/bin:$PATH"
 npx lint-staged
-
-# Check if any files were modified by formatting/linting
-if [ -n "$(git diff --name-only)" ]; then
-  echo "❌ Files were modified by linting/formatting. Please stage the changes and commit again."
-  echo "Modified files:"
-  git diff --name-only
-  exit 1
-fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,23 @@ The #1 source of sloppy code in this project is recreating styles that already e
 
 If a button hover looks wrong, fix the shared `.button-primary` definition — don't add a one-off hover style. That way every button is fixed at once. This is the whole point of standardizing: define once, reference everywhere.
 
+## Error Handling: Never Silently Fail
+
+Errors must propagate so developers can fix them. Never silently swallow errors, use fallback values for invalid data, or assume defaults when encountering unexpected input.
+
+- **Don't** catch exceptions and ignore them
+- **Don't** return default values for invalid input (e.g., assuming `.png` for an unknown extension)
+- **Don't** skip items that fail to process without logging
+- **Do** throw errors with clear messages explaining what went wrong
+- **Do** let builds fail loudly when data is malformed
+- **Do** use `console.warn` for recoverable issues that need attention
+
+A silent failure today becomes a mystery bug tomorrow.
+
+## Before Committing: Always Build
+
+Always run `npm run build` before committing to verify changes work. Don't commit untested code - a broken build in main wastes everyone's time.
+
 ## Reference Files
 
 - `backup/` — HTML snapshots of every live page

--- a/src/app/communities/CommunitiesMap.tsx
+++ b/src/app/communities/CommunitiesMap.tsx
@@ -14,7 +14,6 @@ interface CommunitiesMapProps {
 declare global {
   interface Window {
     mapboxgl: any
-    mobileTooltipHandlersInitialized?: boolean
   }
 }
 
@@ -22,7 +21,7 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
   const mapContainerRef = useRef<HTMLDivElement>(null)
   const mapRef = useRef<any>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
-  const scriptLoadedRef = useRef(false)
+  const cleanupRef = useRef<(() => void) | null>(null)
 
   function initMap() {
     if (!mapContainerRef.current || !tooltipRef.current || !window.mapboxgl)
@@ -292,8 +291,8 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
         })
 
         // Mobile global handlers
-        if (isMobile && !window.mobileTooltipHandlersInitialized) {
-          tooltip.addEventListener('click', function (e) {
+        if (isMobile) {
+          const handleTooltipClick = function (e: MouseEvent) {
             if ((e.target as HTMLElement).closest('#mapbox-tooltip')) {
               const lnk = tooltip.getAttribute('data-link-url')
               if (lnk && lnk !== '#') {
@@ -306,8 +305,9 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
               }
               e.stopPropagation()
             }
-          })
-          document.addEventListener('click', function (e) {
+          }
+
+          const handleDocumentClick = function (e: MouseEvent) {
             const clickedOnMapCanvas = (e.target as HTMLElement).closest(
               '.mapboxgl-canvas'
             )
@@ -323,7 +323,7 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
                 )
                 clickedOnPin = features.length > 0
               } catch {
-                /* Ignore */
+                /* Ignore - map may be in invalid state */
               }
             }
             if (!clickedOnTooltip && !clickedOnPin) {
@@ -335,8 +335,16 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
                 }
               }
             }
-          })
-          window.mobileTooltipHandlersInitialized = true
+          }
+
+          tooltip.addEventListener('click', handleTooltipClick)
+          document.addEventListener('click', handleDocumentClick)
+
+          // Store cleanup function for useEffect teardown
+          cleanupRef.current = () => {
+            tooltip.removeEventListener('click', handleTooltipClick)
+            document.removeEventListener('click', handleDocumentClick)
+          }
         }
 
         // Custom reset button
@@ -399,10 +407,17 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
   }
 
   useEffect(() => {
-    if (scriptLoadedRef.current && window.mapboxgl) {
+    // Check if mapboxgl is already available (script loaded on previous mount)
+    if (window.mapboxgl) {
       initMap()
     }
     return () => {
+      // Clean up event listeners
+      if (cleanupRef.current) {
+        cleanupRef.current()
+        cleanupRef.current = null
+      }
+      // Clean up map instance
       if (mapRef.current) {
         mapRef.current.remove()
         mapRef.current = null
@@ -412,7 +427,6 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
   }, [])
 
   function handleScriptLoad() {
-    scriptLoadedRef.current = true
     initMap()
   }
 

--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -1,6 +1,18 @@
+import fs from 'fs'
+import path from 'path'
+import https from 'https'
+import http from 'http'
+
 export interface AirtableRawRecord {
   id: string
   fields: Record<string, unknown>
+}
+
+interface AirtableAttachment {
+  id: string
+  url: string
+  filename: string
+  type?: string
 }
 
 interface FetchOptions {
@@ -9,6 +21,163 @@ interface FetchOptions {
   filterByFormula?: string
   sort?: Array<{ field: string; direction: 'asc' | 'desc' }>
   fields?: string[]
+}
+
+const CACHE_DIR = path.join(process.cwd(), 'public', 'images', 'airtable-cache')
+const CONCURRENCY = 20
+
+function isAttachmentArray(value: unknown): value is AirtableAttachment[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    typeof value[0] === 'object' &&
+    value[0] !== null &&
+    'url' in value[0] &&
+    'filename' in value[0]
+  )
+}
+
+const ALLOWED_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.svg', '.webp', '.gif']
+
+function getExtension(url: string, filename: string): string {
+  const filenameExt = path.extname(filename).toLowerCase()
+  if (filenameExt && ALLOWED_EXTENSIONS.includes(filenameExt)) {
+    return filenameExt
+  }
+
+  const urlPath = new URL(url).pathname
+  const urlExt = path.extname(urlPath).toLowerCase()
+  if (urlExt && ALLOWED_EXTENSIONS.includes(urlExt)) {
+    return urlExt
+  }
+
+  throw new Error(
+    `Unknown image extension for attachment: filename="${filename}", url="${url}". ` +
+      `Allowed extensions: ${ALLOWED_EXTENSIONS.join(', ')}`
+  )
+}
+
+function downloadFile(url: string, dest: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest)
+    file.on('error', err => {
+      reject(err)
+    })
+    const protocol = url.startsWith('https') ? https : http
+
+    protocol
+      .get(url, response => {
+        if (response.statusCode === 301 || response.statusCode === 302) {
+          const redirectUrl = response.headers.location
+          if (redirectUrl) {
+            file.close()
+            fs.unlinkSync(dest)
+            downloadFile(redirectUrl, dest).then(resolve).catch(reject)
+            return
+          }
+        }
+
+        if (response.statusCode !== 200) {
+          file.close()
+          fs.unlinkSync(dest)
+          reject(new Error(`HTTP ${response.statusCode}`))
+          return
+        }
+
+        response.pipe(file)
+        file.on('finish', () => {
+          file.close()
+          resolve()
+        })
+      })
+      .on('error', err => {
+        file.close()
+        fs.unlink(dest, () => {})
+        reject(err)
+      })
+  })
+}
+
+interface DownloadTask {
+  recordId: string
+  fieldName: string
+  attachment: AirtableAttachment
+  localPath: string
+  localUrl: string
+}
+
+async function downloadAttachments(
+  records: AirtableRawRecord[]
+): Promise<void> {
+  if (!fs.existsSync(CACHE_DIR)) {
+    fs.mkdirSync(CACHE_DIR, { recursive: true })
+  }
+
+  const tasks: DownloadTask[] = []
+
+  for (const record of records) {
+    for (const [fieldName, value] of Object.entries(record.fields)) {
+      if (!isAttachmentArray(value)) continue
+
+      const attachment = value[0]
+      const ext = getExtension(attachment.url, attachment.filename)
+      // Use attachment.id in filename so cache auto-invalidates when image is replaced in Airtable
+      const localFilename = `${attachment.id}${ext}`
+      const localPath = path.join(CACHE_DIR, localFilename)
+      const localUrl = `/images/airtable-cache/${localFilename}`
+
+      if (fs.existsSync(localPath)) {
+        // Already cached, just update the URL
+        value[0] = { ...attachment, url: localUrl }
+        continue
+      }
+
+      tasks.push({
+        recordId: record.id,
+        fieldName,
+        attachment,
+        localPath,
+        localUrl,
+      })
+    }
+  }
+
+  if (tasks.length === 0) return
+
+  console.log(`Downloading ${tasks.length} attachments...`)
+
+  const failures: string[] = []
+
+  // Download in parallel with concurrency limit
+  for (let i = 0; i < tasks.length; i += CONCURRENCY) {
+    const batch = tasks.slice(i, i + CONCURRENCY)
+    const results = await Promise.allSettled(
+      batch.map(task => downloadFile(task.attachment.url, task.localPath))
+    )
+
+    for (let j = 0; j < results.length; j++) {
+      const task = batch[j]
+      const result = results[j]
+      const record = records.find(r => r.id === task.recordId)
+
+      if (result.status === 'fulfilled' && record) {
+        const field = record.fields[task.fieldName]
+        if (isAttachmentArray(field)) {
+          field[0] = { ...field[0], url: task.localUrl }
+        }
+      } else if (result.status === 'rejected') {
+        failures.push(
+          `${task.fieldName} for ${task.recordId}: ${result.reason}`
+        )
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Failed to download ${failures.length} attachments:\n${failures.join('\n')}`
+    )
+  }
 }
 
 export async function fetchAirtableRecords(
@@ -50,6 +219,7 @@ export async function fetchAirtableRecords(
 
     let response = await fetch(url.toString(), {
       headers: { Authorization: `Bearer ${token}` },
+      next: { revalidate: 3600 }, // Hourly revalidation fetches fresh API responses with valid attachment URLs
     })
 
     if (!response.ok) {
@@ -57,18 +227,21 @@ export async function fetchAirtableRecords(
       await new Promise(r => setTimeout(r, 1000))
       response = await fetch(url.toString(), {
         headers: { Authorization: `Bearer ${token}` },
+        next: { revalidate: 3600 }, // Retry also uses hourly revalidation
       })
     }
 
     if (!response.ok) {
-      console.warn('Airtable API error after retry:', response.status)
-      return []
+      throw new Error(`Airtable API error after retry: ${response.status}`)
     }
 
     const data = await response.json()
     allRecords.push(...(data.records as AirtableRawRecord[]))
     offset = data.offset || null
   } while (offset)
+
+  // Download all attachments and replace URLs with local paths
+  await downloadAttachments(allRecords)
 
   return allRecords
 }


### PR DESCRIPTION
Slightly messy PR, hard to avoid not doing that when working with Claude - but should be fine enough.
I don't expect any of you to be able to review the technical details, but feel free to look through the summary for anything that stands out and/or ask Claude.

Fixes #304 

Partially addresses #310 by the 1-hour revalidation. I.e. if somebody loads the page when the cache is more than 1 hour old, a new build will be triggered in the background, which is then served if they continue browsing or for the next person.
Not entirely sure this is the best way to do it, but seems fine enough.

Claude summary:

# Fix Airtable attachment caching and event listener cleanup

## Summary

- Auto-download all Airtable attachments at build time to avoid URL expiration (Airtable
URLs expire after 2 hours). This also speeds up page loading since it doesn't need to hit the airtable API at render time at all.
- Fix dev server not responding to Ctrl-C after running for a while
- Add error handling policies to CLAUDE.md

## Changes

Auto-download Airtable attachments (src/lib/data/airtable.ts)
- Detect attachment fields by shape (array with url + filename properties)
- Download to /public/images/airtable-cache/ and replace URLs with local paths
- Use attachment.id in filename so cache auto-invalidates when images are replaced in

Airtable
- Fail build loudly if any downloads fail (no silent failures)
- Throw on Airtable API failure instead of returning empty data (preserves ISR stale
cache)
- Hourly revalidation to get fresh API responses with valid download URLs

Fix event listener cleanup (src/app/communities/CommunitiesMap.tsx)
- Global document/tooltip click handlers were never removed on unmount
- Added proper cleanup in useEffect teardown

Fix pre-commit hook (.husky/pre-commit)
- Removed buggy check that flagged unrelated modified files (used git diff instead of
checking staged files)

Add policies to CLAUDE.md
- Error handling: never silently fail, always propagate errors
- Always run npm run build before committing