### PR TITLE
QA: Communities filters and exclude hidden records

### DIFF
--- a/src/app/communities/CommunitiesClient.tsx
+++ b/src/app/communities/CommunitiesClient.tsx
@@ -12,9 +12,7 @@ interface CommunitiesClientProps {
 }
 
 // Filter options based on Airtable data
-// QA: Airtable uses "In person" (no hyphen), not "In-person"
 const typeOptions = ['Online', 'In person']
-// QA: "Other" goes last rather than alphabetical
 const platformOptions = [
   'Discord',
   'Facebook',
@@ -26,7 +24,6 @@ const platformOptions = [
   'WhatsApp',
   'Other',
 ]
-// QA: Added "Inactive" option at the bottom
 const activityOptions = ['Very active', 'Active', 'Semi-active', 'Inactive']
 const focusOptions = ['Main focus is AI safety', 'Partial focus on AI safety']
 
@@ -89,8 +86,6 @@ export default function CommunitiesClient({
     focusFilters,
   ])
 
-  // QA: Counts should always reflect totals, not change dynamically
-  // as filters are applied. Use the full communities list, not filteredCommunities.
   const filterCounts = useMemo(() => {
     const counts = {
       type: {} as Record<string, number>,

--- a/src/app/events-and-training/EventsEmbeds.tsx
+++ b/src/app/events-and-training/EventsEmbeds.tsx
@@ -5,8 +5,6 @@ import styles from './page.module.css'
 
 const EMBEDS = [
   {
-    // QA: uses airtable-embed-mobile class to reduce height to 600px on mobile
-    // (matching live site's .airtable-embed-mobile-1 override)
     src: 'https://airtable.com/embed/appF8XfZUGXtfi40E/shrLgl03tMK4q6cyc?viewControls=on',
     height: 2600,
     className: `${styles['airtable-embed']} ${styles['airtable-embed-mobile']} margin-bottom-40px`,
@@ -92,10 +90,8 @@ export default function EventsEmbeds() {
   return (
     <>
       <div className="container-wide">{renderEmbed(0)}</div>
-      {/* QA: second embed is desktop-only, separate wrapper so it hides fully on mobile */}
       <div className="container-wide hide-mobile">{renderEmbed(1)}</div>
 
-      {/* QA: entire "Open for application" section is desktop-only on live site */}
       <div className="container-default hide-mobile">
         <h2 className="padding-bottom-24px">
           Open for application/registration

--- a/src/app/events-and-training/page.module.css
+++ b/src/app/events-and-training/page.module.css
@@ -2,9 +2,6 @@
    EVENTS & TRAINING PAGE STYLES
    =============================== */
 
-/* QA: changed from grid (1fr 1fr 1fr) to flex to match live site.
-   Grid forced equal-width columns, making text wrap too early.
-   Live site uses Webflow's flex-gap-56px class. */
 .action-links-grid {
   display: flex;
   gap: 56px;
@@ -48,7 +45,6 @@
     max-width: 100%;
   }
 
-  /* QA: live site's padding-56px reduces to 32px at mobile breakpoint */
   .action-links-grid {
     flex-direction: column;
     gap: 24px;

--- a/src/app/events-and-training/page.tsx
+++ b/src/app/events-and-training/page.tsx
@@ -37,9 +37,6 @@ export default async function EventsAndTrainingPage() {
           </span>
         </h2>
 
-        {/* Action Links — QA: changed from <h3> to <p> with paragraph-default-bold
-            and padding-bottom-16px to match live Webflow site structure.
-            Arrow uses color-teal-400 span to match live site's color-grey-old class. */}
         <div className={styles['action-links-grid']}>
           <Link
             href="https://aisafetyeventsandtraining.substack.com/"

--- a/src/components/ContributeButtons.tsx
+++ b/src/components/ContributeButtons.tsx
@@ -15,8 +15,6 @@ interface ContributeButtonsProps {
   extraLinks?: ExtraLink[]
 }
 
-// QA: arrow spans changed from color-teal-300 to color-teal-400
-// to match live site's color-grey-old class (which maps to var(--teal-400)).
 export default function ContributeButtons({
   suggestEntryUrl,
   suggestCorrectionUrl,

--- a/src/lib/data/advisors.ts
+++ b/src/lib/data/advisors.ts
@@ -26,7 +26,6 @@ export interface Advisor {
 export async function getAdvisors(): Promise<Advisor[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
-    // QA: Exclude records where Hide? is checked
     filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
     sort: [{ field: 'Sort', direction: 'asc' }],
   })

--- a/src/lib/data/communities.ts
+++ b/src/lib/data/communities.ts
@@ -44,7 +44,6 @@ export interface Community {
 export async function getCommunities(): Promise<Community[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
-    // QA: Exclude hidden records — Airtable view also filters by Hide? = empty
     filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
     sort: [{ field: 'Sort', direction: 'asc' }],
   })

--- a/src/lib/data/founders.ts
+++ b/src/lib/data/founders.ts
@@ -28,7 +28,6 @@ export async function getFounderResources(): Promise<FounderResource[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,
-    // QA: Exclude records where Hide? is checked
     filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
     sort: [
       { field: 'Sort', direction: 'asc' },

--- a/src/lib/data/funding.ts
+++ b/src/lib/data/funding.ts
@@ -28,7 +28,6 @@ export interface Funder {
 export async function getFunders(): Promise<Funder[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
-    // QA: Exclude records where Hide? is checked
     filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
     sort: [{ field: 'Sort', direction: 'asc' }],
   })

--- a/src/lib/data/media-channels.ts
+++ b/src/lib/data/media-channels.ts
@@ -24,7 +24,6 @@ export interface MediaChannel {
 export async function getMediaChannels(): Promise<MediaChannel[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
-    // QA: Exclude records where Hide? is checked
     filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
     sort: [{ field: 'Sort', direction: 'asc' }],
   })

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -25,7 +25,6 @@ export interface Project {
 export async function getProjects(): Promise<Project[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
-    // QA: Exclude records where Hide? is checked
     filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
     sort: [{ field: 'Sort', direction: 'asc' }],
   })

--- a/src/lib/data/self-study.ts
+++ b/src/lib/data/self-study.ts
@@ -30,7 +30,6 @@ export async function getCourses(): Promise<Course[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,
-    // QA: Exclude records where Hide? is checked
     filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
     sort: [{ field: 'Sort', direction: 'asc' }],
   })


### PR DESCRIPTION
- Fix "In-person" type filter to match Airtable value "In person" (no hyphen) — filter was returning 0 results
- Move "Other" to end of Platform filter list
- Add "Inactive" option to Activity level filter
- Make filter counts use full dataset so they don't change dynamically as filters are applied
- Exclude records with Hide? checked from all resource pages that have the field (communities, media channels, founders, advisors, funding, self-study, projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)