### PR TITLE
Open external links on about page in new tabs

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -235,6 +235,8 @@ export default function AboutPage() {
             </p>
             <a
               href="https://discord.gg/faamWzPcv8"
+              target="_blank"
+              rel="noopener noreferrer"
               className="button-secondary"
             >
               Give us your take
@@ -253,6 +255,8 @@ export default function AboutPage() {
           </p>
           <a
             href="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
+            target="_blank"
+            rel="noopener noreferrer"
             className="button-secondary"
           >
             Suggest a correction


### PR DESCRIPTION
- **"Suggest a correction"** and **"Give us your take"** buttons on /about link to external sites (Airtable and Discord) but were opening in the same tab, navigating users away. Added `target="_blank"` so they open in new tabs instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)