### PR TITLE
try different method of dark theme signaling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,9 +24,6 @@
    =============================== */
 
 :root {
-  /* Signal dark mode to browsers and plugins (e.g., Dark Reader) */
-  color-scheme: dark;
-
   /* Teal Scale */
   --teal-100: #e3e5e6;
   --teal-200: #c6cccc;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
 import LayoutShell from '@/components/LayoutShell'
@@ -9,6 +9,10 @@ const inter = Inter({
   weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
   variable: '--font-inter',
 })
+
+export const viewport: Viewport = {
+  colorScheme: 'dark',
+}
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://aisafety.com'),


### PR DESCRIPTION
For some strange reason DarkReader was detecting the dark theme on localhost, but not on vercel deployment, in firefox. But chromium was able to handle both. Trying a new method of signaling dark theme to get around this