### PR TITLE
Fix line spacing shift on card hover animation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -918,6 +918,9 @@ label {
   border: 1px solid var(--teal-700);
   border-radius: 16px;
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
+  will-change: transform;
+  transform: scale(1);
+  backface-visibility: hidden;
   transition:
     background-color var(--hover-transition),
     transform var(--hover-transition);

--- a/src/components/FeaturedCard.module.css
+++ b/src/components/FeaturedCard.module.css
@@ -7,6 +7,9 @@
   border: 1px solid var(--teal-700);
   border-radius: 16px;
   position: relative;
+  will-change: transform;
+  transform: scale(1);
+  backface-visibility: hidden;
   transition:
     background-color var(--hover-transition),
     transform var(--hover-transition);


### PR DESCRIPTION
- The `scale(1.015)` hover animation on resource page cards caused visible line spacing shifts in body text during the transition
- Fixed by forcing GPU compositing (`will-change`, base `scale(1)`, `backface-visibility: hidden`) so the browser scales a pre-rendered texture instead of re-rasterizing text mid-animation
- Affects all resource pages (media channels, funding, communities, etc.) and FeaturedCard

Partially addresses #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)