### PR TITLE
Migrate Webflow redirects to next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,40 @@ const nextConfig: NextConfig = {
         destination: '/founders',
         permanent: true,
       },
+      // Migrated from Webflow redirects (exported 6 April 2026).
+      // Redirects whose destination doesn't exist on the new site
+      // were skipped: /ai-safety-reading-guide, /landscape-map/suggest,
+      // /jobs-old, /reading-guide.
+      // Chains through /stay-informed were collapsed to /media-channels.
+      { source: '/donating', destination: '/donation-guide', permanent: true },
+      { source: '/database', destination: '/communities', permanent: true },
+      {
+        source: '/events',
+        destination: '/events-and-training',
+        permanent: true,
+      },
+      { source: '/talk-to-a-human', destination: '/advisors', permanent: true },
+      { source: '/landscape-map', destination: '/map', permanent: true },
+      { source: '/landscape-map-2025', destination: '/map', permanent: true },
+      { source: '/reading-group', destination: '/', permanent: true },
+      { source: '/courses', destination: '/self-study', permanent: true },
+      { source: '/funders', destination: '/funding', permanent: true },
+      {
+        source: '/volunteer-projects',
+        destination: '/projects',
+        permanent: true,
+      },
+      {
+        source: '/stay-informed',
+        destination: '/media-channels',
+        permanent: true,
+      },
+      {
+        source: '/learn-and-stay-informed',
+        destination: '/media-channels',
+        permanent: true,
+      },
+      { source: '/media', destination: '/media-channels', permanent: true },
     ]
   },
 }


### PR DESCRIPTION
Brings the Webflow redirects across to the Next.js site so old URLs don't break when the domain switches over. Exported from Webflow on 6 April 2026.

**13 redirects added** (all permanent / 308):

| Old | New |
|---|---|
| /donating | /donation-guide |
| /database | /communities |
| /events | /events-and-training |
| /talk-to-a-human | /advisors |
| /landscape-map | /map |
| /landscape-map-2025 | /map |
| /reading-group | / |
| /courses | /self-study |
| /funders | /funding |
| /volunteer-projects | /projects |
| /stay-informed | /media-channels |
| /learn-and-stay-informed | /media-channels |
| /media | /media-channels |

**4 redirects skipped** because their destinations don't exist on the new site:
- `/ai-safety-reading-guide → /reading-guide` (no /reading-guide page)
- `/landscape-map/suggest → /map/suggest` (no /map/suggest page)
- `/jobs-old → /old/jobs-old` (no /old/jobs-old page)
- `/reading-guide → /old/reading-guide` (no /old/reading-guide page)

**Chain collapsing:** In Webflow, `/media` and `/learn-and-stay-informed` redirected to `/stay-informed`, which itself redirected to `/media-channels`. I collapsed these into single-hop redirects directly to `/media-channels` (better for SEO and performance), while keeping `/stay-informed → /media-channels` for any direct hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)