### PR TITLE
Add Open Graph metadata to all resource pages

### DIFF
--- a/src/app/advisors/layout.tsx
+++ b/src/app/advisors/layout.tsx
@@ -3,7 +3,13 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Advisors – AISafety.com',
   description:
-    'These advisors offer free guidance calls to help you most effectively contribute to AI safety.',
+    'Advisors offering free guidance calls to help you most effectively contribute to AI safety.',
+  openGraph: {
+    title: 'Advisors – AISafety.com',
+    description:
+      'Advisors offering free guidance calls to help you most effectively contribute to AI safety.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 export default function AdvisorsLayout({

--- a/src/app/communities/page.tsx
+++ b/src/app/communities/page.tsx
@@ -11,6 +11,12 @@ export const metadata = {
   title: 'Communities – AISafety.com',
   description:
     'Groups dedicated to discussing and contributing to AI safety, both online and in-person.',
+  openGraph: {
+    title: 'Communities – AISafety.com',
+    description:
+      'Groups dedicated to discussing and contributing to AI safety, both online and in-person.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 // Featured communities data (hardcoded as these are special highlights)

--- a/src/app/donation-guide/layout.tsx
+++ b/src/app/donation-guide/layout.tsx
@@ -4,6 +4,12 @@ export const metadata: Metadata = {
   title: 'Donation guide – AISafety.com',
   description:
     'A short guide on how to donate most effectively to the AI safety field.',
+  openGraph: {
+    title: 'Donation guide – AISafety.com',
+    description:
+      'A short guide on how to donate most effectively to the AI safety field.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 export default function DonationGuideLayout({

--- a/src/app/events-and-training/page.tsx
+++ b/src/app/events-and-training/page.tsx
@@ -5,9 +5,15 @@ import EventsEmbeds from './EventsEmbeds'
 import styles from './page.module.css'
 
 export const metadata = {
-  title: 'Events & Training – AISafety.com',
+  title: 'Events & training – AISafety.com',
   description:
     'AI safety events and training programs, both online and in-person.',
+  openGraph: {
+    title: 'Events & training – AISafety.com',
+    description:
+      'AI safety events and training programs, both online and in-person.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 export default async function EventsAndTrainingPage() {

--- a/src/app/founders/layout.tsx
+++ b/src/app/founders/layout.tsx
@@ -1,9 +1,14 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Founder Toolkit – AISafety.com',
-  description:
-    'Resources for starting and growing an AI safety organization – including incubators, fiscal sponsors, venture capital, and practical guides.',
+  title: 'Founder toolkit – AISafety.com',
+  description: 'Resources for starting and growing an AI safety organization.',
+  openGraph: {
+    title: 'Founder toolkit – AISafety.com',
+    description:
+      'Resources for starting and growing an AI safety organization.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 export default function FoundersLayout({

--- a/src/app/funding/layout.tsx
+++ b/src/app/funding/layout.tsx
@@ -3,7 +3,13 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Funding – AISafety.com',
   description:
-    'Organizations providing financial support to organizations and individuals working on AI safety.',
+    'Sources of financial support for organizations and individuals working on AI safety.',
+  openGraph: {
+    title: 'Funding – AISafety.com',
+    description:
+      'Sources of financial support for organizations and individuals working on AI safety.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 export default function FundingLayout({

--- a/src/app/jobs/layout.tsx
+++ b/src/app/jobs/layout.tsx
@@ -3,6 +3,11 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Jobs – AISafety.com',
   description: 'A list of current open positions in AI safety.',
+  openGraph: {
+    title: 'Jobs – AISafety.com',
+    description: 'A list of current open positions in AI safety.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 export default function JobsLayout({

--- a/src/app/map/layout.tsx
+++ b/src/app/map/layout.tsx
@@ -1,7 +1,13 @@
 export const metadata = {
-  title: 'Field Map – AISafety.com',
+  title: 'Field map – AISafety.com',
   description:
     'Map displaying the main organizations, projects, and programs currently operating in the AI safety space.',
+  openGraph: {
+    title: 'Field map – AISafety.com',
+    description:
+      'Map displaying the main organizations, projects, and programs currently operating in the AI safety space.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 export default function MapLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/media-channels/layout.tsx
+++ b/src/app/media-channels/layout.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Media Channels – AISafety.com',
+  title: 'Media channels – AISafety.com',
   description:
     'The AI safety space is changing rapidly. These information sources can help you learn more and stay up to date.',
+  openGraph: {
+    title: 'Media channels – AISafety.com',
+    description:
+      'The AI safety space is changing rapidly. These information sources can help you learn more and stay up to date.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 export default function MediaChannelsLayout({

--- a/src/app/projects/layout.tsx
+++ b/src/app/projects/layout.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Volunteer Projects – AISafety.com',
+  title: 'Volunteer projects – AISafety.com',
   description:
     'Online initiatives supporting the AI safety field and seeking volunteer help.',
+  openGraph: {
+    title: 'Volunteer projects – AISafety.com',
+    description:
+      'Online initiatives supporting the AI safety field and seeking volunteer help.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 export default function ProjectsLayout({

--- a/src/app/self-study/layout.tsx
+++ b/src/app/self-study/layout.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Self-Study – AISafety.com',
+  title: 'Self-study – AISafety.com',
   description:
     'Curricula and reading lists enabling you to dive deeper into AI safety through independent learning.',
+  openGraph: {
+    title: 'Self-study – AISafety.com',
+    description:
+      'Curricula and reading lists enabling you to dive deeper into AI safety through independent learning.',
+    images: [{ url: '/images/link-preview.png' }],
+  },
 }
 
 export default function SelfStudyLayout({


### PR DESCRIPTION
- Link previews (Slack, Twitter, etc.) were showing the generic site description for all resource pages — these OG tags were lost during the Webflow migration
- Restored page-specific `og:title`, `og:description`, and `og:image` for all 11 resource pages using the Webflow backup as reference
- Updated descriptions for /funding, /advisors, and /founders
- Corrected title capitalization to sentence case (e.g. "Field Map" → "Field map")

🤖 Generated with [Claude Code](https://claude.com/claude-code)