### PR TITLE
Increase first events embed height on desktop

### DIFF
--- a/src/app/events-and-training/EventsEmbeds.tsx
+++ b/src/app/events-and-training/EventsEmbeds.tsx
@@ -6,7 +6,7 @@ import styles from './page.module.css'
 const EMBEDS = [
   {
     src: 'https://airtable.com/embed/appF8XfZUGXtfi40E/shrLgl03tMK4q6cyc?viewControls=on',
-    height: 2600,
+    height: 2800,
     className: `${styles['airtable-embed']} ${styles['airtable-embed-mobile']} margin-bottom-40px`,
   },
   {


### PR DESCRIPTION
- The first Airtable embed on /events-and-training was cutting off content on desktop
- Increased iframe height from 2600px to 2800px (+200px)
- Mobile unaffected (stays at 600px via CSS override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)