### PR TITLE
Fix Founder toolkit heading capitalization

### DIFF
--- a/src/app/founders/page.tsx
+++ b/src/app/founders/page.tsx
@@ -20,7 +20,7 @@ export default async function FoundersPage() {
   return (
     <div className="container-default">
       <PageHeader
-        title="Founder Toolkit"
+        title="Founder toolkit"
         lastUpdated={lastUpdated.formattedDate}
         description={
           <>


### PR DESCRIPTION
- Lowercase "toolkit" in the Founder toolkit page header to match site conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)