### PR TITLE
Rename 'Suggest entry' to 'Suggest listing'

### DIFF
--- a/src/app/advisors/AdvisorsClient.tsx
+++ b/src/app/advisors/AdvisorsClient.tsx
@@ -187,7 +187,7 @@ export default function AdvisorsClient({ advisors }: AdvisorsClientProps) {
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagTw6PRaIHUHh8ty/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="advisor"
-          suggestEntryDescription="Suggest an advisor to be listed here"
+          suggestEntryDescription="Suggest a resource to be published here"
           suggestCorrectionDescription="Let us know of changes that should be made"
           extraLinks={[
             {

--- a/src/app/events-and-training/page.module.css
+++ b/src/app/events-and-training/page.module.css
@@ -13,6 +13,10 @@
   color: inherit;
 }
 
+.action-link:hover {
+  opacity: 0.8;
+}
+
 .action-description {
   line-height: 160%;
   color: var(--teal-300);

--- a/src/app/events-and-training/page.tsx
+++ b/src/app/events-and-training/page.tsx
@@ -61,8 +61,7 @@ export default async function EventsAndTrainingPage() {
               Suggest listing <span className="color-teal-400">&rarr;</span>
             </p>
             <p className={styles['action-description']}>
-              Suggest an event or training program to be listed here and in the
-              newsletter
+              Suggest a resource to be published here
             </p>
           </Link>
 

--- a/src/app/events-and-training/page.tsx
+++ b/src/app/events-and-training/page.tsx
@@ -58,7 +58,7 @@ export default async function EventsAndTrainingPage() {
             className={`${styles['action-link']} hide-mobile`}
           >
             <p className="paragraph-default-bold padding-bottom-16px">
-              Suggest entry <span className="color-teal-400">&rarr;</span>
+              Suggest listing <span className="color-teal-400">&rarr;</span>
             </p>
             <p className={styles['action-description']}>
               Suggest an event or training program to be listed here and in the

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -309,7 +309,7 @@ export default function MapClient({
               suggestEntryUrl={suggestEntryLink}
               suggestCorrectionUrl={suggestCorrectionLink}
               noun="listing"
-              suggestEntryDescription="Suggest something to be listed on the map"
+              suggestEntryDescription="Suggest a resource to be published here"
               extraLinks={[
                 {
                   label: 'View raw data',

--- a/src/app/media-channels/MediaChannelsClient.tsx
+++ b/src/app/media-channels/MediaChannelsClient.tsx
@@ -158,7 +158,7 @@ export default function MediaChannelsClient({
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagSZ7vJj9MHyYmtS/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="media source"
-          suggestEntryDescription="Suggest an information source to be listed here"
+          suggestEntryDescription="Suggest a resource to be published here"
           suggestCorrectionDescription="Let us know of changes to an entry"
         />
       </div>

--- a/src/components/ContributeButtons.tsx
+++ b/src/components/ContributeButtons.tsx
@@ -30,7 +30,7 @@ export default function ContributeButtons({
           Suggest listing <span className="color-teal-400">&rarr;</span>
         </p>
         <p className="paragraph-small color-teal-300">
-          {suggestEntryDescription || `Suggest a ${noun} to be listed here`}
+          {suggestEntryDescription || 'Suggest a resource to be published here'}
         </p>
       </a>
       <a href={suggestCorrectionUrl} target="_blank" rel="noopener noreferrer">

--- a/src/components/ContributeButtons.tsx
+++ b/src/components/ContributeButtons.tsx
@@ -27,7 +27,7 @@ export default function ContributeButtons({
     <div className={styles.wrapper}>
       <a href={suggestEntryUrl} target="_blank" rel="noopener noreferrer">
         <p className="paragraph-default-bold padding-bottom-8px">
-          Suggest entry <span className="color-teal-400">&rarr;</span>
+          Suggest listing <span className="color-teal-400">&rarr;</span>
         </p>
         <p className="paragraph-small color-teal-300">
           {suggestEntryDescription || `Suggest a ${noun} to be listed here`}


### PR DESCRIPTION
- Renames the "Suggest entry" button text to "Suggest listing" on all 9 resource pages
- Changes the description below the button to "Suggest a resource to be published here" on all pages
- Adds hover dim effect to the 3 action buttons on /events-and-training (was missing, now matches other resource pages)


🤖 Generated with [Claude Code](https://claude.com/claude-code)