### PR TITLE
Allow AVIF attachments from Airtable

### DIFF
--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -37,7 +37,15 @@ function isAttachmentArray(value: unknown): value is AirtableAttachment[] {
   )
 }
 
-const ALLOWED_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.svg', '.webp', '.gif']
+const ALLOWED_EXTENSIONS = [
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.svg',
+  '.webp',
+  '.gif',
+  '.avif',
+]
 
 function getExtension(url: string, filename: string): string {
   const filenameExt = path.extname(filename).toLowerCase()


### PR DESCRIPTION
- AI Safety Hong Kong's logo is AVIF, which broke the communities page prerender and caused the production deployment to fail.
- AVIF is a valid modern web format supported by Next.js Image, so adding it to the allowed extensions list.