### PR TITLE
Fix nav background disappearing on refresh while scrolled

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,8 +50,13 @@ export default async function RootLayout({
   const counts = await fetchAllCounts()
 
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} antialiased`}>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{if(performance.getEntriesByType('navigation')[0]?.type==='reload')document.documentElement.classList.add('is-reload')}catch(e){}`,
+          }}
+        />
         <Script id="matomo" strategy="afterInteractive">
           {`
             var _paq = window._paq = window._paq || [];

--- a/src/components/Navigation.module.css
+++ b/src/components/Navigation.module.css
@@ -163,6 +163,10 @@
   top: 0;
 }
 
+:global(html.is-reload) .nav-fixed {
+  visibility: hidden;
+}
+
 .nav-blur {
   background-color: rgba(0, 25, 27, 0.4);
   backdrop-filter: blur(16px);

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -128,7 +128,7 @@ export default function Navigation({
     return () => document.removeEventListener('click', handleClickOutside)
   }, [isDropdownOpen])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const handleScroll = () => {
       const el = navOuterRef.current
       if (!el) return
@@ -187,6 +187,8 @@ export default function Navigation({
     }
 
     window.addEventListener('scroll', handleScroll, { passive: true })
+    handleScroll()
+    document.documentElement.classList.remove('is-reload')
     return () => window.removeEventListener('scroll', handleScroll)
   }, [])
   return (


### PR DESCRIPTION
- Refreshing a resource page while scrolled down showed the global nav without its background. The scroll-driven blur class was only toggled inside a scroll event handler that never ran on mount, so on reload at a restored scroll position the nav stayed transparent until the user scrolled.
- Switched the effect to `useLayoutEffect` and call `handleScroll()` synchronously on mount, so the nav's transform and blur class match the current scroll position before the first paint.
- To avoid a brief logo flash during the pre-hydration window on reload, an inline script in the layout tags `<html>` with `is-reload` on reload navigations; CSS keeps the nav hidden until the scroll state is synced, then the class is removed. Fresh visits and internal navigations are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)