### PR TITLE
Increase heights of 1st and 3rd Airtable embeds on /events

### DIFF
--- a/src/app/events-and-training/EventsEmbeds.tsx
+++ b/src/app/events-and-training/EventsEmbeds.tsx
@@ -6,7 +6,7 @@ import styles from './page.module.css'
 const EMBEDS = [
   {
     src: 'https://airtable.com/embed/appF8XfZUGXtfi40E/shrLgl03tMK4q6cyc?viewControls=on',
-    height: 2800,
+    height: 3100,
     className: `${styles['airtable-embed']} ${styles['airtable-embed-mobile']} margin-bottom-40px`,
   },
   {
@@ -16,7 +16,7 @@ const EMBEDS = [
   },
   {
     src: 'https://airtable.com/embed/appF8XfZUGXtfi40E/shrbap2hy8Yd3xojA',
-    height: 1350,
+    height: 1550,
     className: `${styles['airtable-embed']} margin-bottom-40px`,
   },
 ]


### PR DESCRIPTION
- First embed (upcoming events) height: 2800 → 3100 (+300px)
- Third embed (open for application/registration) height: 1350 → 1550 (+200px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)