### PR TITLE
Fix check-rebuild 500 on Projects table

### DIFF
--- a/src/app/api/check-rebuild/route.ts
+++ b/src/app/api/check-rebuild/route.ts
@@ -69,7 +69,6 @@ async function hasChangesSince(
   const url = new URL(`https://api.airtable.com/v0/${baseId}/${tableId}`)
   url.searchParams.set('filterByFormula', formula)
   url.searchParams.set('maxRecords', '1')
-  url.searchParams.set('fields[]', 'Name')
 
   const response = await fetch(url.toString(), {
     headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
- The check-rebuild cron has been 500'ing every minute since PR #366 deployed, so no Airtable-triggered rebuilds have fired today
- Root cause: the endpoint requested `fields[]=Name` from every table, but the Projects table has `Project Name`, not `Name`. Airtable returned 422 UNKNOWN_FIELD_NAME, `Promise.all` rejected, and the whole check failed
- Dropped the `fields[]` param — we only check `records.length`, so trimming response size was pointless premature optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)