### PR TITLE
Remove background SVG on /poster-map

### DIFF
--- a/src/app/poster-map/layout.tsx
+++ b/src/app/poster-map/layout.tsx
@@ -13,5 +13,10 @@ export default function PosterLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  return <>{children}</>
+  return (
+    <>
+      <style>{`body { background-image: none !important; background-color: #000 !important; }`}</style>
+      {children}
+    </>
+  )
 }


### PR DESCRIPTION
- Overrides `body` background to pure black on `/poster-map` only, via the route's `layout.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)