### PR TITLE
Use Short URL field for poster-map QR codes

### DIFF
--- a/src/app/poster-map/D3PosterMap.tsx
+++ b/src/app/poster-map/D3PosterMap.tsx
@@ -331,7 +331,7 @@ export default function D3PosterMap({ orgs }: D3PosterMapProps) {
             .attr('transform', `translate(${qrX}, 0)`)
 
           // Use short URL if available, fall back to full URL
-          const urlForQR = org.link
+          const urlForQR = org.shortUrl || org.link
 
           // Generate QR code as data URL
           QRCode.toDataURL(urlForQR, {

--- a/src/lib/data/map.ts
+++ b/src/lib/data/map.ts
@@ -22,6 +22,7 @@ interface AirtableRecord {
     'Logo (for cards)'?: Array<{ url: string }>
     'Logo (for map)'?: Array<{ url: string }>
     Link?: string
+    'Short URL'?: string
     'Date added'?: string
     x?: number
     y?: number
@@ -40,6 +41,7 @@ export interface MapOrg {
   logo: string | null
   mapLogo: string | null
   link: string
+  shortUrl: string | null
   x: number | null
   y: number | null
   scale: string | null
@@ -64,6 +66,7 @@ const FIELD_LIST = [
   'Logo (for cards)',
   'Logo (for map)',
   'Link',
+  'Short URL',
   'Date added',
   'x',
   'y',
@@ -133,6 +136,7 @@ export async function getMapData(): Promise<MapData> {
       logo,
       mapLogo,
       link: fields.Link || '#',
+      shortUrl: fields['Short URL'] || null,
       x: fields.x ?? null,
       y: fields.y ?? null,
       scale: fields.Scale || null,


### PR DESCRIPTION
- QR codes on `/poster-map` were encoding the full `Link` URL even though the comment said to prefer the short URL
- `map.ts` didn't fetch the Airtable "Short URL" field (fldSLQDvullnrvmut), so `org.shortUrl` was never populated
- Now fetches and exposes it via `MapOrg.shortUrl`, and `D3PosterMap` uses `org.shortUrl || org.link` for the QR content
- Verified by decoding 5 rendered QR codes locally — all returned `is.gd/...` short URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)