### PR TITLE
Rename /events section headers

### DIFF
--- a/src/app/events-and-training/EventsEmbeds.tsx
+++ b/src/app/events-and-training/EventsEmbeds.tsx
@@ -90,11 +90,15 @@ export default function EventsEmbeds() {
   return (
     <>
       <div className="container-wide">{renderEmbed(0)}</div>
+
+      <div className="container-default hide-mobile">
+        <h2 className="padding-bottom-24px">Calendar view</h2>
+      </div>
       <div className="container-wide hide-mobile">{renderEmbed(1)}</div>
 
       <div className="container-default hide-mobile">
         <h2 className="padding-bottom-24px">
-          Open for application/registration
+          By application/registration deadline
         </h2>
       </div>
 

--- a/src/app/events-and-training/page.tsx
+++ b/src/app/events-and-training/page.tsx
@@ -86,9 +86,7 @@ export default async function EventsAndTrainingPage() {
           </Link>
         </div>
 
-        <h2 className="padding-bottom-24px">
-          All upcoming events and training programs
-        </h2>
+        <h2 className="padding-bottom-24px">Table view</h2>
       </div>
 
       {/* Airtable Embeds – load on view, then sequentially in background */}


### PR DESCRIPTION
- Change "All upcoming events and training programs" → "Table view"
- Add new "Calendar view" header above the calendar embed
- Change "Open for application/registration" → "By application/registration deadline"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

For the first embed I'll then filter out listings whose application/registration deadline is passed.

Idea with this is to remove listings to which users can no longer apply (except on the calendar view, which seems fine).