### PR TITLE
Remove Incubator and Venture capitalist filters from /funding

### DIFF
--- a/src/app/funding/FundingClient.tsx
+++ b/src/app/funding/FundingClient.tsx
@@ -18,9 +18,7 @@ const typeOptions = [
   'Fund',
   'Grant program',
   'Grant-based fellowship',
-  'Incubator',
   'Platform',
-  'Venture capitalist',
 ]
 
 export default function FundingClient({ funders }: FundingClientProps) {


### PR DESCRIPTION
- Removes \`Incubator\` and \`Venture capitalist\` from the Type filter on /funding
- These categories now live exclusively on /founders, where every existing record is already represented
- Bryce has hidden the corresponding records in Airtable so they no longer appear on the page

Written by Claude Code 