### PR TITLE
Change "on AI safety" to "in AI safety" in EA Global homepage card

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,7 +77,7 @@ export default async function Home() {
             16–18 October 2026
           </p>
           <p className="padding-bottom-40px">
-            3-day conference with talks, workshops, and networking on AI safety
+            3-day conference with talks, workshops, and networking in AI safety
             and other effective altruism cause areas.
           </p>
           <TrackedLink


### PR DESCRIPTION
- Update the EA Global featured-event description on the homepage so it reads "networking in AI safety" instead of "networking on AI safety"

🤖 Generated with [Claude Code](https://claude.com/claude-code)