### PR TITLE
Apply Airtable retry helper to last-updated and check-rebuild

### DIFF
--- a/src/app/api/check-rebuild/route.ts
+++ b/src/app/api/check-rebuild/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { fetchAirtableWithRetry } from '@/lib/data/airtable'
 
 // Force dynamic - this endpoint must run fresh on every cron invocation
 export const dynamic = 'force-dynamic'
@@ -70,8 +71,7 @@ async function hasChangesSince(
   url.searchParams.set('filterByFormula', formula)
   url.searchParams.set('maxRecords', '1')
 
-  const response = await fetch(url.toString(), {
-    headers: { Authorization: `Bearer ${token}` },
+  const response = await fetchAirtableWithRetry(url.toString(), token, {
     cache: 'no-store',
   })
 

--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -238,14 +238,15 @@ const FETCH_RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504])
 const RATE_LIMIT_BASE_DELAY_MS = 30_000
 const TRANSIENT_BASE_DELAY_MS = 1_000
 
-async function fetchAirtablePage(
+export async function fetchAirtableWithRetry(
   url: string,
-  token: string
+  token: string,
+  init?: RequestInit
 ): Promise<Response> {
   for (let attempt = 0; attempt <= FETCH_MAX_RETRIES; attempt++) {
     const response = await fetch(url, {
+      ...init,
       headers: { Authorization: `Bearer ${token}` },
-      cache: 'no-store',
     })
 
     if (response.ok) return response
@@ -269,7 +270,7 @@ async function fetchAirtablePage(
   }
 
   // Unreachable — the loop returns on the final attempt.
-  throw new Error('fetchAirtablePage exhausted retries without returning')
+  throw new Error('fetchAirtableWithRetry exhausted retries without returning')
 }
 
 function parseRetryAfter(header: string | null): number | null {
@@ -321,7 +322,9 @@ async function fetchAirtableRecordsImpl(
     // Pagination iterators expire in minutes, so per-page caching would
     // serve stale offsets and trigger 422 LIST_RECORDS_ITERATOR_NOT_AVAILABLE.
     // The aggregated result is cached below via unstable_cache instead.
-    const response = await fetchAirtablePage(url.toString(), token)
+    const response = await fetchAirtableWithRetry(url.toString(), token, {
+      cache: 'no-store',
+    })
 
     if (!response.ok) {
       throw new Error(

--- a/src/lib/data/last-updated.ts
+++ b/src/lib/data/last-updated.ts
@@ -1,5 +1,6 @@
 import { DONATION_GUIDE_LAST_UPDATED } from '@/lib/donation-guide-date'
 import { formatDate } from '@/lib/format-date'
+import { fetchAirtableWithRetry } from './airtable'
 
 type QueryConfig = {
   type: 'query'
@@ -115,11 +116,10 @@ export async function fetchLastUpdated(
     throw new Error('Missing AIRTABLE_TOKEN or AIRTABLE_BASE_ID')
 
   if (config.type === 'record') {
-    const response = await fetch(
+    const response = await fetchAirtableWithRetry(
       `https://api.airtable.com/v0/${baseId}/${config.tableId}/${config.recordId}`,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      }
+      token,
+      { next: { revalidate: 3600 } }
     )
     if (!response.ok)
       throw new Error(
@@ -150,8 +150,8 @@ export async function fetchLastUpdated(
   url.searchParams.set('maxRecords', '1')
   url.searchParams.set('fields[]', config.sortField)
 
-  const response = await fetch(url.toString(), {
-    headers: { Authorization: `Bearer ${token}` },
+  const response = await fetchAirtableWithRetry(url.toString(), token, {
+    next: { revalidate: 3600 },
   })
   if (!response.ok)
     throw new Error(


### PR DESCRIPTION
- Production deploy at 72e406b (PR #386) failed: \`/projects\` prerender hit 429 from Airtable. Root cause: PR #386 added retry-with-backoff to \`fetchAirtableRecords\`, but two other callers — \`fetchLastUpdated\` (called from every resource page) and the \`check-rebuild\` cron route — still issued raw fetches with no retry. Build-time fan-out across 29 parallel workers blew past Airtable's 5 req/sec/base limit.
- Exports \`fetchAirtableWithRetry\` from \`airtable.ts\` and reuses it in both sites. The helper now accepts a fetch init so callers pick the caching mode they need: \`no-store\` for paginated record fetches and the cron route, \`{ revalidate: 3600 }\` for \`last-updated\` (so the resource pages stay statically generated).
- Verified locally that all 13 resource pages remain statically prerendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)