### PR TITLE
Add canonical tags, sitemap, and robots.txt for SEO

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /_next/static/
+Disallow: /api/
+
+Sitemap: https://aisafety.com/sitemap.xml

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,6 +5,7 @@ export const metadata = {
   title: 'About – AISafety.com',
   description:
     'We aim to provide a central and comprehensive hub for AI safety, through which individuals can easily discover the most impactful resources for them.',
+  alternates: { canonical: '/about' },
 }
 
 export default function AboutPage() {

--- a/src/app/advisors/page.tsx
+++ b/src/app/advisors/page.tsx
@@ -9,6 +9,7 @@ export const metadata = {
   title: 'Advisors – AISafety.com',
   description:
     'Advisors offering free guidance calls to help you most effectively contribute to AI safety.',
+  alternates: { canonical: '/advisors' },
 }
 
 export default async function AdvisorsPage() {

--- a/src/app/communities/page.tsx
+++ b/src/app/communities/page.tsx
@@ -11,6 +11,7 @@ export const metadata = {
   title: 'Communities – AISafety.com',
   description:
     'Groups dedicated to discussing and contributing to AI safety, both online and in-person.',
+  alternates: { canonical: '/communities' },
   openGraph: {
     title: 'Communities – AISafety.com',
     description:

--- a/src/app/events-and-training/page.tsx
+++ b/src/app/events-and-training/page.tsx
@@ -8,6 +8,7 @@ export const metadata = {
   title: 'Events & training – AISafety.com',
   description:
     'AI safety events and training programs, both online and in-person.',
+  alternates: { canonical: '/events-and-training' },
   openGraph: {
     title: 'Events & training – AISafety.com',
     description:

--- a/src/app/founders/page.tsx
+++ b/src/app/founders/page.tsx
@@ -9,6 +9,7 @@ export const metadata = {
   title: 'Founder Toolkit – AISafety.com',
   description:
     'Resources for starting and growing an AI safety organization, including incubators, fiscal sponsors, VCs, and practical tools.',
+  alternates: { canonical: '/founders' },
 }
 
 export default async function FoundersPage() {

--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -8,6 +8,7 @@ export const metadata = {
   title: 'Funding – AISafety.com',
   description:
     'Organizations offering financial support to organizations and individuals working on AI safety.',
+  alternates: { canonical: '/funding' },
 }
 
 export default async function FundingPage() {

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -7,6 +7,7 @@ export const metadata = {
   title: 'Jobs – AISafety.com',
   description:
     "AI safety career opportunities. Many roles don't require technical skills.",
+  alternates: { canonical: '/jobs' },
 }
 
 export default async function JobsPage() {

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -5,6 +5,7 @@ export const metadata = {
   title: 'Field Map – AISafety.com',
   description:
     'An overview of the key organizations, programs, and projects operating in the AI safety space.',
+  alternates: { canonical: '/map' },
 }
 
 export default async function MapPage() {

--- a/src/app/media-channels/page.tsx
+++ b/src/app/media-channels/page.tsx
@@ -8,6 +8,7 @@ export const metadata = {
   title: 'Media Channels – AISafety.com',
   description:
     'Information sources to help you learn more about AI safety and stay up to date.',
+  alternates: { canonical: '/media-channels' },
 }
 
 export default async function MediaChannelsPage() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,10 @@ import TrackedLink from '@/components/TrackedLink'
 import { fetchAllLastUpdated } from '@/lib/data/last-updated'
 import styles from './page.module.css'
 
+export const metadata = {
+  alternates: { canonical: '/' },
+}
+
 export default async function Home() {
   const dates = await fetchAllLastUpdated()
 

--- a/src/app/poster-map/page.tsx
+++ b/src/app/poster-map/page.tsx
@@ -1,6 +1,10 @@
 import { getMapData, MapOrg } from '@/lib/data/map'
 import PosterMapClient from './PosterMapClient'
 
+export const metadata = {
+  robots: { index: false, follow: false },
+}
+
 // Filter orgs that have map coordinates for the D3 map
 function getMapOrgs(records: MapOrg[]): MapOrg[] {
   return records.filter(org => org.x !== null && org.y !== null)

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -8,6 +8,7 @@ export const metadata = {
   title: 'Volunteer Projects – AISafety.com',
   description:
     'Initiatives seeking your volunteer help, focused on supporting and improving the AI safety field.',
+  alternates: { canonical: '/projects' },
 }
 
 export default async function ProjectsPage() {

--- a/src/app/self-study/page.tsx
+++ b/src/app/self-study/page.tsx
@@ -9,6 +9,7 @@ export const metadata = {
   title: 'Self-study – AISafety.com',
   description:
     'Curricula and reading lists to dive deeper into AI safety through independent learning.',
+  alternates: { canonical: '/self-study' },
 }
 
 export default async function SelfStudyPage() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from 'next'
+
+const BASE_URL = 'https://aisafety.com'
+
+const ROUTES = [
+  '/',
+  '/about',
+  '/advisors',
+  '/communities',
+  '/donation-guide',
+  '/events-and-training',
+  '/founders',
+  '/funding',
+  '/jobs',
+  '/map',
+  '/media-channels',
+  '/projects',
+  '/self-study',
+] as const
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date()
+  return ROUTES.map(path => ({
+    url: `${BASE_URL}${path}`,
+    lastModified,
+    changeFrequency: path === '/' ? 'weekly' : 'daily',
+    priority: path === '/' ? 1.0 : 0.8,
+  }))
+}


### PR DESCRIPTION
- Adds `alternates: { canonical: '/<path>' }` to every resource page and the homepage. Google was reporting 72 of 90 known pages as not indexed, mostly under "Duplicate without user-selected canonical" — `www`/non-`www`, `http`/`https`, and utm-tagged variants were all competing for indexing without a clear canonical.
- Adds `public/robots.txt` blocking `/_next/static/` and `/api/` so Google stops crawling JS chunks (about 6 of the 19 "Crawled - currently not indexed" entries were Next.js bundles).
- Adds `src/app/sitemap.ts` listing all 13 main routes. The live `/sitemap.xml` was returning 404 — it had been a Webflow auto-generated sitemap that didn't survive the migration, but Search Console was still expecting one.
- Marks `/poster-map` as `noindex, nofollow` so it stays hidden the way the original obscure-slug version was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)