### PR TITLE
Stack mapbox controls above the logo on /communities

### DIFF
--- a/src/app/communities/page.module.css
+++ b/src/app/communities/page.module.css
@@ -36,6 +36,7 @@
   top: auto !important;
   bottom: 16px !important;
   right: 8px !important;
+  z-index: 2 !important;
 }
 
 @media (max-width: 991px) {

--- a/src/app/communities/page.module.css
+++ b/src/app/communities/page.module.css
@@ -36,7 +36,7 @@
   top: auto !important;
   bottom: 16px !important;
   right: 8px !important;
-  z-index: 2 !important;
+  z-index: 3 !important;
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
- The Mapbox attribution logo was painting on top of the zoom and locate controls in the bottom-right of the communities map (the controls are repositioned from top-right via CSS, so they came earlier in the DOM than the logo container).
- Added `z-index: 2` to the `.mapboxgl-ctrl-top-right` override so the controls stack above the logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)