### PR TITLE
Show loading indicator while communities map renders

### DIFF
--- a/src/app/communities/CommunitiesMap.tsx
+++ b/src/app/communities/CommunitiesMap.tsx
@@ -23,6 +23,7 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
   const tooltipRef = useRef<HTMLDivElement>(null)
   const cleanupRef = useRef<(() => void) | null>(null)
   const [scriptLoaded, setScriptLoaded] = useState(false)
+  const [pinsLoaded, setPinsLoaded] = useState(false)
 
   function initMap() {
     if (!mapContainerRef.current || !tooltipRef.current || !window.mapboxgl)
@@ -237,6 +238,10 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
           'icon-allow-overlap': true,
         },
       })
+
+      // `idle` fires after tiles + pins have actually painted — much more
+      // accurate than hiding the loader when the layer is merely registered.
+      map.once('idle', () => setPinsLoaded(true))
 
       function updateTooltipPosition(
         e: any,
@@ -513,6 +518,12 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
         onLoad={handleScriptLoad}
       />
       <div ref={mapContainerRef} className={styles.mapContainer}>
+        {!pinsLoaded && (
+          <div className={styles.mapLoading} aria-live="polite">
+            <div className={styles.mapSpinner} aria-hidden="true" />
+            <p className="paragraph-small">Loading map…</p>
+          </div>
+        )}
         <button
           onClick={handleViewOnline}
           className={`button-primary ${styles.mapButton}`}

--- a/src/app/communities/page.module.css
+++ b/src/app/communities/page.module.css
@@ -31,6 +31,44 @@
   box-shadow: 0 12px 24px rgba(0, 25, 27, 0.5);
 }
 
+.mapLoading {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 20px;
+  background-color: var(--teal-850);
+  border: 1px solid var(--teal-700);
+  border-radius: 12px;
+  color: var(--teal-300);
+  box-shadow: 0 12px 24px rgba(0, 25, 27, 0.5);
+  pointer-events: none;
+}
+
+.mapLoading p {
+  margin: 0;
+}
+
+.mapSpinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--teal-700);
+  border-top-color: var(--bright-teal-300);
+  border-radius: 50%;
+  animation: mapSpin 0.8s linear infinite;
+}
+
+@keyframes mapSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Mapbox controls position - bottom-right on both desktop and mobile */
 :global(.mapboxgl-ctrl-top-right) {
   top: auto !important;


### PR DESCRIPTION
- Adds a centered "Loading map…" pill with a spinner that overlays the map area on /communities while Mapbox is loading.
- Stays visible until Mapbox emits its `idle` event (i.e. tiles + pins have actually painted), so it covers the gap where the basemap is rendered but the pins haven't appeared yet.
- On fast loads it disappears effectively instantly, so there's no flash on a warm cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)