### PR TITLE
Skip Airtable image caching on read-only filesystems

### DIFF
--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -159,8 +159,21 @@ interface DownloadTask {
 async function downloadAttachments(
   records: AirtableRawRecord[]
 ): Promise<void> {
-  if (!fs.existsSync(CACHE_DIR)) {
-    fs.mkdirSync(CACHE_DIR, { recursive: true })
+  // The cache lives under public/ so it can be served as static assets.
+  // That works at build time (writable filesystem) but not at request time
+  // on Vercel serverless (read-only). When the cache dir isn't writable,
+  // skip caching and leave the original Airtable signed URLs in place —
+  // they're valid long enough for an interactive request.
+  try {
+    if (!fs.existsSync(CACHE_DIR)) {
+      fs.mkdirSync(CACHE_DIR, { recursive: true })
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'EROFS' || code === 'EACCES' || code === 'ENOENT') {
+      return
+    }
+    throw err
   }
 
   const tasks: DownloadTask[] = []


### PR DESCRIPTION
- Pre-existing bug in `src/lib/data/airtable.ts`: the build-time image cache logic crashes any runtime caller on Vercel because `/var/task` is read-only.
- Surfaced by #393 — the chatbot's `getCatalog()` hits the same Airtable fetchers as static pages, but at request time. Every chat request was returning HTTP 500 with `ENOENT: mkdir '/var/task/public/images/airtable-cache'`.
- Fix catches `EROFS`/`EACCES`/`ENOENT` from the mkdir and falls back to the original Airtable signed URLs (valid long enough for an interactive request). Build-time behavior is unchanged.

Verified end-to-end on a Vercel preview combining this fix with #393's branch — the chatbot now streams responses correctly.

Once merged, #393 will need to merge main into its branch (or be rebased) for its preview to pick up the fix.

_PR description written by Claude Code._