### PR TITLE
Add canonical tag to /donation-guide

### DIFF
--- a/src/app/donation-guide/layout.tsx
+++ b/src/app/donation-guide/layout.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
   title: 'Donation guide – AISafety.com',
   description:
     'A short guide on how to donate most effectively to the AI safety field.',
+  alternates: { canonical: '/donation-guide' },
   openGraph: {
     title: 'Donation guide – AISafety.com',
     description:


### PR DESCRIPTION
- PR #389 added canonical tags to other resource pages via their `page.tsx` metadata. `/donation-guide` was missed because its `page.tsx` is a client component (`'use client'`) and can't export metadata.
- This adds `alternates: { canonical: '/donation-guide' }` to `donation-guide/layout.tsx` so Google has an explicit canonical URL for the page.
- Verified the built HTML renders `<link rel="canonical" href="https://aisafety.com/donation-guide"/>`.
- Fixes the remaining "Duplicate without user-selected canonical" warning from Google Search Console for this URL.

_PR description written by Claude Code._