### PR TITLE
Allow Google to crawl /_next/static/ assets

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,5 @@
 User-agent: *
 Allow: /
-Disallow: /_next/static/
 Disallow: /api/
 
 Sitemap: https://aisafety.com/sitemap.xml


### PR DESCRIPTION
- Removes the `Disallow: /_next/static/` rule from robots.txt so Googlebot can fetch JS/CSS chunks while rendering pages, which Google uses to understand page content.
- Triggered by a Search Console notification flagging 46 `/_next/static/chunks/*.js` and `*.css` URLs as blocked by robots.txt.
- `/api/` remains disallowed.

_PR description written by Claude Code._