### PR TITLE
Drive featured cards from Airtable

### DIFF
--- a/src/app/advisors/page.tsx
+++ b/src/app/advisors/page.tsx
@@ -37,30 +37,26 @@ export default async function AdvisorsPage() {
       {/* Featured Cards + Related Resources */}
       <div className="flex flex-col-mobile gap-56px padding-bottom-80px">
         <div className="flex flex-col-mobile gap-40px">
-          <FeaturedCard
-            href="https://successif.org/"
-            tagline="Career transition advice"
-            name="Successif"
-            description="Provides personalized career advising to experienced professionals seeking to transition into AI risk reduction roles, offering expert guidance and practical support."
-            logo="/images/successif.webp"
-            metadata={[
-              { label: 'Focus', value: 'Career/contribution' },
-              { label: 'Status', value: 'Active' },
-            ]}
-            trackingPage="Advisors"
-          />
-          <FeaturedCard
-            href="https://aisafety.quest/#calls"
-            tagline="Impact-focused career advice"
-            name="AI Safety Quest"
-            description="Grassroots volunteer organization helping people contribute to reducing catastrophic risk from AI by directing them to the most relevant resources and communities."
-            logo="/images/ai-safety-quest.png"
-            metadata={[
-              { label: 'Focus', value: 'Career/contribution' },
-              { label: 'Status', value: 'Active' },
-            ]}
-            trackingPage="Advisors"
-          />
+          {[
+            advisors.find(a => a.featured === '1'),
+            advisors.find(a => a.featured === '2'),
+          ]
+            .filter((a): a is NonNullable<typeof a> => a != null)
+            .map(advisor => (
+              <FeaturedCard
+                key={advisor.id}
+                href={advisor.url !== '#' ? advisor.url : undefined}
+                tagline={advisor.featuredTagline!}
+                name={advisor.name}
+                description={advisor.description}
+                logo={advisor.logo ?? undefined}
+                metadata={[
+                  { label: 'Focus', value: advisor.focus },
+                  { label: 'Status', value: advisor.status },
+                ]}
+                trackingPage="Advisors"
+              />
+            ))}
         </div>
 
         <aside className="hide-mobile">

--- a/src/app/communities/page.tsx
+++ b/src/app/communities/page.tsx
@@ -20,35 +20,6 @@ export const metadata = {
   },
 }
 
-// Featured communities data (hardcoded as these are special highlights)
-const featuredCommunities = [
-  {
-    id: 'ai-alignment-slack',
-    name: 'AI Alignment Slack',
-    tagline: 'Largest real-time online community',
-    description:
-      'Community of thousands involved in making AI safe. Includes channels dedicated to making introductions, finding study buddies, asking questions, and discovering opportunities.',
-    logo: '/images/ai-alignment-slack.png',
-    platform: 'Slack',
-    activityLevel: 'Very active',
-    focus: 'Main focus is AI safety',
-    joinLink:
-      'https://join.slack.com/t/ai-alignment/shared_invite/zt-3oytsoq2q-nzMwWJqs5fl4H~VXA6FQTA',
-  },
-  {
-    id: 'lesswrong',
-    name: 'LessWrong',
-    tagline: 'Main forum for research and advocacy',
-    description:
-      'Forum dedicated to improving human reasoning and decision-making, and the primary online hub for long-form AI safety discussion and research.',
-    logo: '/images/lesswrong.png',
-    platform: 'Forum',
-    activityLevel: 'Very active',
-    focus: 'Partial focus on AI safety',
-    joinLink: 'https://www.lesswrong.com/w/ai',
-  },
-]
-
 export default async function CommunitiesPage() {
   const [communities, lastUpdated] = await Promise.all([
     getCommunities(),
@@ -82,22 +53,32 @@ export default async function CommunitiesPage() {
         {/* Featured Communities + Related Resources */}
         <div className="flex flex-col-mobile gap-56px padding-bottom-80px">
           <div className="flex flex-col-mobile gap-40px">
-            {featuredCommunities.map(community => (
-              <FeaturedCard
-                key={community.id}
-                href={community.joinLink}
-                tagline={community.tagline}
-                name={community.name}
-                description={community.description}
-                logo={community.logo}
-                metadata={[
-                  { label: 'Platform', value: community.platform },
-                  { label: 'Activity level', value: community.activityLevel },
-                  { label: 'Focus', value: community.focus },
-                ]}
-                trackingPage="Communities"
-              />
-            ))}
+            {[
+              communities.find(c => c.featured === '1'),
+              communities.find(c => c.featured === '2'),
+            ]
+              .filter((c): c is NonNullable<typeof c> => c != null)
+              .map(community => (
+                <FeaturedCard
+                  key={community.id}
+                  href={
+                    community.joinLink !== '#' ? community.joinLink : undefined
+                  }
+                  tagline={community.featuredTagline!}
+                  name={community.name}
+                  description={community.description}
+                  logo={community.logo ?? undefined}
+                  metadata={[
+                    { label: 'Platform', value: community.platformText },
+                    {
+                      label: 'Activity level',
+                      value: community.activityLevel,
+                    },
+                    { label: 'Focus', value: community.focus },
+                  ]}
+                  trackingPage="Communities"
+                />
+              ))}
           </div>
 
           <aside className="hide-mobile">

--- a/src/app/founders/page.tsx
+++ b/src/app/founders/page.tsx
@@ -36,24 +36,23 @@ export default async function FoundersPage() {
       {/* Featured Cards + Related Resources */}
       <div className="flex flex-col-mobile gap-56px padding-bottom-80px">
         <div className="flex flex-col-mobile gap-40px">
-          <FeaturedCard
-            href="https://www.ashgro.org/"
-            tagline="Featured fiscal sponsor"
-            name="Ashgro"
-            description="Providing fiscal sponsorship to AI safety projects, saving them time and allowing them to access more funding. Fee: 5–10%."
-            logo="/images/ashgro-logo.png"
-            metadata={[{ label: 'Type', value: 'Fiscal sponsor' }]}
-            trackingPage="Founders"
-          />
-          <FeaturedCard
-            href="https://www.catalyze-impact.org/"
-            tagline="Featured incubator"
-            name="Catalyze Impact"
-            description="Brings together co-founders, experts, and mission-oriented funders to accelerate founders from pre-idea to scaling an AI safety org. Includes mentorship and seed funding."
-            logo="/images/catalyze-impact-logo.png"
-            metadata={[{ label: 'Type', value: 'Incubator' }]}
-            trackingPage="Founders"
-          />
+          {[
+            resources.find(r => r.featured === '1'),
+            resources.find(r => r.featured === '2'),
+          ]
+            .filter((r): r is NonNullable<typeof r> => r != null)
+            .map(resource => (
+              <FeaturedCard
+                key={resource.id}
+                href={resource.website !== '#' ? resource.website : undefined}
+                tagline={resource.featuredTagline!}
+                name={resource.name}
+                description={resource.description}
+                logo={resource.image ?? undefined}
+                metadata={[{ label: 'Type', value: resource.type }]}
+                trackingPage="Founders"
+              />
+            ))}
         </div>
 
         <aside className="hide-mobile">

--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -34,33 +34,29 @@ export default async function FundingPage() {
       {/* Featured Cards + Related Resources */}
       <div className="flex flex-col-mobile gap-56px padding-bottom-80px">
         <div className="flex flex-col-mobile gap-40px">
-          <FeaturedCard
-            href="https://coefficientgiving.org/apply-for-funding/"
-            tagline="Largest funder in x-risk reduction"
-            name="Coefficient Giving (CG)"
-            description="Most funding is done via proactive research, but there are frequent requests for proposals in certain areas. Previously called Open Philanthropy."
-            logo="/images/coefficient-giving.webp"
-            metadata={[
-              { label: 'Type', value: 'Fund' },
-              { label: 'Accepting applications', value: 'Yes – rolling basis' },
-            ]}
-            trackingPage="Funding"
-          />
-          <FeaturedCard
-            href="https://survivalandflourishing.fund/"
-            tagline="Best for mid- to large-scale projects"
-            name="Survival and Flourishing Fund (SFF)"
-            description="Provides financial support to organizations working to improve humanity's long-term prospects for survival and flourishing. Speculation Grants are rolling; full S-Process runs annually."
-            logo="/images/sff-white.svg"
-            metadata={[
-              { label: 'Type', value: 'Fund' },
-              {
-                label: 'Accepting applications',
-                value: 'Yes – rolling basis',
-              },
-            ]}
-            trackingPage="Funding"
-          />
+          {[
+            funders.find(f => f.featured === '1'),
+            funders.find(f => f.featured === '2'),
+          ]
+            .filter((f): f is NonNullable<typeof f> => f != null)
+            .map(funder => (
+              <FeaturedCard
+                key={funder.id}
+                href={funder.url !== '#' ? funder.url : undefined}
+                tagline={funder.featuredTagline!}
+                name={funder.name}
+                description={funder.description}
+                logo={funder.logo ?? undefined}
+                metadata={[
+                  { label: 'Type', value: funder.type },
+                  {
+                    label: 'Accepting applications',
+                    value: funder.acceptingApplications,
+                  },
+                ]}
+                trackingPage="Funding"
+              />
+            ))}
         </div>
 
         <aside className="hide-mobile">

--- a/src/app/media-channels/page.tsx
+++ b/src/app/media-channels/page.tsx
@@ -36,24 +36,23 @@ export default async function MediaChannelsPage() {
       {/* Featured Cards + Related Resources */}
       <div className="flex flex-col-mobile gap-56px padding-bottom-80px">
         <div className="flex flex-col-mobile gap-40px">
-          <FeaturedCard
-            href="https://thezvi.substack.com/"
-            tagline="Top blog recommendation"
-            name="Don't Worry About the Vase"
-            description="Blog by Zvi Mowshowitz on various topics, including AI, offering detailed analysis and personal insights from a rationalist perspective. Posts very often."
-            logo="/images/zvi.webp"
-            metadata={[{ label: 'Type', value: 'Blog' }]}
-            trackingPage="Media channels"
-          />
-          <FeaturedCard
-            href="https://www.youtube.com/playlist?list=PLWQikawCP4UFM_ziLf9X2rcOLCSbqisRE"
-            tagline="Top recommended videos"
-            name="AI Safety Playlist"
-            description="A carefully curated and regularly updated YouTube playlist to help people gain an understanding of what's going on with AI."
-            logo="/images/YouTube.png"
-            metadata={[{ label: 'Type', value: 'YouTube' }]}
-            trackingPage="Media channels"
-          />
+          {[
+            channels.find(c => c.featured === '1'),
+            channels.find(c => c.featured === '2'),
+          ]
+            .filter((c): c is NonNullable<typeof c> => c != null)
+            .map(channel => (
+              <FeaturedCard
+                key={channel.id}
+                href={channel.url !== '#' ? channel.url : undefined}
+                tagline={channel.featuredTagline!}
+                name={channel.name}
+                description={channel.description}
+                logo={channel.logo ?? undefined}
+                metadata={[{ label: 'Type', value: channel.type }]}
+                trackingPage="Media channels"
+              />
+            ))}
         </div>
 
         <aside className="hide-mobile">

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -37,32 +37,33 @@ export default async function ProjectsPage() {
       {/* Featured Cards + Related Resources */}
       <div className="flex flex-col-mobile gap-56px padding-bottom-80px">
         <div className="flex flex-col-mobile gap-40px">
-          <FeaturedCard
-            tagline="Seeking maintainer"
-            name="Alignment Research Dataset"
-            description="Regularly scrapes all major sources of alignment data for use by the Stampy chatbot and other projects. Currently needs someone to maintain it."
-            metadata={[
-              {
-                label: 'Contact',
-                value: ['Olivier Coutu', 'coutu.olivier@gmail.com'],
-              },
-              { label: 'Status', value: 'Active' },
-            ]}
-            trackingPage="Projects"
-          />
-          <FeaturedCard
-            tagline="Content curation platform"
-            name="AI Safety Feed"
-            description="Curated stream for AI safety content, gathering posts and research from key sources. AI helps summarize, tag, and rate the novelty of content. Site: aisafetyfeed.com"
-            metadata={[
-              {
-                label: 'Contact',
-                value: ['Matt Brooks', 'matthewrbrooks94@gmail.com'],
-              },
-              { label: 'Status', value: 'Active' },
-            ]}
-            trackingPage="Projects"
-          />
+          {[
+            projects.find(p => p.featured === '1'),
+            projects.find(p => p.featured === '2'),
+          ]
+            .filter((p): p is NonNullable<typeof p> => p != null)
+            .map(project => (
+              <FeaturedCard
+                key={project.id}
+                tagline={project.featuredTagline!}
+                name={project.name}
+                description={project.description}
+                metadata={[
+                  ...(project.contact || project.email
+                    ? [
+                        {
+                          label: 'Contact',
+                          value: [project.contact, project.email].filter(
+                            Boolean
+                          ) as string[],
+                        },
+                      ]
+                    : []),
+                  { label: 'Status', value: project.status },
+                ]}
+                trackingPage="Projects"
+              />
+            ))}
         </div>
 
         <aside className="hide-mobile">

--- a/src/app/self-study/page.tsx
+++ b/src/app/self-study/page.tsx
@@ -37,30 +37,26 @@ export default async function SelfStudyPage() {
       {/* Featured Cards + Related Resources */}
       <div className="flex flex-col-mobile gap-56px padding-bottom-80px">
         <div className="flex flex-col-mobile gap-40px">
-          <FeaturedCard
-            href="https://www.alignmentforum.org/library"
-            tagline="Fundamental reading"
-            name="AI Alignment Forum: Curated Sequences"
-            description="List of sequences curated by the AI Alignment Forum team, featuring work from Richard Ngo, Paul Christiano, etc."
-            logo="/images/alignment-forum.png"
-            metadata={[
-              { label: 'Category', value: 'Technical Alignment' },
-              { label: 'Created by', value: 'Various' },
-            ]}
-            trackingPage="Self-study"
-          />
-          <FeaturedCard
-            href="https://bluedot.org/"
-            tagline="Standard introductory courses"
-            name="BlueDot Impact: Technical & Frontier AI Governance"
-            description="Covers key concepts and research perspectives in AI safety, split into two main streams: Technical AI Safety and AI Governance."
-            logo="/images/blue-dot-impact.svg"
-            metadata={[
-              { label: 'Category', value: 'Technical Alignment, Governance' },
-              { label: 'Created by', value: 'BlueDot Impact' },
-            ]}
-            trackingPage="Self-study"
-          />
+          {[
+            courses.find(c => c.featured === '1'),
+            courses.find(c => c.featured === '2'),
+          ]
+            .filter((c): c is NonNullable<typeof c> => c != null)
+            .map(course => (
+              <FeaturedCard
+                key={course.id}
+                href={course.url !== '#' ? course.url : undefined}
+                tagline={course.featuredTagline!}
+                name={course.name}
+                description={course.description}
+                logo={course.image ?? undefined}
+                metadata={[
+                  { label: 'Category', value: course.category },
+                  { label: 'Created by', value: course.organizer },
+                ]}
+                trackingPage="Self-study"
+              />
+            ))}
         </div>
 
         <aside className="hide-mobile">

--- a/src/lib/data/advisors.ts
+++ b/src/lib/data/advisors.ts
@@ -11,6 +11,8 @@ interface AirtableRecord {
     Focus?: string | string[]
     Status?: string | string[]
     Link?: string
+    Featured?: string
+    'Featured tagline'?: string
   }
 }
 
@@ -22,6 +24,8 @@ export interface Advisor {
   focus: string
   status: string
   url: string
+  featured: '1' | '2' | null
+  featuredTagline: string | null
 }
 
 export async function getAdvisors(): Promise<Advisor[]> {
@@ -54,6 +58,11 @@ export async function getAdvisors(): Promise<Advisor[]> {
         ? fields.Status.join(', ')
         : fields.Status || '',
       url: fields.Link || '#',
+      featured:
+        fields.Featured === '1' || fields.Featured === '2'
+          ? (fields.Featured as '1' | '2')
+          : null,
+      featuredTagline: fields['Featured tagline'] || null,
     })
   }
 

--- a/src/lib/data/communities.ts
+++ b/src/lib/data/communities.ts
@@ -20,6 +20,8 @@ interface AirtableRecord {
     Sort?: number
     Latitude?: number
     Longitude?: number
+    Featured?: string
+    'Featured tagline'?: string
   }
 }
 
@@ -40,6 +42,8 @@ export interface Community {
   sort: number
   latitude: number | null
   longitude: number | null
+  featured: '1' | '2' | null
+  featuredTagline: string | null
 }
 
 export async function getCommunities(): Promise<Community[]> {
@@ -77,6 +81,11 @@ export async function getCommunities(): Promise<Community[]> {
       sort: fields.Sort || 9999,
       latitude: fields.Latitude ?? null,
       longitude: fields.Longitude ?? null,
+      featured:
+        fields.Featured === '1' || fields.Featured === '2'
+          ? (fields.Featured as '1' | '2')
+          : null,
+      featuredTagline: fields['Featured tagline'] || null,
     })
   }
 

--- a/src/lib/data/founders.ts
+++ b/src/lib/data/founders.ts
@@ -11,6 +11,8 @@ interface AirtableRecord {
     Image?: Array<{ url: string }>
     Description?: string
     Website?: string
+    Featured?: string
+    'Featured tagline'?: string
   }
 }
 
@@ -22,6 +24,8 @@ export interface FounderResource {
   image: string | null
   description: string
   website: string
+  featured: '1' | '2' | null
+  featuredTagline: string | null
 }
 
 export async function getFounderResources(): Promise<FounderResource[]> {
@@ -55,6 +59,11 @@ export async function getFounderResources(): Promise<FounderResource[]> {
       image,
       description: fields.Description || '',
       website: fields.Website || '#',
+      featured:
+        fields.Featured === '1' || fields.Featured === '2'
+          ? (fields.Featured as '1' | '2')
+          : null,
+      featuredTagline: fields['Featured tagline'] || null,
     })
   }
 

--- a/src/lib/data/funding.ts
+++ b/src/lib/data/funding.ts
@@ -12,6 +12,8 @@ interface AirtableRecord {
     'Recipient type'?: string | string[]
     'Accepting applications?'?: string | string[]
     Website?: string
+    Featured?: string
+    'Featured tagline'?: string
   }
 }
 
@@ -24,6 +26,8 @@ export interface Funder {
   recipientType: string
   acceptingApplications: string
   url: string
+  featured: '1' | '2' | null
+  featuredTagline: string | null
 }
 
 export async function getFunders(): Promise<Funder[]> {
@@ -59,6 +63,11 @@ export async function getFunders(): Promise<Funder[]> {
         ? fields['Accepting applications?'].join(', ')
         : fields['Accepting applications?'] || '',
       url: fields.Website || '#',
+      featured:
+        fields.Featured === '1' || fields.Featured === '2'
+          ? (fields.Featured as '1' | '2')
+          : null,
+      featuredTagline: fields['Featured tagline'] || null,
     })
   }
 

--- a/src/lib/data/media-channels.ts
+++ b/src/lib/data/media-channels.ts
@@ -10,6 +10,8 @@ interface AirtableRecord {
     Image?: Array<{ url: string }>
     Type?: string | string[]
     Link?: string
+    Featured?: string
+    'Featured tagline'?: string
   }
 }
 
@@ -20,6 +22,8 @@ export interface MediaChannel {
   logo: string | null
   type: string
   url: string
+  featured: '1' | '2' | null
+  featuredTagline: string | null
 }
 
 export async function getMediaChannels(): Promise<MediaChannel[]> {
@@ -49,6 +53,11 @@ export async function getMediaChannels(): Promise<MediaChannel[]> {
         ? fields.Type.join(', ')
         : fields.Type || '',
       url: fields.Link || '#',
+      featured:
+        fields.Featured === '1' || fields.Featured === '2'
+          ? (fields.Featured as '1' | '2')
+          : null,
+      featuredTagline: fields['Featured tagline'] || null,
     })
   }
 

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -10,6 +10,8 @@ interface AirtableRecord {
     Status?: string | string[]
     'Contact name'?: string
     'Contact email'?: string
+    Featured?: string
+    'Featured tagline'?: string
   }
 }
 
@@ -21,6 +23,8 @@ export interface Project {
   contact: string
   email: string | null
   status: string
+  featured: '1' | '2' | null
+  featuredTagline: string | null
 }
 
 export async function getProjects(): Promise<Project[]> {
@@ -46,6 +50,11 @@ export async function getProjects(): Promise<Project[]> {
       status: Array.isArray(fields.Status)
         ? fields.Status.join(', ')
         : fields.Status || '',
+      featured:
+        fields.Featured === '1' || fields.Featured === '2'
+          ? (fields.Featured as '1' | '2')
+          : null,
+      featuredTagline: fields['Featured tagline'] || null,
     })
   }
 

--- a/src/lib/data/self-study.ts
+++ b/src/lib/data/self-study.ts
@@ -12,6 +12,8 @@ interface AirtableRecord {
     'Created by'?: string
     Link?: string
     Logo?: Array<{ url: string }>
+    Featured?: string
+    'Featured tagline'?: string
   }
 }
 
@@ -24,6 +26,8 @@ export interface Course {
   organizer: string
   url: string
   image: string | null
+  featured: '1' | '2' | null
+  featuredTagline: string | null
 }
 
 export async function getCourses(): Promise<Course[]> {
@@ -57,6 +61,11 @@ export async function getCourses(): Promise<Course[]> {
       organizer: fields['Created by'] || '',
       url: fields.Link || '#',
       image,
+      featured:
+        fields.Featured === '1' || fields.Featured === '2'
+          ? (fields.Featured as '1' | '2')
+          : null,
+      featuredTagline: fields['Featured tagline'] || null,
     })
   }
 


### PR DESCRIPTION
- Featured cards on 7 resource pages are now driven by Airtable instead of hardcoded in JSX
- Two new Airtable fields: "Featured" (single select: "1" or "2" for left/right position) and "Featured tagline" (text)
- Data layer (7 files in `src/lib/data/`) gains `featured` and `featuredTagline` fields
- Page components (7 `page.tsx` files) render FeaturedCards dynamically from the data
- Related Resources sidebars remain hardcoded
- No visual change — initial Airtable values match the previously hardcoded content

Pages affected: Self-study, Communities, Funding, Media Channels, Advisors, Founders, Projects. Jobs and Map have no featured cards and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_PR description written by Claude Code._