### PR TITLE
Fix broken featured card logos

### DIFF
--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -47,6 +47,7 @@ export default function FeaturedCard({
               width={64}
               height={64}
               className="card-image"
+              unoptimized
             />
           </div>
           <h3>{name}</h3>


### PR DESCRIPTION
- Adds `unoptimized` to the `<Image>` in `FeaturedCard.tsx`
- All other card components already have this prop — it was just missing from FeaturedCard
- Needed now that featured card logos come from Airtable (airtable-cache paths) instead of hardcoded local images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_PR description written by Claude Code._