### PR TITLE
Replace homepage Volunteer projects panel with Founder toolkit

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -374,17 +374,17 @@ export default async function Home() {
         <div className={styles['card-third-width-2']}>
           <div className={styles['card-half-width-main-text']}>
             <p className="paragraph-small-bold padding-bottom-8px">
-              Volunteer projects
+              Found an organization
             </p>
             <h3 className="padding-bottom-32px">
-              Build online tools to support the AI safety ecosystem
+              Resources for starting and growing an AI safety organization
             </h3>
-            <Link href="/projects" className="button-primary drop-shadow">
-              View all projects
+            <Link href="/founders" className="button-primary drop-shadow">
+              View founder toolkit
             </Link>
-            {dates.projects && (
+            {dates.founders && (
               <RelativeDate
-                iso={dates.projects}
+                iso={dates.founders}
                 className={`${styles['date-alt']} paragraph-xs`}
               />
             )}
@@ -399,19 +399,19 @@ export default async function Home() {
               height={32}
             />
             <p className="paragraph-small-bold padding-bottom-12px">
-              Featured project
+              Featured fiscal sponsor
             </p>
             <div className={`${styles['icon-row']} padding-bottom-24px`}>
-              <h3>AI Safety Feed</h3>
+              <h3>Ashgro</h3>
             </div>
             <div className="block">
               <TrackedLink
-                href="https://aisafetyfeed.com/"
+                href="https://www.ashgro.org/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="button-secondary"
                 trackingPage="Home"
-                trackingName="AI Safety Feed"
+                trackingName="Ashgro"
               >
                 Learn more
               </TrackedLink>


### PR DESCRIPTION
- Replaces the "Volunteer projects" panel (the middle card in the homepage's bottom row) with a **Founder toolkit** panel linking to `/founders`.
- Panel now reads **"Found an organization" → "Resources for starting and growing an AI safety organization"**, with a **View founder toolkit** button.
- The featured sub-card now showcases **Ashgro** ("Featured fiscal sponsor") in place of AI Safety Feed.
- The "Updated … ago" timestamp now tracks the Founder toolkit table (already wired in `last-updated.ts`).
- Reuses the existing `card-third-width-2` styling — no CSS changes. The Volunteer projects page is untouched: it stays in the top nav and at `/projects`, just no longer featured on the homepage.

_PR description written by Claude Code._
