### PR TITLE
Fix background glow seam (remove stray SVG mask clipping the blur)

### DIFF
--- a/public/images/bg.svg
+++ b/public/images/bg.svg
@@ -1,8 +1,5 @@
 <svg width="2028" height="944" viewBox="0 0 2028 944" fill="none" xmlns="http://www.w3.org/2000/svg">
-<mask id="mask0_10234_2930" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="2028" height="933">
-<rect width="2028" height="933" fill="#D9D9D9"/>
-</mask>
-<g mask="url(#mask0_10234_2930)">
+<g>
 <g opacity="0.2" filter="url(#filter0_f_10234_2930)">
 <ellipse cx="1012" cy="-57" rx="825" ry="792" fill="#62B0BA"/>
 </g>


### PR DESCRIPTION
- The site background glow (`public/images/bg.svg`) had an internal `<mask>` set to 933px tall while the SVG itself is 944px. The blurred glow was still faintly visible at the mask's edge, so it got hard-clipped in a single row — producing a visible horizontal "cutoff" line on longer pages (e.g. `/self-study`), most noticeable in Safari.
- This mask was a Figma export artifact. On the old Webflow site the same SVG was only ever shown as a 1600×600 `object-fit: none` hero crop (≈ y172–772), so the seam was never visible. The Next.js migration applies the full-height SVG as the `body` background, which exposed it.
- Fix: removed the `<mask>` so the glow fades smoothly to the SVG edge, where it already matches `--teal-900` — no visible seam. The top glow is byte-for-byte unchanged.
- Verified by sampling rendered pixels down the page centre: the hard step (Δluma ≈ 1.7 at y=933) is gone and the gradient is smooth/uniform through the former seam. Confirmed visually with before/after screenshots. `npm run build` passes.

_PR description written by Claude Code._
