### PR TITLE
Use design-system utility classes for the search clear button

### DIFF
--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -4,11 +4,13 @@
   min-width: 0;
 }
 
+/* Make room for the clear button; .text-field already sets width: 100%. */
 .input {
-  width: 100%;
   padding-right: 52px;
 }
 
+/* Only the overlay positioning and button reset live here — flex centering,
+   cursor, and color come from globals.css utility classes on the element. */
 .clearButton {
   position: absolute;
   top: 50%;
@@ -18,9 +20,4 @@
   height: 32px;
   border: none;
   background-color: transparent;
-  color: var(--teal-400);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,10 +1,6 @@
 'use client'
 
-import type {
-  ComponentPropsWithoutRef,
-  KeyboardEvent,
-  RefObject,
-} from 'react'
+import type { ComponentPropsWithoutRef, KeyboardEvent, RefObject } from 'react'
 import { useRef } from 'react'
 import styles from './SearchBar.module.css'
 
@@ -89,7 +85,7 @@ export default function SearchBar({
       {showClear ? (
         <button
           type="button"
-          className={`${styles.clearButton}${clearButtonClassName ? ` ${clearButtonClassName}` : ''}`}
+          className={`${styles.clearButton} flex items-center justify-center cursor-pointer color-teal-400${clearButtonClassName ? ` ${clearButtonClassName}` : ''}`}
           aria-label="Clear search"
           onMouseDown={event => event.preventDefault()}
           onClick={clearSearch}


### PR DESCRIPTION
Follow-up to #402 — a small style-guide compliance cleanup for the new search clear button. No visual change.

- Move flex centering, cursor, and color to `globals.css` utility classes (`flex`, `items-center`, `justify-center`, `cursor-pointer`, `color-teal-400`) instead of hand-writing them in CSS, per `docs/css-guidelines.md`.
- Leave only the genuinely-custom overlay positioning and button reset in `SearchBar.module.css` (no utility equivalent exists for those).
- Drop the redundant `width: 100%` on the input — the shared `.text-field` class already sets it.

_PR description written by Claude Code._