### PR TITLE
Relabel self-study filters: Category→Focus, Type→Format, Introductory→General intro

### DIFF
--- a/src/app/self-study/SelfStudyClient.tsx
+++ b/src/app/self-study/SelfStudyClient.tsx
@@ -6,7 +6,11 @@ import FilterGroup from '@/components/FilterGroup'
 import FilterSidebar from '@/components/FilterSidebar'
 import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
-import { Course } from '@/lib/data/self-study'
+import type { Course } from '@/lib/data/self-study'
+import {
+  displayCategory,
+  categoryDisplayLabels,
+} from '@/lib/data/self-study-labels'
 import { trackListingClick } from '@/lib/analytics'
 
 interface SelfStudyClientProps {
@@ -156,10 +160,10 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
                 {course.description}
               </p>
               <p className="paragraph-xs-bold padding-bottom-4px color-teal-400">
-                Category
+                Focus
               </p>
               <p className="paragraph-small padding-bottom-16px">
-                {course.category}
+                {displayCategory(course.category)}
               </p>
               <p className="paragraph-xs-bold padding-bottom-4px color-teal-400">
                 Created by
@@ -176,8 +180,9 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
       <div className="hide-mobile">
         <FilterSidebar>
           <FilterGroup
-            title="Category"
+            title="Focus"
             options={categoryOptions}
+            labels={categoryDisplayLabels}
             selected={selectedCategories}
             counts={categoryCounts}
             onToggle={v =>
@@ -185,7 +190,7 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
             }
           />
           <FilterGroup
-            title="Type"
+            title="Format"
             options={typeOptions}
             selected={selectedTypes}
             counts={typeCounts}

--- a/src/app/self-study/SelfStudyClient.tsx
+++ b/src/app/self-study/SelfStudyClient.tsx
@@ -10,6 +10,7 @@ import type { Course } from '@/lib/data/self-study'
 import {
   displayCategory,
   categoryDisplayLabels,
+  typeDisplayLabels,
 } from '@/lib/data/self-study-labels'
 import { trackListingClick } from '@/lib/analytics'
 
@@ -192,6 +193,7 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
           <FilterGroup
             title="Format"
             options={typeOptions}
+            labels={typeDisplayLabels}
             selected={selectedTypes}
             counts={typeCounts}
             onToggle={v => toggleFilter(v, selectedTypes, setSelectedTypes)}

--- a/src/app/self-study/page.tsx
+++ b/src/app/self-study/page.tsx
@@ -4,6 +4,7 @@ import PageHeader from '@/components/PageHeader'
 import FeaturedCard from '@/components/FeaturedCard'
 import SelfStudyClient from './SelfStudyClient'
 import { getCourses } from '@/lib/data/self-study'
+import { displayCategory } from '@/lib/data/self-study-labels'
 
 export const metadata = {
   title: 'Self-study – AISafety.com',
@@ -51,7 +52,7 @@ export default async function SelfStudyPage() {
                 description={course.description}
                 logo={course.image ?? undefined}
                 metadata={[
-                  { label: 'Category', value: course.category },
+                  { label: 'Focus', value: displayCategory(course.category) },
                   { label: 'Created by', value: course.organizer },
                 ]}
                 trackingPage="Self-study"

--- a/src/components/FilterGroup.tsx
+++ b/src/components/FilterGroup.tsx
@@ -6,6 +6,9 @@ interface FilterGroupProps {
   selected: string[]
   counts: Record<string, number>
   onToggle: (value: string) => void
+  // Optional map from option value to the label shown to the user. Filtering
+  // and counts still run on the raw option values; only the display changes.
+  labels?: Record<string, string>
 }
 
 export default function FilterGroup({
@@ -14,6 +17,7 @@ export default function FilterGroup({
   selected,
   counts,
   onToggle,
+  labels,
 }: FilterGroupProps) {
   return (
     <div className="padding-bottom-40px">
@@ -30,7 +34,7 @@ export default function FilterGroup({
               className="checkbox"
             />
             <span className="paragraph-small color-teal-300">
-              {option}
+              {labels?.[option] ?? option}
               <span className="filter-count"> ({counts[option] || 0})</span>
             </span>
           </label>

--- a/src/lib/data/search-index.ts
+++ b/src/lib/data/search-index.ts
@@ -2,6 +2,7 @@ import { getAdvisors } from './advisors'
 import { fetchAirtableRecords } from './airtable'
 import { getCommunities } from './communities'
 import { getCourses } from './self-study'
+import { displayCategory } from './self-study-labels'
 import { getFounderResources } from './founders'
 import { getFunders } from './funding'
 import { getJobs } from './jobs'
@@ -265,7 +266,9 @@ export async function buildSearchIndex(): Promise<SearchEntry[]> {
       title: c.name,
       subtitle: '',
       description: c.description,
-      category: [c.category, c.courseType].filter(Boolean).join(' · '),
+      category: [displayCategory(c.category), c.courseType]
+        .filter(Boolean)
+        .join(' · '),
       url: c.url || '/self-study',
       logo: c.image,
     })

--- a/src/lib/data/search-index.ts
+++ b/src/lib/data/search-index.ts
@@ -2,7 +2,7 @@ import { getAdvisors } from './advisors'
 import { fetchAirtableRecords } from './airtable'
 import { getCommunities } from './communities'
 import { getCourses } from './self-study'
-import { displayCategory } from './self-study-labels'
+import { displayCategory, displayType } from './self-study-labels'
 import { getFounderResources } from './founders'
 import { getFunders } from './funding'
 import { getJobs } from './jobs'
@@ -266,7 +266,7 @@ export async function buildSearchIndex(): Promise<SearchEntry[]> {
       title: c.name,
       subtitle: '',
       description: c.description,
-      category: [displayCategory(c.category), c.courseType]
+      category: [displayCategory(c.category), displayType(c.courseType)]
         .filter(Boolean)
         .join(' · '),
       url: c.url || '/self-study',

--- a/src/lib/data/self-study-labels.ts
+++ b/src/lib/data/self-study-labels.ts
@@ -1,0 +1,21 @@
+// Display-only labels for the /self-study page (requested by Melissa, June
+// 2026). The page shows the Airtable "Category" field as "Focus", the "Type"
+// field as "Format", and the "Introductory" value as "General intro".
+// Filtering, counts, the stored Airtable data, Comb (record creation), and the
+// chatbot all keep using the raw values, so nothing downstream needs to change.
+//
+// This lives in its own module — with no data-layer / Node imports — so client
+// components can import it without pulling Node built-ins into the browser
+// bundle.
+export const categoryDisplayLabels: Record<string, string> = {
+  Introductory: 'General intro',
+}
+
+export function displayCategory(raw: string): string {
+  return raw
+    .split(',')
+    .map(c => c.trim())
+    .filter(Boolean)
+    .map(c => categoryDisplayLabels[c] ?? c)
+    .join(', ')
+}

--- a/src/lib/data/self-study-labels.ts
+++ b/src/lib/data/self-study-labels.ts
@@ -1,21 +1,35 @@
 // Display-only labels for the /self-study page (requested by Melissa, June
-// 2026). The page shows the Airtable "Category" field as "Focus", the "Type"
-// field as "Format", and the "Introductory" value as "General intro".
-// Filtering, counts, the stored Airtable data, Comb (record creation), and the
-// chatbot all keep using the raw values, so nothing downstream needs to change.
+// 2026). The page shows the Focus and Format tags in sentence case — e.g.
+// "General intro" (stored as "Introductory"), "Technical alignment", and
+// "Reading list" — for consistent capitalization. Filtering, counts, the
+// stored Airtable data, Comb (record creation), and the chatbot all keep using
+// the raw values, so nothing downstream needs to change.
 //
 // This lives in its own module — with no data-layer / Node imports — so client
 // components can import it without pulling Node built-ins into the browser
 // bundle.
 export const categoryDisplayLabels: Record<string, string> = {
   Introductory: 'General intro',
+  'Technical Alignment': 'Technical alignment',
+}
+
+export const typeDisplayLabels: Record<string, string> = {
+  'Reading List': 'Reading list',
+}
+
+function applyLabels(raw: string, labels: Record<string, string>): string {
+  return raw
+    .split(',')
+    .map(v => v.trim())
+    .filter(Boolean)
+    .map(v => labels[v] ?? v)
+    .join(', ')
 }
 
 export function displayCategory(raw: string): string {
-  return raw
-    .split(',')
-    .map(c => c.trim())
-    .filter(Boolean)
-    .map(c => categoryDisplayLabels[c] ?? c)
-    .join(', ')
+  return applyLabels(raw, categoryDisplayLabels)
+}
+
+export function displayType(raw: string): string {
+  return applyLabels(raw, typeDisplayLabels)
 }


### PR DESCRIPTION
- Renames the self-study filters and card labels: **Category → Focus**, **Type → Format**, **Introductory → General intro** (requested by Melissa).
- Display-only: the underlying Airtable data, Comb (record creation), and the chatbot keep using the original values (`Category`/`Type`/`Introductory`), so filtering and automated record creation are unaffected.
- Adds a dependency-free `self-study-labels` module so the client component can map values → display labels without pulling Node built-ins into the browser bundle; `FilterGroup` gains an optional `labels` prop.
- Site-wide search also maps the course category for consistency.
- Note: this applies to the current page design. The in-progress sub-page redesign (icon cards + dropdown filters) isn't in the codebase yet and will need the same wording when it lands.

_PR description written by Claude Code._