### PR TITLE
Events: make the first (Table view) embed 300px taller

### DIFF
--- a/src/app/events-and-training/EventsEmbeds.tsx
+++ b/src/app/events-and-training/EventsEmbeds.tsx
@@ -6,7 +6,7 @@ import styles from './page.module.css'
 const EMBEDS = [
   {
     src: 'https://airtable.com/embed/appF8XfZUGXtfi40E/shrLgl03tMK4q6cyc?viewControls=on',
-    height: 2210,
+    height: 2510,
     className: `${styles['airtable-embed']} ${styles['airtable-embed-mobile']} margin-bottom-40px`,
   },
   {


### PR DESCRIPTION
- Increases the height of the first Airtable embed (the "Table view" grid) on /events-and-training from 2210px to 2510px (+300px), so more rows are visible without scrolling inside the embed.
- Only the first embed is affected; the Calendar view and deadline embeds are unchanged.

_PR description written by Claude Code._