### PR TITLE
Remove self-study Category/Type compatibility shim

### DIFF
--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -356,9 +356,12 @@ async function fetchAirtableRecordsImpl(
 }
 
 // unstable_cache keys on the stringified arguments automatically; the
-// static keyParts below are just a namespace tag for invalidation.
+// static keyParts below are just a namespace tag for invalidation. Bump the
+// version segment to force a fresh fetch on deploy after an Airtable schema
+// change (e.g. the self-study Category/Type -> Focus/Format rename), so cached
+// records under the old field shape can't be served to new code.
 export const fetchAirtableRecords = unstable_cache(
   fetchAirtableRecordsImpl,
-  ['airtable-records'],
+  ['airtable-records', 'v2'],
   { revalidate: 3600 }
 )

--- a/src/lib/data/self-study.ts
+++ b/src/lib/data/self-study.ts
@@ -7,37 +7,14 @@ interface AirtableRecord {
   fields: {
     Name?: string
     Description?: string
-    // "Focus"/"Format" are the current field names; "Category"/"Type" are read
-    // as a fallback so this works both before and after the Airtable rename.
     Focus?: string | string[]
     Format?: string | string[]
-    Category?: string | string[]
-    Type?: string | string[]
     'Created by'?: string
     Link?: string
     Logo?: Array<{ url: string }>
     Featured?: string
     'Featured tagline'?: string
   }
-}
-
-// Normalise legacy option values to the current names, so filtering/display
-// keep working during the transition window before/after the Airtable rename.
-// Safe to remove once the rename is fully propagated.
-const FOCUS_VALUE_RENAMES: Record<string, string> = {
-  Introductory: 'General intro',
-  'Technical Alignment': 'Technical alignment',
-}
-const FORMAT_VALUE_RENAMES: Record<string, string> = {
-  'Reading List': 'Reading list',
-}
-
-function normalizeMultiSelect(
-  raw: string | string[] | undefined,
-  renames: Record<string, string>
-): string {
-  const values = Array.isArray(raw) ? raw : raw ? [raw] : []
-  return values.map(v => renames[v] ?? v).join(', ')
 }
 
 export interface Course {
@@ -75,14 +52,12 @@ export async function getCourses(): Promise<Course[]> {
       id: record.id,
       name: fields.Name,
       description: fields.Description || '',
-      category: normalizeMultiSelect(
-        fields.Focus ?? fields.Category,
-        FOCUS_VALUE_RENAMES
-      ),
-      courseType: normalizeMultiSelect(
-        fields.Format ?? fields.Type,
-        FORMAT_VALUE_RENAMES
-      ),
+      category: Array.isArray(fields.Focus)
+        ? fields.Focus.join(', ')
+        : fields.Focus || '',
+      courseType: Array.isArray(fields.Format)
+        ? fields.Format.join(', ')
+        : fields.Format || '',
       organizer: fields['Created by'] || '',
       url: fields.Link || '#',
       image,


### PR DESCRIPTION
- The self-study Airtable fields are now fully renamed (Category→Focus, Type→Format) with all option values updated, so the transition-window shim in `self-study.ts` (field-name fallback + value normalization) is dead code. Now reads `Focus`/`Format` directly.
- Bumps the Airtable `unstable_cache` keyParts to `v2` so this deploy fetches fresh records rather than serving cached pre-rename field shapes to the new code — avoids any blank-filters window on the live page.
- Verified locally against a fresh fetch: Focus (General intro · Technical alignment · Governance · Strategy) and Format (Curriculum · Reading list) all populate correctly.

_PR description written by Claude Code._