### PR TITLE
Move scroll-to-top button to the bottom-left (clear of the chat launcher)

### DIFF
--- a/src/components/UpButton.module.css
+++ b/src/components/UpButton.module.css
@@ -2,8 +2,11 @@
 
 .up-button {
   position: fixed;
-  bottom: 16px;
-  right: 16px;
+  /* Bottom-left, mirroring the assistant launcher's offsets in the opposite
+     corner so the chat never covers it. */
+  bottom: 24px;
+  left: 24px;
+  z-index: 98; /* under the assistant panel (99) and launcher (100) */
   padding: 9px 15px;
   background: none;
   border: none;
@@ -11,4 +14,12 @@
   font-size: 20px;
   cursor: pointer;
   text-decoration: none;
+}
+
+@media (max-width: 991px) {
+  .up-button {
+    /* Mobile launcher sits at 16px/16px; mirror it */
+    bottom: 16px;
+    left: 16px;
+  }
 }


### PR DESCRIPTION
- The chatbot launcher now sits in the bottom-right corner — exactly where the scroll-to-top (⌃) button used to be, so they overlapped.
- Moves the scroll-to-top button to the **bottom-left**, mirroring the launcher's offsets (24px desktop / 16px mobile) so the two sit symmetrically and never collide. It also stays usable while the chat panel is open, since the panel only covers the right side.
- CSS-only change in the button's own module (`UpButton.module.css`) — same caret, same appearance, same scroll behavior. No changes to the chatbot.

_PR description written by Claude Code._