### PR TITLE
Fix chatbot conversations never reaching Airtable in production

### DIFF
--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk'
-import { NextRequest } from 'next/server'
+import { NextRequest, after } from 'next/server'
 import { getCatalog } from '@/lib/assistant/catalog'
 import {
   PRODUCTION_PROMPT,
@@ -128,27 +128,33 @@ export async function POST(req: NextRequest) {
 
     const zeroMatches =
       result.citations.length === 0 && /\[\[suggest:/.test(result.assistantText)
-    void storeConversationTurn({
-      ts: new Date().toISOString(),
-      sessionId: body.sessionId ?? null,
-      currentPage: ctx.currentPage,
-      pageState: ctx.pageState ?? null,
-      referrer: ctx.referrer ?? null,
-      geo: ctx.geo ?? null,
-      utm: ctx.utm ?? null,
-      user: userQuery,
-      // Full conversation including the assistant's just-completed reply,
-      // so the upsert can persist the up-to-date History in one row.
-      history: [
-        ...messages,
-        { role: 'assistant', content: result.assistantText },
-      ],
-      toolCalls: result.toolCalls,
-      response: result.assistantText,
-      citations: result.citations.map(c => c.id),
-      zeroMatches,
-      latencyMs: Date.now() - startedAt,
-      promptVersion: PROMPT_VERSION,
-    })
+    // after() keeps the serverless function alive until the write completes.
+    // A bare fire-and-forget promise gets frozen (and usually lost) the moment
+    // the response stream closes, so conversations were never reaching
+    // Airtable in production.
+    after(() =>
+      storeConversationTurn({
+        ts: new Date().toISOString(),
+        sessionId: body.sessionId ?? null,
+        currentPage: ctx.currentPage,
+        pageState: ctx.pageState ?? null,
+        referrer: ctx.referrer ?? null,
+        geo: ctx.geo ?? null,
+        utm: ctx.utm ?? null,
+        user: userQuery,
+        // Full conversation including the assistant's just-completed reply,
+        // so the upsert can persist the up-to-date History in one row.
+        history: [
+          ...messages,
+          { role: 'assistant', content: result.assistantText },
+        ],
+        toolCalls: result.toolCalls,
+        response: result.assistantText,
+        citations: result.citations.map(c => c.id),
+        zeroMatches,
+        latencyMs: Date.now() - startedAt,
+        promptVersion: PROMPT_VERSION,
+      })
+    )
   })
 }


### PR DESCRIPTION
- Conversation logging after each chatbot turn was fire-and-forget (`void storeConversationTurn(...)`). On Vercel, the function is suspended the moment the SSE response stream closes, so the Airtable write never completed in production — zero conversations have been logged since launch. (The write would occasionally resume minutes later inside an unrelated invocation — visible in the runtime logs as `[assistant] airtable log failed` warnings during `/api/check-rebuild` cron runs — and then fail because its connection was torn down.)
- Wrapped the write in `after()` from `next/server`, which keeps the function alive until the write finishes. The response stream still closes immediately, so nothing changes for the visitor.
- Verified locally end-to-end: a chat turn now lands as a record in the conversations table. Production behavior to be confirmed after deploy (the chatbot's `ANTHROPIC_API_KEY` and `ADMIN_CONVERSATIONS_TABLE_ID` are production-only, so a preview deployment can't exercise this path).

_PR description written by Claude Code._