### PR TITLE
Make the admin Conversations panel more readable

### DIFF
--- a/src/app/admin/AdminHeader.tsx
+++ b/src/app/admin/AdminHeader.tsx
@@ -29,7 +29,7 @@ export default function AdminHeader({ tabs }: Props) {
     <header className={styles.adminHeader}>
       <div className={styles.adminHeaderInner}>
         <Link href="/admin/assistant" className={styles.adminBrand}>
-          AISafety Admin
+          AISafety.com Chatbot Admin
         </Link>
         <nav className={styles.adminNav}>
           {tabs?.map(tab => {

--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -593,6 +593,26 @@
   color: var(--teal-400);
 }
 
+.convRowMeta {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.convRowDate {
+  color: var(--teal-300);
+}
+
+.convRowPage {
+  padding: 1px 7px;
+  background-color: var(--teal-800);
+  border-radius: 999px;
+  color: var(--teal-300);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+}
+
 .convRowZero {
   color: #ffb87a;
   font-weight: 600;
@@ -688,6 +708,171 @@
   white-space: pre-wrap;
   word-break: break-word;
   line-height: 1.5;
+}
+
+/* ─── Rendered assistant message ──────────────────────────────────────── */
+
+.convMsg {
+  font-size: 13px;
+  color: var(--white);
+  line-height: 1.55;
+  word-break: break-word;
+}
+
+.convMsg p {
+  margin: 0 0 10px;
+}
+
+.convMsg ul,
+.convMsg ol {
+  margin: 0 0 10px;
+  padding-left: 20px;
+}
+
+.convMsg li {
+  margin-bottom: 3px;
+}
+
+.convMsg > :last-child {
+  margin-bottom: 0;
+}
+
+.convLink {
+  color: var(--bright-teal-300);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.convLink:hover {
+  color: var(--bright-teal-500);
+}
+
+.convThinking {
+  margin-bottom: 10px;
+  padding: 6px 10px;
+  border-left: 2px solid var(--teal-700);
+  color: var(--teal-400);
+  font-size: 12px;
+  font-style: italic;
+}
+
+.convThinkingLabel {
+  display: block;
+  font-size: 10px;
+  font-style: normal;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--teal-500);
+  margin-bottom: 2px;
+}
+
+.convCards {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 0 0 10px;
+}
+
+.convCard {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  background-color: var(--teal-850);
+  border: 1px solid var(--teal-700);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--white);
+}
+
+.convCardType {
+  padding: 1px 7px;
+  background-color: var(--teal-800);
+  border-radius: 999px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--bright-teal-300);
+}
+
+.convCardInline {
+  display: inline;
+  padding: 0 5px;
+  background-color: var(--teal-800);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--bright-teal-300);
+}
+
+.convChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.convChip {
+  padding: 3px 10px;
+  background-color: var(--teal-800);
+  border: 1px solid var(--teal-700);
+  border-radius: 999px;
+  font-size: 11px;
+  color: var(--teal-300);
+}
+
+.convSuggestNote {
+  margin-top: 10px;
+  font-size: 11px;
+  color: #ffb87a;
+}
+
+/* ─── Tool calls + citations ──────────────────────────────────────────── */
+
+.convToolCalls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.convToolCall,
+.convToolCallFailed {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 3px 8px;
+  background-color: var(--teal-850);
+  border: 1px solid var(--teal-800);
+  border-radius: 6px;
+  font-size: 11px;
+  color: var(--teal-300);
+}
+
+.convToolCallFailed {
+  border-color: #ff8b8b;
+  color: #ff8b8b;
+}
+
+.convToolCallName {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--bright-teal-300);
+}
+
+.convCitations {
+  max-height: 96px;
+  overflow-y: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--teal-400);
+  line-height: 1.6;
+  word-break: break-all;
+}
+
+.convError {
+  font-size: 11px;
+  color: #ff8b8b;
 }
 
 .convNotes {

--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -539,6 +539,12 @@
 
 /* ─── Conversations ─────────────────────────────────────────────────── */
 
+/* Readable column on wide screens; the full console width makes the
+   preview lines far too long. */
+.convPage {
+  max-width: 960px;
+}
+
 .conversationsWrap {
   display: flex;
   flex-direction: column;
@@ -564,6 +570,27 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.convDayDivider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 20px 0 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--teal-300);
+}
+
+.convDayDivider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background-color: var(--teal-800);
+}
+
+.convList > .convDayDivider:first-child {
+  margin-top: 0;
 }
 
 .convRow {

--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -539,10 +539,11 @@
 
 /* ─── Conversations ─────────────────────────────────────────────────── */
 
-/* Readable column on wide screens; the full console width makes the
-   preview lines far too long. */
+/* Readable centered column on wide screens; the full console width makes
+   the preview lines far too long. */
 .convPage {
   max-width: 960px;
+  margin: 0 auto;
 }
 
 .conversationsWrap {

--- a/src/app/admin/assistant/ConversationList.tsx
+++ b/src/app/admin/assistant/ConversationList.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import styles from '../admin.module.css'
+import TranscriptMessage, { plainPreview } from './TranscriptMessage'
 
 interface HistoryTurn {
   role: 'user' | 'assistant'
@@ -35,7 +36,68 @@ interface Conversation {
 
 function geoString(geo: ConversationData['geo']): string {
   if (!geo) return ''
-  return [geo.city, geo.region, geo.country].filter(Boolean).join(', ')
+  return [geo.city ?? geo.region, geo.country].filter(Boolean).join(', ')
+}
+
+/** "12 June 2026, 17:51" — site-wide DATE MONTH YEAR convention. */
+function formatDateTime(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  const date = d.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+  const time = d.toLocaleTimeString('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+  return `${date}, ${time}`
+}
+
+function formatLatency(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`
+}
+
+interface ToolCallEntry {
+  name?: string
+  input?: unknown
+  ok?: boolean
+}
+
+/** The Data column stores one tool-call array per turn; flatten across
+ *  turns and drop anything that isn't a call object. */
+function flattenToolCalls(tools: unknown[]): ToolCallEntry[] {
+  const out: ToolCallEntry[] = []
+  for (const entry of tools) {
+    const calls = Array.isArray(entry) ? entry : [entry]
+    for (const call of calls) {
+      if (call && typeof call === 'object' && 'name' in call) {
+        out.push(call as ToolCallEntry)
+      }
+    }
+  }
+  return out
+}
+
+/** {type:"job", filters:{skillSet:"X"}} → "type: job · skillSet: X" */
+function describeToolInput(input: unknown): string {
+  if (!input || typeof input !== 'object') return ''
+  const parts: string[] = []
+  const walk = (obj: Record<string, unknown>) => {
+    for (const [key, value] of Object.entries(obj)) {
+      if (value == null || value === '') continue
+      if (Array.isArray(value)) {
+        parts.push(`${key}: ${value.join(', ')}`)
+      } else if (typeof value === 'object') {
+        walk(value as Record<string, unknown>)
+      } else {
+        parts.push(`${key}: ${String(value)}`)
+      }
+    }
+  }
+  walk(input as Record<string, unknown>)
+  return parts.join(' · ')
 }
 
 export default function ConversationList() {
@@ -79,27 +141,23 @@ export default function ConversationList() {
   return (
     <div>
       <div className={styles.convFilters}>
-        <label>
+        <label title="Only show conversations where the chatbot found no matching listings">
           <input
             type="checkbox"
             checked={zeroOnly}
             onChange={e => setZeroOnly(e.target.checked)}
           />
-          Zero-match only
+          No-match only
         </label>
         <button
           type="button"
-          className={styles.promptToolbarReset}
+          className={styles.editorButton}
           onClick={() => void load(zeroOnly)}
         >
           Refresh
         </button>
         {loading && <span className={styles.convStatus}>loading…</span>}
-        {error && (
-          <span className={styles.convStatus} style={{ color: '#ff8b8b' }}>
-            {error}
-          </span>
-        )}
+        {error && <span className={styles.convError}>{error}</span>}
       </div>
 
       <div className={styles.convList}>
@@ -138,6 +196,7 @@ function ConversationRow({
   const data = conv.data
   const turnCount = data?.history.filter(t => t.role === 'user').length ?? 0
   const geo = data ? geoString(data.geo) : ''
+  const toolCalls = data ? flattenToolCalls(data.tools) : []
 
   const persist = async (patch: { notes?: string; tags?: string[] }) => {
     setSaveStatus('saving…')
@@ -184,25 +243,33 @@ function ConversationRow({
         aria-expanded={expanded}
       >
         <div className={styles.convRowHeader}>
-          <span>
-            {new Date(conv.createdAt).toLocaleString()} · {conv.page}
-            {turnCount > 1 && ` · ${turnCount} turns`}
-            {geo && ` · ${geo}`}
-            {conv.promptVersion && ` · v${conv.promptVersion}`}
+          <span className={styles.convRowMeta}>
+            <span className={styles.convRowDate}>
+              {formatDateTime(conv.createdAt)}
+            </span>
+            <span className={styles.convRowPage}>{conv.page}</span>
+            {turnCount > 1 && <span>{turnCount} turns</span>}
+            {geo && <span>{geo}</span>}
             {data?.zeroMatches && (
-              <>
-                {' · '}
-                <span className={styles.convRowZero}>NO MATCH</span>
-              </>
+              <span className={styles.convRowZero}>NO MATCH</span>
             )}
           </span>
-          <span>
-            {conv.latencyMs ? `${conv.latencyMs}ms` : ''}
-            {conv.tags.length > 0 && ` · ${conv.tags.join(', ')}`}
+          <span className={styles.convRowMeta}>
+            {conv.tags.length > 0 && <span>{conv.tags.join(', ')}</span>}
+            {conv.promptVersion && (
+              <span title="Prompt version">v{conv.promptVersion}</span>
+            )}
+            {conv.latencyMs ? (
+              <span title="Response time of the latest reply">
+                {formatLatency(conv.latencyMs)}
+              </span>
+            ) : null}
           </span>
         </div>
         <div className={styles.convRowQuery}>{data?.user ?? ''}</div>
-        <div className={styles.convRowResponse}>{data?.response ?? ''}</div>
+        <div className={styles.convRowResponse}>
+          {data ? plainPreview(data.response) : ''}
+        </div>
       </button>
 
       {expanded && data && (
@@ -222,29 +289,54 @@ function ConversationRow({
                         : styles.convTurnAssistant
                     }
                   >
-                    <div className={styles.convTurnRole}>{t.role}</div>
-                    <div className={styles.convTurnContent}>{t.content}</div>
+                    <div className={styles.convTurnRole}>
+                      {t.role === 'user' ? 'Visitor' : 'Chatbot'}
+                    </div>
+                    {t.role === 'user' ? (
+                      <div className={styles.convTurnContent}>{t.content}</div>
+                    ) : (
+                      <TranscriptMessage text={t.content} />
+                    )}
                   </div>
                 ))
               ) : (
-                <div className={styles.convDetailValue}>{data.response}</div>
+                <TranscriptMessage text={data.response} />
               )}
             </div>
           </div>
 
-          {data.tools.length > 0 && (
+          {toolCalls.length > 0 && (
             <div className={styles.convDetailField}>
-              <div className={styles.convDetailLabel}>Tool calls</div>
-              <div className={styles.convDetailValueMono}>
-                {JSON.stringify(data.tools, null, 2)}
+              <div className={styles.convDetailLabel}>
+                Searches the chatbot ran ({toolCalls.length})
+              </div>
+              <div className={styles.convToolCalls}>
+                {toolCalls.map((call, i) => (
+                  <span
+                    key={i}
+                    className={
+                      call.ok === false
+                        ? styles.convToolCallFailed
+                        : styles.convToolCall
+                    }
+                  >
+                    <span className={styles.convToolCallName}>
+                      {call.name ?? 'unknown'}
+                    </span>
+                    {describeToolInput(call.input)}
+                    {call.ok === false && ' — failed'}
+                  </span>
+                ))}
               </div>
             </div>
           )}
 
           {data.citations.length > 0 && (
             <div className={styles.convDetailField}>
-              <div className={styles.convDetailLabel}>Citations</div>
-              <div className={styles.convDetailValue}>
+              <div className={styles.convDetailLabel}>
+                Listings shown or searched ({data.citations.length})
+              </div>
+              <div className={styles.convCitations}>
                 {data.citations.join(', ')}
               </div>
             </div>
@@ -261,7 +353,7 @@ function ConversationRow({
 
           {data.referrer && (
             <div className={styles.convDetailField}>
-              <div className={styles.convDetailLabel}>Referrer</div>
+              <div className={styles.convDetailLabel}>Came from</div>
               <div className={styles.convDetailValue}>{data.referrer}</div>
             </div>
           )}

--- a/src/app/admin/assistant/ConversationList.tsx
+++ b/src/app/admin/assistant/ConversationList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import styles from '../admin.module.css'
 import TranscriptMessage, { plainPreview } from './TranscriptMessage'
 
@@ -39,20 +39,21 @@ function geoString(geo: ConversationData['geo']): string {
   return [geo.city ?? geo.region, geo.country].filter(Boolean).join(', ')
 }
 
-/** "12 June 2026, 17:51" — site-wide DATE MONTH YEAR convention. */
-function formatDateTime(iso: string): string {
+/** "12 June 2026" — site-wide DATE MONTH YEAR convention. */
+function formatDay(iso: string): string {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return iso
-  const date = d.toLocaleDateString('en-GB', {
+  return d.toLocaleDateString('en-GB', {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
   })
-  const time = d.toLocaleTimeString('en-GB', {
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-  return `${date}, ${time}`
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
 }
 
 function formatLatency(ms: number): string {
@@ -161,15 +162,26 @@ export default function ConversationList() {
       </div>
 
       <div className={styles.convList}>
-        {conversations.map(c => (
-          <ConversationRow
-            key={c.id}
-            conv={c}
-            expanded={expandedId === c.id}
-            onToggle={() => setExpandedId(expandedId === c.id ? null : c.id)}
-            onUpdate={handleUpdate}
-          />
-        ))}
+        {conversations.map((c, i) => {
+          const day = formatDay(c.createdAt)
+          const prevDay =
+            i > 0 ? formatDay(conversations[i - 1].createdAt) : null
+          return (
+            <Fragment key={c.id}>
+              {day !== prevDay && (
+                <div className={styles.convDayDivider}>{day}</div>
+              )}
+              <ConversationRow
+                conv={c}
+                expanded={expandedId === c.id}
+                onToggle={() =>
+                  setExpandedId(expandedId === c.id ? null : c.id)
+                }
+                onUpdate={handleUpdate}
+              />
+            </Fragment>
+          )
+        })}
         {conversations.length === 0 && !loading && (
           <div className={styles.convStatus}>No conversations yet.</div>
         )}
@@ -245,7 +257,7 @@ function ConversationRow({
         <div className={styles.convRowHeader}>
           <span className={styles.convRowMeta}>
             <span className={styles.convRowDate}>
-              {formatDateTime(conv.createdAt)}
+              {formatTime(conv.createdAt)}
             </span>
             <span className={styles.convRowPage}>{conv.page}</span>
             {turnCount > 1 && <span>{turnCount} turns</span>}

--- a/src/app/admin/assistant/ConversationList.tsx
+++ b/src/app/admin/assistant/ConversationList.tsx
@@ -142,13 +142,13 @@ export default function ConversationList() {
   return (
     <div>
       <div className={styles.convFilters}>
-        <label title="Only show conversations where the chatbot found no matching listings">
+        <label title="Show only conversations where the chatbot searched the directory and found nothing — useful for spotting gaps in the listings">
           <input
             type="checkbox"
             checked={zeroOnly}
             onChange={e => setZeroOnly(e.target.checked)}
           />
-          No-match only
+          Only chats with no results
         </label>
         <button
           type="button"

--- a/src/app/admin/assistant/TranscriptMessage.tsx
+++ b/src/app/admin/assistant/TranscriptMessage.tsx
@@ -1,0 +1,273 @@
+// Renders a stored assistant reply the way visitors saw it: markdown
+// formatted, [[card:...]] lines as listing pills, [[chip:...]] tokens as
+// suggestion chips, and the pre-[[/thinking]] search trail dimmed. The
+// stored history has no resolvable citation objects, so card pills are
+// label-driven (the text after the | in the token).
+
+import { Fragment, ReactNode } from 'react'
+import styles from '../admin.module.css'
+
+const THINKING_RE = /\[\[\s*\/?\s*thinking\s*\]\]/i
+const CHIP_RE = /\[\[\s*chip\s*:([^\]\n]*)\]\]/gi
+const SUGGEST_RE = /\[\[\s*suggest\s*:[^\]\n]*\]\]/gi
+const CARD_LINE_RE =
+  /^\s*\[\[\s*card\s*:\s*([^\]|\n]+?)(?:\s*\|([^\]\n]*))?\s*\]\]\s*$/i
+const INLINE_RE =
+  /(\[\[[^\]\n]*\]\])|(\[[^\]\n]+\]\(\/?[^)\n]+\))|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)/g
+const ANY_DIRECTIVE_RE = /\[\[[^\]]*\]\]/g
+
+/** "job:recXXX" → "job"; bare rec ids have no type. */
+function cardType(rawId: string): string | null {
+  const cleaned = rawId.replace(/\s+/g, '')
+  const m = /^([a-z-]+):/i.exec(cleaned)
+  return m ? m[1].toLowerCase() : null
+}
+
+/** Human label for an inline card/id token: prefer the |label, then the
+ *  type prefix, then the bare rec id. */
+function inlineCardLabel(token: string): string {
+  const m =
+    /^\[\[\s*(?:card|id)\s*:\s*([^\]|\n]+?)(?:\s*\|([^\]\n]*))?\s*\]\]$/i.exec(
+      token
+    )
+  if (!m) return ''
+  if (m[2]?.trim()) return m[2].trim()
+  const type = cardType(m[1])
+  const rec = /rec[A-Za-z0-9]+/.exec(m[1])?.[0] ?? m[1].trim()
+  return type ? `${type} ${rec}` : rec
+}
+
+interface ParsedMessage {
+  thinking: string | null
+  body: string
+  chips: string[]
+  suggestedListing: boolean
+}
+
+function parseMessage(text: string): ParsedMessage {
+  const thinkingMatch = THINKING_RE.exec(text)
+  const thinking = thinkingMatch
+    ? text.slice(0, thinkingMatch.index).trim() || null
+    : null
+  let body = thinkingMatch
+    ? text.slice(thinkingMatch.index + thinkingMatch[0].length)
+    : text
+
+  const chips: string[] = []
+  body = body.replace(CHIP_RE, (_, label: string) => {
+    const trimmed = label.trim()
+    if (trimmed) chips.push(trimmed)
+    return ''
+  })
+
+  const suggestedListing = SUGGEST_RE.test(body)
+  SUGGEST_RE.lastIndex = 0
+  body = body.replace(SUGGEST_RE, '')
+
+  return { thinking, body: body.trim(), chips, suggestedListing }
+}
+
+/** Plain-text one-liner for the collapsed row preview: search trail and
+ *  directives removed, card tokens replaced by their labels, markdown
+ *  markers stripped. */
+export function plainPreview(text: string): string {
+  const { body } = parseMessage(text)
+  return body
+    .replace(/\[\[\s*card\s*:[^\]|\n]*\|([^\]\n]*)\]\]/gi, '$1')
+    .replace(ANY_DIRECTIVE_RE, ' ')
+    .replace(/\[([^\]\n]+)\]\([^)\n]+\)/g, '$1')
+    .replace(/\*\*([^*\n]+)\*\*/g, '$1')
+    .replace(/\*([^*\n]+)\*/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function renderInline(text: string): ReactNode[] {
+  const parts: ReactNode[] = []
+  let lastIndex = 0
+  let key = 0
+  let match: RegExpExecArray | null
+  INLINE_RE.lastIndex = 0
+
+  while ((match = INLINE_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) parts.push(text.slice(lastIndex, match.index))
+    const token = match[0]
+
+    if (/^\[\[/.test(token)) {
+      // Well-formed card/id tokens become inline badges; any other [[...]]
+      // directive is malformed or already handled — drop it silently rather
+      // than leaking raw brackets.
+      const label = /^\[\[\s*(?:card|id)\s*:/i.test(token)
+        ? inlineCardLabel(token)
+        : ''
+      if (label) {
+        parts.push(
+          <span key={`c-${key++}`} className={styles.convCardInline}>
+            {label}
+          </span>
+        )
+      }
+    } else if (token.startsWith('[')) {
+      const m = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(token)
+      if (m) {
+        parts.push(
+          <a
+            key={`l-${key++}`}
+            href={m[2]}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.convLink}
+          >
+            {m[1]}
+          </a>
+        )
+      } else {
+        parts.push(token)
+      }
+    } else if (token.startsWith('**')) {
+      parts.push(<strong key={`b-${key++}`}>{token.slice(2, -2)}</strong>)
+    } else {
+      parts.push(<em key={`i-${key++}`}>{token.slice(1, -1)}</em>)
+    }
+    lastIndex = match.index + token.length
+  }
+  if (lastIndex < text.length) parts.push(text.slice(lastIndex))
+  return parts
+}
+
+interface CardSpec {
+  type: string | null
+  label: string
+}
+
+type Block =
+  | { kind: 'paragraph'; lines: string[] }
+  | { kind: 'ul'; lines: string[] }
+  | { kind: 'ol'; lines: string[] }
+  | { kind: 'cards'; cards: CardSpec[] }
+
+function parseBlocks(text: string): Block[] {
+  const blocks: Block[] = []
+  let current: Block | null = null
+
+  const flush = () => {
+    if (
+      current &&
+      ((current.kind === 'cards' && current.cards.length > 0) ||
+        (current.kind !== 'cards' && current.lines.length > 0))
+    ) {
+      blocks.push(current)
+    }
+    current = null
+  }
+
+  for (const raw of text.split('\n')) {
+    const line = raw.trimEnd()
+    if (line === '') {
+      flush()
+      continue
+    }
+    const cardMatch = CARD_LINE_RE.exec(line)
+    const ulMatch = /^\s*[-•]\s+(.+)$/.exec(line)
+    const olMatch = /^\s*\d+\.\s+(.+)$/.exec(line)
+
+    if (cardMatch) {
+      if (current?.kind !== 'cards') {
+        flush()
+        current = { kind: 'cards', cards: [] }
+      }
+      const rec = /rec[A-Za-z0-9]+/.exec(cardMatch[1])?.[0]
+      current.cards.push({
+        type: cardType(cardMatch[1]),
+        label: cardMatch[2]?.trim() || rec || cardMatch[1].trim(),
+      })
+    } else if (ulMatch) {
+      if (current?.kind !== 'ul') {
+        flush()
+        current = { kind: 'ul', lines: [] }
+      }
+      current.lines.push(ulMatch[1])
+    } else if (olMatch) {
+      if (current?.kind !== 'ol') {
+        flush()
+        current = { kind: 'ol', lines: [] }
+      }
+      current.lines.push(olMatch[1])
+    } else {
+      if (current?.kind !== 'paragraph') {
+        flush()
+        current = { kind: 'paragraph', lines: [] }
+      }
+      current.lines.push(line)
+    }
+  }
+  flush()
+  return blocks
+}
+
+function MessageBody({ text }: { text: string }) {
+  const blocks = parseBlocks(text)
+  return (
+    <>
+      {blocks.map((block, i) => {
+        if (block.kind === 'cards') {
+          return (
+            <div key={i} className={styles.convCards}>
+              {block.cards.map((card, j) => (
+                <span key={j} className={styles.convCard}>
+                  {card.type && (
+                    <span className={styles.convCardType}>{card.type}</span>
+                  )}
+                  {card.label}
+                </span>
+              ))}
+            </div>
+          )
+        }
+        if (block.kind === 'paragraph') {
+          return <p key={i}>{renderInline(block.lines.join(' '))}</p>
+        }
+        const Tag = block.kind === 'ul' ? 'ul' : 'ol'
+        return (
+          <Tag key={i}>
+            {block.lines.map((item, j) => (
+              <li key={j}>
+                <Fragment>{renderInline(item)}</Fragment>
+              </li>
+            ))}
+          </Tag>
+        )
+      })}
+    </>
+  )
+}
+
+export default function TranscriptMessage({ text }: { text: string }) {
+  const { thinking, body, chips, suggestedListing } = parseMessage(text)
+  return (
+    <div className={styles.convMsg}>
+      {thinking && (
+        <div className={styles.convThinking}>
+          <span className={styles.convThinkingLabel}>Search trail</span>
+          {plainPreview(thinking)}
+        </div>
+      )}
+      <MessageBody text={body} />
+      {suggestedListing && (
+        <div className={styles.convSuggestNote}>
+          Nothing matched — visitor was shown a &ldquo;Suggest a listing&rdquo;
+          button
+        </div>
+      )}
+      {chips.length > 0 && (
+        <div className={styles.convChips}>
+          {chips.map((chip, i) => (
+            <span key={i} className={styles.convChip}>
+              {chip}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/assistant/conversations/page.tsx
+++ b/src/app/admin/assistant/conversations/page.tsx
@@ -5,7 +5,7 @@ import styles from '../../admin.module.css'
 export default function ConversationsPage() {
   const configured = isConversationsTableConfigured()
   return (
-    <>
+    <div className={styles.convPage}>
       <div className={styles.pageHeading}>
         <h1 className={styles.pageTitle}>Conversations</h1>
         <div className={styles.pageMeta}>
@@ -20,6 +20,6 @@ export default function ConversationsPage() {
           conversation log.
         </div>
       )}
-    </>
+    </div>
   )
 }

--- a/src/app/admin/assistant/conversations/page.tsx
+++ b/src/app/admin/assistant/conversations/page.tsx
@@ -8,9 +8,6 @@ export default function ConversationsPage() {
     <div className={styles.convPage}>
       <div className={styles.pageHeading}>
         <h1 className={styles.pageTitle}>Conversations</h1>
-        <div className={styles.pageMeta}>
-          Newest first · click a row to expand
-        </div>
       </div>
       {configured ? (
         <ConversationList />


### PR DESCRIPTION
- Assistant replies in the admin transcript now render the way visitors saw them: markdown formatting, `[[card:]]` tokens as listing pills with type badges, `[[chip:]]` tokens as suggestion chips, and the pre-`[[/thinking]]` search trail as a dimmed block. Row previews strip all directives. (New `TranscriptMessage` component — label-driven, since stored history has no resolvable citation objects.)
- Tool calls render as readable search summaries instead of raw JSON, and the section is hidden when no tools ran (previously showed `[ [], [] ]`).
- The list is grouped under day dividers (12 June 2026) with rows showing just the time, latency in seconds, Visitor/Chatbot role labels, citations in a scrollable box with a count, and a properly styled Refresh button (was referencing a nonexistent `promptToolbarReset` class).
- Conversations page is a centered 960px column, the zero-match filter is labeled "Only chats with no results" (with tooltip), the heading hint is removed, and the header brand is renamed to "AISafety.com Chatbot Admin".

_PR description written by Claude Code._