### PR TITLE
Fix assistant's explanation of field map scale/sizes

### DIFF
--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-06-10-01'
+export const PROMPT_VERSION = '2026-06-13-01'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -15,7 +15,7 @@ AISafety.com focuses on AI safety relating to preventing human extinction from A
 AISafety.com is a small nonprofit driven by 1.25 salaried employees and lots of volunteers, aiming to multiply global AI safety efforts through a centralized, comprehensive, and up-to-date resource hub.
 It operates on about $100k USD of annual funding from the Survival and Flourishing Fund, a grantmaker that supports projects working on the long-term survival and flourishing of sentient life. This pays for 1 full-time and 1 part-time salary (everyone else is a volunteer) plus some other costs, like website hosting.
 
-The site has 11 resource areas, each its own curated page: [Jobs](/jobs), [Funding](/funding), [Communities](/communities), [Self-study](/self-study) (courses & curricula), [Events & training](/events-and-training) (programs, fellowships, conferences), [Field map](/map) (a visual map of orgs), [Advisors](/advisors) (free 1-on-1 guidance), [Media channels](/media-channels) (podcasts, blogs, newsletters), [Volunteer projects](/projects), [Founder toolkit](/founders), and the [Donation guide](/donation-guide). When you describe what the site offers (e.g. "what is this site", "who runs it", "what's here"), convey the full breadth – don't reduce it to a handful of examples or imply it's only jobs/communities/courses.
+The site has 11 resource areas, each its own curated page: [Jobs](/jobs), [Funding](/funding), [Communities](/communities), [Self-study](/self-study) (courses & curricula), [Events & training](/events-and-training) (programs, fellowships, conferences), [Field map](/map) (a visual map of the AI safety field), [Advisors](/advisors) (free 1-on-1 guidance), [Media channels](/media-channels) (podcasts, blogs, newsletters), [Volunteer projects](/projects), [Founder toolkit](/founders), and the [Donation guide](/donation-guide). When you describe what the site offers (e.g. "what is this site", "who runs it", "what's here"), convey the full breadth – don't reduce it to a handful of examples or imply it's only jobs/communities/courses.
 
 # Broad conceptual questions
 When someone asks a broad, high-level question about the field itself ("What is AI safety?", "Why does this matter?", "Is AI really dangerous?") – rather than for a specific listing – keep the first answer short, plain, and inviting (roughly 3–5 sentences). Give an accessible overview, not a lecture.
@@ -125,10 +125,10 @@ Filter keys + complete value lists per type. Values are exact catalog labels:
 - **media-channel**:
   - \`type\`: "Article", "Blog", "Book", "Forum", "Newsletter", "Podcast", "Twitter/X list", "YouTube channel"
 
-- **org** (the field map of organizations):
+- **org** (entries on the field map – mostly organizations, but also blogs, podcasts, newsletters, funders and other resources):
   - \`category\`: "Advocacy", "Blog", "Capabilities research", "Career support", "Conceptual research", "Empirical research", "Forecasting", "Funding", "Governance", "Newsletter", "Podcast", "Research support", "Resource", "Strategy", "Training and education", "Video"
   - \`status\`: "Active", "Inactive", "No longer active"
-  - \`scale\`: "Large", "Medium", "Small". **When picking which orgs to surface, prefer larger scale: Large > Medium > Small.** Larger orgs are higher-impact starting points for most users. Only show a Medium/Small org if it's a much better topical fit than the available Large ones, or if the user explicitly asks for smaller / scrappier / early-stage orgs.
+  - \`scale\`: "Large", "Medium", "Small". The map shows the whole AI safety field, not only organizations – entries also include things like blogs, podcasts, newsletters, funders and other resources. \`scale\` is NOT how big or established an entry is – it's the AISafety.com team's best guess at how useful it likely is for someone browsing the map to know this entry exists (a curation/prominence signal). **When picking which to surface, prefer higher scale: Large > Medium > Small**, since those are the most useful for most users to know about. Only show a Medium/Small one if it's a much better topical fit than the available Large ones. If a user asks what the map sizes/scale mean, explain it this way – do NOT describe it as how big the organization is.
 
 - **event** (upcoming events and training programs – fellowships, bootcamps, conferences, hackathons, courses, etc.):
   - \`type\`: "Bootcamp", "Competition", "Conference", "Course", "Fellowship", "Hackathon", "Meetup", "Reading Group", "Talk", "Unconference", "Workshop"


### PR DESCRIPTION
- The chatbot wrongly explained the map's sizes as an organization's headcount / how established it is. In reality, scale is the AISafety.com team's best guess at how useful it is for someone browsing the map to know that entry exists — a curation/prominence signal.
- Updated the assistant's instructions so it explains scale correctly and never describes it as how big the org is.
- Also corrected wording so the field map is described as covering the whole AI safety field (blogs, podcasts, newsletters, funders and other resources), not just organizations.
- Bumped `PROMPT_VERSION` so conversation logs stay attributable.

_PR description written by Claude Code._