### PR TITLE
Make linkless community cards non-clickable

### DIFF
--- a/src/app/communities/CommunitiesClient.tsx
+++ b/src/app/communities/CommunitiesClient.tsx
@@ -172,62 +172,81 @@ export default function CommunitiesClient({
           {filteredCommunities.length === 0 ? (
             <p className="paragraph-small color-teal-300">Nothing found.</p>
           ) : (
-            filteredCommunities.map(community => (
-              <Link
-                key={community.id}
-                href={community.joinLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="card"
-                onClick={() =>
-                  trackListingClick(
-                    'Communities',
-                    community.name,
-                    community.joinLink
-                  )
-                }
-              >
-                <div className="flex items-center gap-16px padding-bottom-24px">
-                  {community.logo && (
-                    <div className="featured-img">
-                      <Image
-                        src={community.logo}
-                        alt={`${community.name} logo`}
-                        width={64}
-                        height={64}
-                        className="card-image"
-                        unoptimized
-                        onError={e => {
-                          ;(e.target as HTMLImageElement).style.display = 'none'
-                        }}
-                      />
-                    </div>
+            filteredCommunities.map(community => {
+              const hasLink =
+                Boolean(community.joinLink) && community.joinLink !== '#'
+              const cardContent = (
+                <>
+                  <div className="flex items-center gap-16px padding-bottom-24px">
+                    {community.logo && (
+                      <div className="featured-img">
+                        <Image
+                          src={community.logo}
+                          alt={`${community.name} logo`}
+                          width={64}
+                          height={64}
+                          className="card-image"
+                          unoptimized
+                          onError={e => {
+                            ;(e.target as HTMLImageElement).style.display =
+                              'none'
+                          }}
+                        />
+                      </div>
+                    )}
+                    <h3>{community.name}</h3>
+                  </div>
+                  {community.description && (
+                    <p className="paragraph-small padding-bottom-24px">
+                      {community.description}
+                    </p>
                   )}
-                  <h3>{community.name}</h3>
-                </div>
-                {community.description && (
-                  <p className="paragraph-small padding-bottom-24px">
-                    {community.description}
+                  <p className="paragraph-xs-bold color-teal-400 padding-bottom-4px">
+                    Platform
                   </p>
-                )}
-                <p className="paragraph-xs-bold color-teal-400 padding-bottom-4px">
-                  Platform
-                </p>
-                <p className="paragraph-small padding-bottom-16px">
-                  {community.platformText || community.platform.join(', ')}
-                </p>
-                <p className="paragraph-xs-bold color-teal-400 padding-bottom-4px">
-                  Activity level
-                </p>
-                <p className="paragraph-small padding-bottom-16px">
-                  {community.activityLevel}
-                </p>
-                <p className="paragraph-xs-bold color-teal-400 padding-bottom-4px">
-                  Focus
-                </p>
-                <p className="paragraph-small">{community.focus}</p>
-              </Link>
-            ))
+                  <p className="paragraph-small padding-bottom-16px">
+                    {community.platformText || community.platform.join(', ')}
+                  </p>
+                  <p className="paragraph-xs-bold color-teal-400 padding-bottom-4px">
+                    Activity level
+                  </p>
+                  <p className="paragraph-small padding-bottom-16px">
+                    {community.activityLevel}
+                  </p>
+                  <p className="paragraph-xs-bold color-teal-400 padding-bottom-4px">
+                    Focus
+                  </p>
+                  <p className="paragraph-small">{community.focus}</p>
+                </>
+              )
+
+              if (!hasLink) {
+                return (
+                  <div key={community.id} className="card card-static">
+                    {cardContent}
+                  </div>
+                )
+              }
+
+              return (
+                <Link
+                  key={community.id}
+                  href={community.joinLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="card"
+                  onClick={() =>
+                    trackListingClick(
+                      'Communities',
+                      community.name,
+                      community.joinLink
+                    )
+                  }
+                >
+                  {cardContent}
+                </Link>
+              )
+            })
           )}
         </div>
       </div>


### PR DESCRIPTION
- Community listings with no Join link previously defaulted to `href="#"`, so they rendered as clickable cards that just jumped to the top of the page.
- These are now rendered as static, non-clickable cards (matching how /projects listings behave). Listings that have a link are unchanged.

_PR description written by Claude Code._