### PR TITLE
Chatbot fixes + admin Conversations cleanup

### DIFF
--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -780,6 +780,25 @@
   color: var(--bright-teal-500);
 }
 
+/* Inline link the visitor actually clicked: brighter, with a small ✓ badge. */
+.convLinkClicked {
+  color: var(--bright-teal-300);
+  font-weight: 600;
+}
+
+.convLinkClickedTag {
+  display: inline-block;
+  margin-left: 3px;
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--teal-900);
+  background-color: var(--bright-teal-300);
+  border-radius: 999px;
+  padding: 0 4px;
+  text-decoration: none;
+  vertical-align: 1px;
+}
+
 .convThinking {
   margin-bottom: 10px;
   padding: 6px 10px;

--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -558,6 +558,27 @@
   gap: 12px;
 }
 
+.convSearch {
+  height: 32px;
+  min-width: 260px;
+  padding: 0 12px;
+  background-color: var(--teal-900);
+  border: 1px solid var(--teal-800);
+  border-radius: 6px;
+  color: var(--white);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+}
+
+.convSearch:focus {
+  border-color: var(--teal-500);
+}
+
+.convSearch::placeholder {
+  color: var(--teal-500);
+}
+
 .convFilters label {
   font-size: 12px;
   color: var(--teal-300);

--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -718,15 +718,6 @@
   line-height: 1.5;
 }
 
-.convDetailValueMono {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  color: var(--bright-teal-300);
-  white-space: pre-wrap;
-  word-break: break-all;
-  line-height: 1.5;
-}
-
 .convTranscript {
   display: flex;
   flex-direction: column;
@@ -970,49 +961,6 @@
   color: #ffb87a;
 }
 
-/* ─── Tool calls + citations ──────────────────────────────────────────── */
-
-.convToolCalls {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
-}
-
-.convToolCall,
-.convToolCallFailed {
-  display: inline-flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 3px 8px;
-  background-color: var(--teal-850);
-  border: 1px solid var(--teal-800);
-  border-radius: 6px;
-  font-size: 11px;
-  color: var(--teal-300);
-}
-
-.convToolCallFailed {
-  border-color: #ff8b8b;
-  color: #ff8b8b;
-}
-
-.convToolCallName {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  color: var(--bright-teal-300);
-}
-
-.convCitations {
-  max-height: 96px;
-  overflow-y: auto;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  color: var(--teal-400);
-  line-height: 1.6;
-  word-break: break-all;
-}
-
 .convError {
   font-size: 11px;
   color: #ff8b8b;
@@ -1033,52 +981,6 @@
 }
 
 .convNotes:focus {
-  border-color: var(--teal-500);
-}
-
-.convTagInput {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  align-items: center;
-}
-
-.convTag {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 2px 8px;
-  background-color: var(--teal-800);
-  border: 1px solid var(--teal-700);
-  border-radius: 999px;
-  font-size: 11px;
-  color: var(--white);
-}
-
-.convTag button {
-  background: none;
-  border: none;
-  color: var(--teal-400);
-  cursor: pointer;
-  font-size: 13px;
-  line-height: 1;
-  padding: 0;
-}
-
-.convTagAdd {
-  height: 22px;
-  padding: 0 8px;
-  background-color: var(--teal-900);
-  border: 1px solid var(--teal-800);
-  border-radius: 999px;
-  color: var(--white);
-  font-size: 11px;
-  outline: none;
-  min-width: 100px;
-  font-family: inherit;
-}
-
-.convTagAdd:focus {
   border-color: var(--teal-500);
 }
 

--- a/src/app/admin/assistant/ConversationList.tsx
+++ b/src/app/admin/assistant/ConversationList.tsx
@@ -102,47 +102,6 @@ function formatLatency(ms: number): string {
   return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`
 }
 
-interface ToolCallEntry {
-  name?: string
-  input?: unknown
-  ok?: boolean
-}
-
-/** The Data column stores one tool-call array per turn; flatten across
- *  turns and drop anything that isn't a call object. */
-function flattenToolCalls(tools: unknown[]): ToolCallEntry[] {
-  const out: ToolCallEntry[] = []
-  for (const entry of tools) {
-    const calls = Array.isArray(entry) ? entry : [entry]
-    for (const call of calls) {
-      if (call && typeof call === 'object' && 'name' in call) {
-        out.push(call as ToolCallEntry)
-      }
-    }
-  }
-  return out
-}
-
-/** {type:"job", filters:{skillSet:"X"}} → "type: job · skillSet: X" */
-function describeToolInput(input: unknown): string {
-  if (!input || typeof input !== 'object') return ''
-  const parts: string[] = []
-  const walk = (obj: Record<string, unknown>) => {
-    for (const [key, value] of Object.entries(obj)) {
-      if (value == null || value === '') continue
-      if (Array.isArray(value)) {
-        parts.push(`${key}: ${value.join(', ')}`)
-      } else if (typeof value === 'object') {
-        walk(value as Record<string, unknown>)
-      } else {
-        parts.push(`${key}: ${String(value)}`)
-      }
-    }
-  }
-  walk(input as Record<string, unknown>)
-  return parts.join(' · ')
-}
-
 export default function ConversationList() {
   const [conversations, setConversations] = useState<Conversation[]>([])
   const [listings, setListings] = useState<Record<string, ListingInfo>>({})
@@ -350,13 +309,10 @@ function ConversationRow({
   onUpdate: (c: Conversation) => void
 }) {
   const [notes, setNotes] = useState(conv.notes)
-  const [tags, setTags] = useState<string[]>(conv.tags)
-  const [tagInput, setTagInput] = useState('')
   const [saveStatus, setSaveStatus] = useState('')
   const data = conv.data
   const turnCount = data?.history.filter(t => t.role === 'user').length ?? 0
   const geo = data ? geoString(data.geo) : ''
-  const toolCalls = data ? flattenToolCalls(data.tools) : []
   // Collapsed row previews the visitor's OPENING message (how they first
   // arrived), not the most recent turn. Fall back to the latest-turn field
   // for old rows that have no stored history.
@@ -374,7 +330,7 @@ function ConversationRow({
     return s
   }, [conv.clickedCitations])
 
-  const persist = async (patch: { notes?: string; tags?: string[] }) => {
+  const persist = async (patch: { notes?: string }) => {
     setSaveStatus('saving…')
     try {
       const res = await fetch('/api/admin/conversations', {
@@ -393,21 +349,6 @@ function ConversationRow({
     } catch {
       setSaveStatus('save failed')
     }
-  }
-
-  const removeTag = (t: string) => {
-    const next = tags.filter(x => x !== t)
-    setTags(next)
-    void persist({ tags: next })
-  }
-
-  const addTag = (t: string) => {
-    const trimmed = t.trim()
-    if (!trimmed || tags.includes(trimmed)) return
-    const next = [...tags, trimmed]
-    setTags(next)
-    setTagInput('')
-    void persist({ tags: next })
   }
 
   return (
@@ -447,7 +388,6 @@ function ConversationRow({
             )}
           </span>
           <span className={styles.convRowMeta}>
-            {conv.tags.length > 0 && <span>{conv.tags.join(', ')}</span>}
             {conv.promptVersion && (
               <span title="Prompt version">v{conv.promptVersion}</span>
             )}
@@ -497,97 +437,12 @@ function ConversationRow({
               </div>
             </div>
 
-            {toolCalls.length > 0 && (
-              <div className={styles.convDetailField}>
-                <div className={styles.convDetailLabel}>
-                  Searches the chatbot ran ({toolCalls.length})
-                </div>
-                <div className={styles.convToolCalls}>
-                  {toolCalls.map((call, i) => (
-                    <span
-                      key={i}
-                      className={
-                        call.ok === false
-                          ? styles.convToolCallFailed
-                          : styles.convToolCall
-                      }
-                    >
-                      <span className={styles.convToolCallName}>
-                        {call.name ?? 'unknown'}
-                      </span>
-                      {describeToolInput(call.input)}
-                      {call.ok === false && ' — failed'}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {data.citations.length > 0 && (
-              <div className={styles.convDetailField}>
-                <div className={styles.convDetailLabel}>
-                  Listings shown or searched ({data.citations.length})
-                </div>
-                <div className={styles.convCitations}>
-                  {data.citations.join(', ')}
-                </div>
-              </div>
-            )}
-
-            {data.pageState && (
-              <div className={styles.convDetailField}>
-                <div className={styles.convDetailLabel}>Page state</div>
-                <div className={styles.convDetailValueMono}>
-                  {JSON.stringify(data.pageState, null, 2)}
-                </div>
-              </div>
-            )}
-
             {data.referrer && (
               <div className={styles.convDetailField}>
                 <div className={styles.convDetailLabel}>Came from</div>
                 <div className={styles.convDetailValue}>{data.referrer}</div>
               </div>
             )}
-
-            {data.utm && (
-              <div className={styles.convDetailField}>
-                <div className={styles.convDetailLabel}>UTM</div>
-                <div className={styles.convDetailValueMono}>
-                  {JSON.stringify(data.utm, null, 2)}
-                </div>
-              </div>
-            )}
-
-            <div className={styles.convDetailField}>
-              <div className={styles.convDetailLabel}>Tags</div>
-              <div className={styles.convTagInput}>
-                {tags.map(t => (
-                  <span key={t} className={styles.convTag}>
-                    {t}
-                    <button
-                      type="button"
-                      onClick={() => removeTag(t)}
-                      aria-label={`Remove ${t}`}
-                    >
-                      ×
-                    </button>
-                  </span>
-                ))}
-                <input
-                  className={styles.convTagAdd}
-                  value={tagInput}
-                  onChange={e => setTagInput(e.target.value)}
-                  onKeyDown={e => {
-                    if (e.key === 'Enter' || e.key === ',') {
-                      e.preventDefault()
-                      addTag(tagInput)
-                    }
-                  }}
-                  placeholder="Add tag, Enter"
-                />
-              </div>
-            </div>
 
             <div className={styles.convDetailField}>
               <div className={styles.convDetailLabel}>Notes</div>

--- a/src/app/admin/assistant/ConversationList.tsx
+++ b/src/app/admin/assistant/ConversationList.tsx
@@ -56,10 +56,29 @@ function countryLabel(code: string): string {
   return `${name && name !== cc ? name : cc} ${flag}`
 }
 
+/** ISO 3166-2 subdivision codes that read as opaque abbreviations when Vercel
+ *  has no city for a visitor. Keyed by country so codes stay unambiguous;
+ *  anything unmapped shows as-is. */
+const REGION_NAMES: Record<string, string> = {
+  'GB-ENG': 'England',
+  'GB-SCT': 'Scotland',
+  'GB-WLS': 'Wales',
+  'GB-NIR': 'Northern Ireland',
+}
+
+function regionLabel(region: string, country?: string): string {
+  const cc = country?.trim().toUpperCase() ?? ''
+  return REGION_NAMES[`${cc}-${region.trim().toUpperCase()}`] ?? region
+}
+
 function geoString(geo: ConversationData['geo']): string {
   if (!geo) return ''
   const country = geo.country ? countryLabel(geo.country) : undefined
-  return [geo.city ?? geo.region, country].filter(Boolean).join(', ')
+  // Prefer the city; only when there's none do we show the region (expanded to
+  // a readable name where we have one, e.g. "ENG" → "England").
+  const place =
+    geo.city ?? (geo.region ? regionLabel(geo.region, geo.country) : undefined)
+  return [place, country].filter(Boolean).join(', ')
 }
 
 /** "12 June 2026" — site-wide DATE MONTH YEAR convention. */

--- a/src/app/admin/assistant/ConversationList.tsx
+++ b/src/app/admin/assistant/ConversationList.tsx
@@ -150,6 +150,10 @@ export default function ConversationList() {
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [zeroOnly, setZeroOnly] = useState(false)
+  // `searchInput` tracks the box; `search` is the debounced value actually sent
+  // to the server, so we don't refetch on every keystroke.
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
   const [expandedId, setExpandedId] = useState<string | null>(null)
   // Airtable cursor for the next, older batch — null once we've reached the
   // very first conversation. Drives the "Load more" button.
@@ -161,13 +165,14 @@ export default function ConversationList() {
 
   const PAGE_SIZE = 200
 
-  const load = async (zo: boolean) => {
+  const load = async (zo: boolean, q: string) => {
     setLoading(true)
     setError(null)
     try {
       const params = new URLSearchParams()
       params.set('limit', String(PAGE_SIZE))
       if (zo) params.set('zeroOnly', '1')
+      if (q) params.set('search', q)
       const res = await fetch(`/api/admin/conversations?${params}`)
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
@@ -199,6 +204,7 @@ export default function ConversationList() {
       params.set('limit', String(PAGE_SIZE))
       params.set('offset', offset)
       if (zeroOnly) params.set('zeroOnly', '1')
+      if (search) params.set('search', search)
       const res = await fetch(`/api/admin/conversations?${params}`)
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
@@ -226,9 +232,15 @@ export default function ConversationList() {
     }
   }
 
+  // Debounce typing into the committed `search` value (350ms after a pause).
   useEffect(() => {
-    void load(zeroOnly)
-  }, [zeroOnly])
+    const t = setTimeout(() => setSearch(searchInput.trim()), 350)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  useEffect(() => {
+    void load(zeroOnly, search)
+  }, [zeroOnly, search])
 
   useEffect(() => {
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -245,6 +257,14 @@ export default function ConversationList() {
   return (
     <ListingInfoContext.Provider value={listings}>
       <div className={styles.convFilters}>
+        <input
+          type="search"
+          className={styles.convSearch}
+          placeholder="Search conversations…"
+          value={searchInput}
+          onChange={e => setSearchInput(e.target.value)}
+          title="Searches the whole log — visitor questions, bot replies, listings shown, page and notes"
+        />
         <label title="Show only conversations where the chatbot searched the directory and found nothing — useful for spotting gaps in the listings">
           <input
             type="checkbox"
@@ -256,7 +276,7 @@ export default function ConversationList() {
         <button
           type="button"
           className={styles.editorButton}
-          onClick={() => void load(zeroOnly)}
+          onClick={() => void load(zeroOnly, search)}
         >
           Refresh
         </button>
@@ -294,7 +314,11 @@ export default function ConversationList() {
           )
         })}
         {conversations.length === 0 && !loading && (
-          <div className={styles.convStatus}>No conversations yet.</div>
+          <div className={styles.convStatus}>
+            {search || zeroOnly
+              ? 'No conversations match.'
+              : 'No conversations yet.'}
+          </div>
         )}
       </div>
 

--- a/src/app/admin/assistant/TranscriptMessage.tsx
+++ b/src/app/admin/assistant/TranscriptMessage.tsx
@@ -134,9 +134,40 @@ export function plainPreview(text: string): string {
     .trim()
 }
 
+/** Wraps an inline link with a "clicked" badge when the visitor opened it.
+ *  Link clicks are stored in the same Clicked set as cards, keyed `link:<href>`. */
+function inlineLink(
+  href: string,
+  text: ReactNode,
+  clicked: Set<string>,
+  key: string
+): ReactNode {
+  const wasClicked = clicked.has(`link:${href}`)
+  return (
+    <a
+      key={key}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`${styles.convLink}${wasClicked ? ` ${styles.convLinkClicked}` : ''}`}
+    >
+      {text}
+      {wasClicked && (
+        <span
+          className={styles.convLinkClickedTag}
+          title="The visitor clicked this link"
+        >
+          ✓
+        </span>
+      )}
+    </a>
+  )
+}
+
 function renderInline(
   text: string,
-  listings: Record<string, ListingInfo>
+  listings: Record<string, ListingInfo>,
+  clicked: Set<string>
 ): ReactNode[] {
   const parts: ReactNode[] = []
   let lastIndex = 0
@@ -165,17 +196,7 @@ function renderInline(
     } else if (token.startsWith('[')) {
       const m = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(token)
       if (m) {
-        parts.push(
-          <a
-            key={`l-${key++}`}
-            href={m[2]}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.convLink}
-          >
-            {m[1]}
-          </a>
-        )
+        parts.push(inlineLink(m[2], m[1], clicked, `l-${key++}`))
       } else {
         parts.push(token)
       }
@@ -184,17 +205,7 @@ function renderInline(
     } else if (/^aisafety\.info/i.test(token)) {
       // Auto-linkify bare aisafety.info mentions, matching the live renderer
       // (the bot writes it as plain text rather than a markdown link).
-      parts.push(
-        <a
-          key={`u-${key++}`}
-          href={`https://${token}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.convLink}
-        >
-          {token}
-        </a>
-      )
+      parts.push(inlineLink(`https://${token}`, token, clicked, `u-${key++}`))
     } else {
       parts.push(<em key={`i-${key++}`}>{token.slice(1, -1)}</em>)
     }
@@ -362,6 +373,7 @@ function CardPill({ card }: { card: CardSpec }) {
 function MessageBody({ text }: { text: string }) {
   const blocks = parseBlocks(text)
   const listings = useContext(ListingInfoContext)
+  const clicked = useContext(ClickedCardsContext)
   return (
     <>
       {blocks.map((block, i) => {
@@ -375,14 +387,16 @@ function MessageBody({ text }: { text: string }) {
           )
         }
         if (block.kind === 'paragraph') {
-          return <p key={i}>{renderInline(block.lines.join(' '), listings)}</p>
+          return (
+            <p key={i}>{renderInline(block.lines.join(' '), listings, clicked)}</p>
+          )
         }
         const Tag = block.kind === 'ul' ? 'ul' : 'ol'
         return (
           <Tag key={i}>
             {block.lines.map((item, j) => (
               <li key={j}>
-                <Fragment>{renderInline(item, listings)}</Fragment>
+                <Fragment>{renderInline(item, listings, clicked)}</Fragment>
               </li>
             ))}
           </Tag>

--- a/src/app/admin/assistant/TranscriptMessage.tsx
+++ b/src/app/admin/assistant/TranscriptMessage.tsx
@@ -65,7 +65,6 @@ const CARD_LINE_RE =
   /^\s*\[\[\s*card\s*:\s*([^\]|\n]+?)(?:\s*\|([^\]\n]*))?\s*\]\]\s*$/i
 const INLINE_RE =
   /(\[\[[^\]\n]*\]\])|(\[[^\]\n]+\]\(\/?[^)\n]+\))|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(\baisafety\.info(?:\/[^\s<>),]*)?)/gi
-const ANY_DIRECTIVE_RE = /\[\[[^\]]*\]\]/g
 
 /** "job:recXXX" → "job"; bare rec ids have no type. */
 function cardType(rawId: string): string | null {
@@ -117,21 +116,6 @@ function parseMessage(text: string): ParsedMessage {
   body = body.replace(SUGGEST_RE, '')
 
   return { thinking, body: body.trim(), chips, suggestedListing }
-}
-
-/** Plain-text one-liner for the collapsed row preview: search trail and
- *  directives removed, card tokens replaced by their labels, markdown
- *  markers stripped. */
-export function plainPreview(text: string): string {
-  const { body } = parseMessage(text)
-  return body
-    .replace(/\[\[\s*card\s*:[^\]|\n]*\|([^\]\n]*)\]\]/gi, '$1')
-    .replace(ANY_DIRECTIVE_RE, ' ')
-    .replace(/\[([^\]\n]+)\]\([^)\n]+\)/g, '$1')
-    .replace(/\*\*([^*\n]+)\*\*/g, '$1')
-    .replace(/\*([^*\n]+)\*/g, '$1')
-    .replace(/\s+/g, ' ')
-    .trim()
 }
 
 /** Wraps an inline link with a "clicked" badge when the visitor opened it.
@@ -407,15 +391,13 @@ function MessageBody({ text }: { text: string }) {
 }
 
 export default function TranscriptMessage({ text }: { text: string }) {
-  const { thinking, body, chips, suggestedListing } = parseMessage(text)
+  // The reasoning/search trail before the [[/thinking]] boundary is dropped
+  // here: it's never shown to visitors (the live chat hides it), and it adds
+  // noise to the admin transcript. parseMessage still splits it off so it
+  // stays out of the body below.
+  const { body, chips, suggestedListing } = parseMessage(text)
   return (
     <div className={styles.convMsg}>
-      {thinking && (
-        <div className={styles.convThinking}>
-          <span className={styles.convThinkingLabel}>Search trail</span>
-          {plainPreview(thinking)}
-        </div>
-      )}
       <MessageBody text={body} />
       {suggestedListing && (
         <div className={styles.convSuggestNote}>

--- a/src/app/api/admin/conversations/route.ts
+++ b/src/app/api/admin/conversations/route.ts
@@ -48,9 +48,11 @@ export async function GET(req: NextRequest) {
     : 200
   const offsetParam = url.searchParams.get('offset') || undefined
   const zeroOnly = url.searchParams.get('zeroOnly') === '1'
+  const search = url.searchParams.get('search') || undefined
   const { conversations, offset } = await listConversationsPage({
     pageSize,
     offset: offsetParam,
+    search,
   })
   // zeroMatches now lives inside Data; filter client-side here so the API
   // contract stays the same for the admin viewer.

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -31,23 +31,19 @@ function readGeo(
   req: NextRequest,
   fallback: AssistantRequest['geoFallback']
 ): RequestContext['geo'] {
-  const city = req.headers.get('x-vercel-ip-city')
+  const headerCity = req.headers.get('x-vercel-ip-city')
   const region = req.headers.get('x-vercel-ip-country-region')
   const country = req.headers.get('x-vercel-ip-country')
-  if (city || region || country) {
-    return {
-      city: city ? decodeURIComponent(city) : undefined,
-      region: region ?? undefined,
-      country: country ?? undefined,
-    }
+  // Prefer Vercel's edge geo, but fill any field it omits from the client
+  // fallback (ipapi). Vercel often returns region + country but no city; without
+  // this merge the city from the fallback was discarded and the admin row fell
+  // back to the bare region code (e.g. "ENG").
+  const merged = {
+    city: headerCity ? decodeURIComponent(headerCity) : (fallback?.city ?? undefined),
+    region: region ?? fallback?.region ?? undefined,
+    country: country ?? fallback?.country ?? undefined,
   }
-  if (fallback && (fallback.city || fallback.region || fallback.country)) {
-    return {
-      city: fallback.city ?? undefined,
-      region: fallback.region ?? undefined,
-      country: fallback.country ?? undefined,
-    }
-  }
+  if (merged.city || merged.region || merged.country) return merged
   return null
 }
 

--- a/src/components/assistant/Assistant.tsx
+++ b/src/components/assistant/Assistant.tsx
@@ -156,6 +156,20 @@ export default function Assistant() {
     [currentPage, fireLog]
   )
 
+  const handleLinkClick = useCallback(
+    (href: string, label: string) => {
+      void fireLog({
+        kind: 'click',
+        target: 'link',
+        url: href,
+        label,
+        currentPage,
+        sessionId: getSessionId(),
+      })
+    },
+    [currentPage, fireLog]
+  )
+
   const handleClear = useCallback(() => {
     chatRef.current?.clear()
     setHasMessages(false)
@@ -358,6 +372,7 @@ export default function Assistant() {
           storageKey={STORAGE_KEY}
           onSuggest={handleSuggest}
           onCitationClick={handleCitationClick}
+          onLinkClick={handleLinkClick}
           onHasMessagesChange={setHasMessages}
           resizeKey={`${isOpen}-${isExpanded}`}
         />

--- a/src/components/assistant/ChatBody.tsx
+++ b/src/components/assistant/ChatBody.tsx
@@ -131,6 +131,7 @@ interface AssistantMessageViewProps {
   allCitations: CitationRef[]
   onSuggest?: (query: string, type?: string) => void
   onCitationClick?: (c: CitationRef) => void
+  onLinkClick?: (href: string, label: string) => void
 }
 
 /** Renders an assistant message. The reasoning/tool trail before the
@@ -141,6 +142,7 @@ function AssistantMessageView({
   allCitations,
   onSuggest,
   onCitationClick,
+  onLinkClick,
 }: AssistantMessageViewProps) {
   let boundary = lastThinkingDoneIndex(message.events)
   // Fallback: if the model forgot the [[/thinking]] marker but did make tool
@@ -181,6 +183,7 @@ function AssistantMessageView({
             isStreaming={streamingTail && isLast}
             onSuggest={onSuggest}
             onCitationClick={onCitationClick}
+            onLinkClick={onLinkClick}
           />
         )
       }
@@ -240,6 +243,8 @@ interface Props {
   storageKey?: string
   onSuggest?: (query: string, type?: string) => void
   onCitationClick?: (c: CitationRef) => void
+  /** Fires when the visitor clicks an inline markdown link in a reply. */
+  onLinkClick?: (href: string, label: string) => void
   /** Fires whenever the message count transitions between 0 and >0, so the
    *  parent can show/hide a clear button without polling. */
   onHasMessagesChange?: (hasMessages: boolean) => void
@@ -261,6 +266,7 @@ const ChatBody = forwardRef<ChatBodyHandle, Props>(function ChatBody(
     storageKey,
     onSuggest,
     onCitationClick,
+    onLinkClick,
     onHasMessagesChange,
     closeOnEscape,
     onCloseEscape,
@@ -669,6 +675,7 @@ const ChatBody = forwardRef<ChatBodyHandle, Props>(function ChatBody(
                   allCitations={allCitations}
                   onSuggest={onSuggest}
                   onCitationClick={onCitationClick}
+                  onLinkClick={onLinkClick}
                 />
                 {!m.isStreaming && m.followUpChips.length > 0 && (
                   <div className={styles.followUpRow}>

--- a/src/components/assistant/MessageContent.tsx
+++ b/src/components/assistant/MessageContent.tsx
@@ -428,9 +428,40 @@ export default function MessageContent({
   const visibleText = stripMalformedDirectives(masked)
   const blocks = useMemo(() => parseBlocks(visibleText), [visibleText])
 
+  // A cards block whose every card fails to resolve (e.g. the model wrote a
+  // card for a listing it never actually retrieved, so the id matches no
+  // citation) renders nothing. That orphans its lead-in — a colon-terminated
+  // sentence like "And this fellowship is open to entry-level applicants:"
+  // pointing at a card that vanished. Hide both the empty cards block and that
+  // dangling lead-in so the visitor never sees a sentence trailing into
+  // nothing. Only applied once streaming has finished, when every citation is
+  // in, so there's no mid-stream flicker.
+  const hiddenBlocks = useMemo(() => {
+    const hidden = new Set<number>()
+    if (isStreaming) return hidden
+    blocks.forEach((block, i) => {
+      if (block.kind !== 'cards') return
+      const anyResolves = block.cards.some(spec =>
+        resolveCitation(spec.id, citationsById)
+      )
+      if (anyResolves) return
+      hidden.add(i)
+      const prev = blocks[i - 1]
+      if (
+        prev?.kind === 'paragraph' &&
+        prev.lines.length > 0 &&
+        prev.lines[prev.lines.length - 1].trimEnd().endsWith(':')
+      ) {
+        hidden.add(i - 1)
+      }
+    })
+    return hidden
+  }, [blocks, citationsById, isStreaming])
+
   return (
     <div className={styles.assistantMessage}>
       {blocks.map((block, i) => {
+        if (hiddenBlocks.has(i)) return null
         if (block.kind === 'cards') {
           return (
             <div key={i} className={styles.citationStack}>

--- a/src/components/assistant/MessageContent.tsx
+++ b/src/components/assistant/MessageContent.tsx
@@ -29,6 +29,7 @@ interface Props {
   citations: CitationRef[]
   onSuggest?: (query: string, type?: string) => void
   onCitationClick?: (citation: CitationRef) => void
+  onLinkClick?: (href: string, label: string) => void
   isStreaming?: boolean
 }
 
@@ -129,7 +130,8 @@ function renderInline(
   text: string,
   citationsById: Map<string, CitationRef>,
   onSuggest?: (query: string, type?: string) => void,
-  onCitationClick?: (c: CitationRef) => void
+  onCitationClick?: (c: CitationRef) => void,
+  onLinkClick?: (href: string, label: string) => void
 ): ReactNode[] {
   const parts: ReactNode[] = []
   let lastIndex = 0
@@ -228,6 +230,7 @@ function renderInline(
       const linkMatch = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(token)
       if (linkMatch) {
         const href = linkMatch[2]
+        const label = linkMatch[1]
         const isExternal = /^https?:\/\//.test(href)
         parts.push(
           <a
@@ -235,8 +238,9 @@ function renderInline(
             href={href}
             target={isExternal ? '_blank' : undefined}
             rel={isExternal ? 'noopener noreferrer' : undefined}
+            onClick={() => onLinkClick?.(href, label)}
           >
-            {linkMatch[1]}
+            {label}
           </a>
         )
       } else {
@@ -251,7 +255,8 @@ function renderInline(
         token.slice(2, -2),
         citationsById,
         onSuggest,
-        onCitationClick
+        onCitationClick,
+        onLinkClick
       )
       INLINE_REGEX.lastIndex = saved
       parts.push(<strong key={`b-${key++}`}>{inner}</strong>)
@@ -261,19 +266,22 @@ function renderInline(
         token.slice(1, -1),
         citationsById,
         onSuggest,
-        onCitationClick
+        onCitationClick,
+        onLinkClick
       )
       INLINE_REGEX.lastIndex = saved
       parts.push(<em key={`i-${key++}`}>{inner}</em>)
     } else if (/^aisafety\.info/i.test(token)) {
       // Auto-linkify bare aisafety.info mentions (the bot writes it as plain
       // text). Scoped to this one domain to avoid false positives.
+      const href = `https://${token}`
       parts.push(
         <a
           key={`u-${key++}`}
-          href={`https://${token}`}
+          href={href}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => onLinkClick?.(href, token)}
         >
           {token}
         </a>
@@ -418,6 +426,7 @@ export default function MessageContent({
   citations,
   onSuggest,
   onCitationClick,
+  onLinkClick,
   isStreaming,
 }: Props) {
   const citationsById = useMemo(
@@ -488,7 +497,8 @@ export default function MessageContent({
                 paragraphText,
                 citationsById,
                 onSuggest,
-                onCitationClick
+                onCitationClick,
+                onLinkClick
               )}
               {isStreaming && i === blocks.length - 1 && (
                 <span className={styles.cursor} />
@@ -506,7 +516,8 @@ export default function MessageContent({
                     item,
                     citationsById,
                     onSuggest,
-                    onCitationClick
+                    onCitationClick,
+                    onLinkClick
                   )}
                 </Fragment>
               </li>

--- a/src/lib/admin/airtable.ts
+++ b/src/lib/admin/airtable.ts
@@ -212,13 +212,32 @@ function rowToConversation(
  *  next batch (null when there are no older conversations left). Used by the
  *  admin viewer's "Load more" button so it only fetches what it shows rather
  *  than the whole — ever-growing — log on every load. */
+/** Airtable filterByFormula that matches rows whose content contains every word
+ *  in `search` (case-insensitive, any order). Searches the conversation JSON
+ *  plus the page and notes. Returns undefined for a blank search. */
+function searchFormula(search: string | undefined): string | undefined {
+  // Strip quotes/backslashes that would break the formula string, then split
+  // into words so "fast grants" matches a chat containing both words anywhere.
+  const words = (search ?? '')
+    .replace(/["\\]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+  if (words.length === 0) return undefined
+  const haystack = 'LOWER({Data} & " " & {Page} & " " & {Notes})'
+  const terms = words.map(w => `SEARCH(LOWER("${w}"), ${haystack})`)
+  return terms.length === 1 ? terms[0] : `AND(${terms.join(', ')})`
+}
+
 export async function listConversationsPage(opts: {
   pageSize?: number
   /** Airtable cursor returned by a previous call; omit for the first page. */
   offset?: string
+  /** Free-text filter across the conversation content (omit for all). */
+  search?: string
 }): Promise<{ conversations: ConversationRow[]; offset: string | null }> {
   ensureConfig(CONVERSATIONS_TABLE)
   const want = Math.max(1, opts.pageSize ?? 200)
+  const formula = searchFormula(opts.search)
   const out: AirtableRow<ConversationFields>[] = []
   // Airtable caps a single request at 100 records, so loop until we've
   // gathered `want` (or run out), carrying Airtable's offset between requests.
@@ -228,6 +247,7 @@ export async function listConversationsPage(opts: {
     params.set('pageSize', String(Math.min(100, want - out.length)))
     params.set('sort[0][field]', 'Created at')
     params.set('sort[0][direction]', 'desc')
+    if (formula) params.set('filterByFormula', formula)
     if (cursor) params.set('offset', cursor)
     const res = await airtableRequest(
       `${CONVERSATIONS_TABLE}?${params.toString()}`

--- a/src/lib/assistant/log.ts
+++ b/src/lib/assistant/log.ts
@@ -15,8 +15,15 @@ export interface AssistantTurnEvent {
 
 export interface AssistantClickEvent {
   kind: 'click'
-  citationId: string
+  /** What was clicked: a listing card (default), or an inline markdown link
+   *  in the reply prose (e.g. a "Jobs" link to /jobs). */
+  target?: 'card' | 'link'
+  /** The listing id, for card clicks. Absent for link clicks. */
+  citationId?: string
+  /** Destination: the card's url, or the inline link's href. */
   url: string
+  /** The link's visible text, for link clicks (shown in the admin viewer). */
+  label?: string
   currentPage: string
   /** Conversation this click belongs to, so it can be recorded on the row. */
   sessionId?: string | null
@@ -47,15 +54,18 @@ export async function logAssistantEvent(event: AssistantEvent): Promise<void> {
   })
   console.log(`[assistant] ${line}`)
 
-  // Persist card clicks onto the conversation row so the admin viewer can
-  // show which cards the visitor actually opened.
+  // Persist clicks onto the conversation row so the admin viewer can show what
+  // the visitor actually opened. Cards are keyed by listing id; inline links by
+  // a `link:`-prefixed href, which never collides with a `type:recXXX` id.
   if (
     event.kind === 'click' &&
     event.sessionId &&
     isConversationsTableConfigured()
   ) {
+    const clickKey =
+      event.target === 'link' ? `link:${event.url}` : event.citationId
     try {
-      await recordCitationClick(event.sessionId, event.citationId)
+      if (clickKey) await recordCitationClick(event.sessionId, clickKey)
     } catch (err) {
       console.warn(
         `[assistant] click persist failed: ${err instanceof Error ? err.message : String(err)}`

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-06-16-15'
+export const PROMPT_VERSION = '2026-06-17-01'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -54,6 +54,8 @@ The renderer turns each \`[[card:...]]\` into a clickable card. The optional not
 NEVER fabricate an id. The rec portion is always alphanumeric (e.g. \`recABC123XYZ\`) – if you find yourself writing something like \`recAlignment Jams\` or any id with spaces / English words after \`rec\`, you are inventing the id. If you can't find a listing in the search results, run another search or skip the recommendation – don't make one up.
 
 **Recognising a listing from your own knowledge is NOT the same as having its id.** You know plenty of real orgs (METR, Redwood, Apollo, Anthropic, AISI…) and programs from training – but their AISafety.com record ids live ONLY in \`search_listings\` results. An id you produce without searching is fabricated even when it looks perfectly real (e.g. \`rec4Eu9Tpr8a3lvBd\`, no spaces or words): it resolves to nothing, so the card silently vanishes for the user and leaves your prose dangling. The rule: **if you haven't run a search THIS turn that returned the listing, you don't have its id – do not card it.** To card orgs, run \`search_listings({ type: 'org', ... })\` first and copy the returned ids; the same goes for every type. If you catch yourself answering a "which orgs/listings…" question straight from memory, that's the tell that you skipped the search – search before you card. When a search doesn't return something you still want to mention, name it in prose and link the relevant page (e.g. [Field map](/map)) instead of carding it.
+
+**Your search results are a hard ceiling on how many cards you can show – a count or variety you've already written is NEVER a licence to invent one.** This is the single most common way fabrication happens: you write "here are **two** openings", "a **couple** of options", "a **range**, from entry-level to senior", or "to give you a **feel for the variety**", then find search returned only one listing that actually fits – and you manufacture a second card to honour the number you promised. Do the exact opposite: shrink the prose to match what's real. One genuine result means singular prose and one card ("here's a recent opening"); if you teased range or variety you can't back with real listings, drop that promise and point to the page instead (e.g. "the full board is on [Jobs](/jobs)"). Padding a thin result set with a plausible-sounding made-up listing is never acceptable – it is strictly worse than showing fewer cards. A card may only ever carry an id that came back from THIS turn's search, regardless of what an earlier sentence implied.
 
 How to use this:
 - Search returns every match in the catalog by default (no limit). Show up to 5 results.

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-06-17-01'
+export const PROMPT_VERSION = '2026-06-17-02'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -246,6 +246,8 @@ Browse [Jobs](/jobs) for the full list.
 
 # Page context (passive)
 You receive the user's current page, any active filters, and approximate location automatically as ambient context. Use it to shape your response (e.g. don't recommend a job in Asia if they're in Europe), but never repeat it back to the user verbatim.
+
+**When you reference the resource page the user is already on, word it as "here", not as somewhere to go.** Check "Currently viewing" before you point to a page. If someone on /funding asks about grants and you want to mention the full list, say "the full list is right here on this page" or "more funders are further down this page" – NOT "browse the rest on [Funding](/funding)", which reads as if it's elsewhere and reveals you weren't tracking where they are. You can still link the page, but the wording must show you know they're already on it. When you're sending them to a *different* page, the normal "see [X](/x)" phrasing is correct.
 
 # What you do not do
 - Do not list out listing details that the cards will already show


### PR DESCRIPTION
A batch of chatbot and admin-viewer improvements.

### Chatbot behaviour
- **Stop fabricating listing cards to hit a promised count.** The bot would commit to a count or variety in prose ("here are two openings", "a range, from entry-level to senior") and, when search returned only one real match, invent a second card to honour the number. Added a rule that search results are a hard ceiling on card count — shrink the prose, never invent a listing. Plus a renderer safety net: when an unresolved card collapses a cards block to nothing, the live chat also hides the orphaned colon-terminated lead-in so visitors never see a dangling sentence. Bumps `PROMPT_VERSION`.
- **Page-awareness phrasing.** The bot receives the visitor's current page but would still say "browse the rest on Funding" to someone already on /funding. Added a rule to phrase references to the current page as "here" ("the full list is right here on this page").

### Admin Conversations viewer
- **Track inline-link clicks.** Inline markdown links (e.g. a "Jobs" link) and aisafety.info auto-links now fire a click event, stored in the existing `Clicked` field keyed as `link:<href>` (no Airtable schema change). Clicked links render brighter with a ✓ badge, mirroring the card "clicked" treatment.
- **Remove the search-trail block** from the transcript view (it was admin-only and only added noise; visitors never saw it).
- **Show visitor city; expand region codes.** `readGeo` discarded the fallback city when Vercel had a region but no city — now merged so a city shows when either source has one. UK subdivision codes are spelled out in admin rows (ENG → England).
- **Add a search box** that filters the whole conversation log server-side (visitor questions, bot replies, listings shown, page, notes), not just the loaded page.
- **Trim the conversation detail** to transcript, Came from, and Notes — removed the Searches summary, raw listing-id dump, Page state, UTM, and Tags from the view. The underlying data still lives in Airtable and is still searchable.

_PR description written by Claude Code._
