### PR TITLE
Add an optional second admin password for partner log review

### DIFF
--- a/src/app/api/admin/auth/route.ts
+++ b/src/app/api/admin/auth/route.ts
@@ -20,7 +20,9 @@ export async function POST(req: NextRequest) {
       headers: { 'Content-Type': 'application/json' },
     })
   }
-  await setAdminCookie()
+  // checkAdminPassword has confirmed this is one of the accepted passwords;
+  // mint the cookie derived from it so isAdmin() recognises the session.
+  await setAdminCookie(body.password as string)
   return new Response(JSON.stringify({ ok: true }), {
     headers: { 'Content-Type': 'application/json' },
   })

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -5,29 +5,43 @@ const COOKIE_NAME = 'aisafety_admin'
 // 30 days. Re-auth when expired.
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 30
 
-/** Cookie value derived from ADMIN_PASSWORD. Forging the cookie therefore
- *  requires knowing the password — pasting any literal string into the
- *  browser cookie store will not pass `isAdmin()`. */
-function expectedCookieValue(): string | null {
-  const pw = process.env.ADMIN_PASSWORD
-  if (!pw) return null
-  return createHash('sha256').update(`${pw}:aisafety-admin-v1`).digest('hex')
+/** Passwords that grant admin access: the primary owner password plus an
+ *  optional secondary one (e.g. a shareable "successif…" password handed to a
+ *  partner reviewing the chat logs). Each lives in its own env var, so either
+ *  can be revoked on its own — drop `ADMIN_PASSWORD_SUCCESSIF` and that
+ *  password (and any cookie derived from it) stops working immediately, while
+ *  the primary is untouched. */
+function validPasswords(): string[] {
+  return [
+    process.env.ADMIN_PASSWORD,
+    process.env.ADMIN_PASSWORD_SUCCESSIF,
+  ].filter((p): p is string => typeof p === 'string' && p.length > 0)
+}
+
+/** Cookie value derived from a password. Forging the cookie therefore requires
+ *  knowing a valid password — pasting any literal string into the browser
+ *  cookie store will not pass `isAdmin()`. */
+function cookieValueFor(password: string): string {
+  return createHash('sha256')
+    .update(`${password}:aisafety-admin-v1`)
+    .digest('hex')
 }
 
 export async function isAdmin(): Promise<boolean> {
-  const expected = expectedCookieValue()
-  if (!expected) return false
+  const accepted = validPasswords().map(cookieValueFor)
+  if (accepted.length === 0) return false
   const c = await cookies()
-  return c.get(COOKIE_NAME)?.value === expected
+  const got = c.get(COOKIE_NAME)?.value
+  return got != null && accepted.includes(got)
 }
 
-export async function setAdminCookie(): Promise<void> {
-  const value = expectedCookieValue()
-  if (!value) return
+export async function setAdminCookie(password: string): Promise<void> {
+  // Only mint a cookie for a password we actually accept.
+  if (!validPasswords().includes(password)) return
   const c = await cookies()
   c.set({
     name: COOKIE_NAME,
-    value,
+    value: cookieValueFor(password),
     httpOnly: true,
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
@@ -42,16 +56,21 @@ export async function clearAdminCookie(): Promise<void> {
 }
 
 export function checkAdminPassword(password: unknown): boolean {
-  const expected = process.env.ADMIN_PASSWORD
-  if (!expected) return false
   if (typeof password !== 'string') return false
-  // Constant-time compare. Iterate the longer of the two so an attacker
-  // cannot infer the expected length by measuring response time, then fold
-  // the length mismatch into the result.
-  const len = Math.max(password.length, expected.length)
-  let diff = password.length ^ expected.length
-  for (let i = 0; i < len; i++) {
-    diff |= (password.charCodeAt(i) | 0) ^ (expected.charCodeAt(i) | 0)
+  const valids = validPasswords()
+  if (valids.length === 0) return false
+  // Constant-time compare against each accepted password. Iterate the longer of
+  // the two so an attacker cannot infer a password's length by measuring
+  // response time, and never early-exit (OR the per-candidate results) so the
+  // number of configured passwords isn't observable either.
+  let matched = false
+  for (const expected of valids) {
+    const len = Math.max(password.length, expected.length)
+    let diff = password.length ^ expected.length
+    for (let i = 0; i < len; i++) {
+      diff |= (password.charCodeAt(i) | 0) ^ (expected.charCodeAt(i) | 0)
+    }
+    matched = matched || diff === 0
   }
-  return diff === 0
+  return matched
 }


### PR DESCRIPTION
- Adds an optional second admin password (`ADMIN_PASSWORD_SUCCESSIF`) alongside the primary `ADMIN_PASSWORD`. Either one grants full admin access (assistant Playground + Conversations).
- The two passwords live in separate env vars and derive separate cookies, so the secondary can be revoked on its own: unset `ADMIN_PASSWORD_SUCCESSIF` and any session created with it stops being recognized immediately, while the primary login is untouched.
- Purpose: give a partner (Successif) a shareable, independently-revocable login to review the assistant chat logs, without handing over the owner password.
- Password checks stay constant-time across every configured password (no early-exit), empty/unset vars are filtered out, and the cookie scheme and flags are unchanged.

_PR description written by Claude Code._