### PR TITLE
Rename admin "Conversations" to "Conversation Log" and "Visitor" to "User"

### DIFF
--- a/src/app/admin/assistant/ConversationList.tsx
+++ b/src/app/admin/assistant/ConversationList.tsx
@@ -222,7 +222,7 @@ export default function ConversationList() {
           placeholder="Search conversations…"
           value={searchInput}
           onChange={e => setSearchInput(e.target.value)}
-          title="Searches the whole log — visitor questions, bot replies, listings shown, page and notes"
+          title="Searches the whole log — user questions, bot replies, listings shown, page and notes"
         />
         <label title="Show only conversations where the chatbot searched the directory and found nothing — useful for spotting gaps in the listings">
           <input
@@ -373,7 +373,7 @@ function ConversationRow({
             {data?.status === 'abandoned' && (
               <span
                 className={styles.convRowAbandoned}
-                title="The visitor left before (or without) an answer streamed — only their question was logged"
+                title="The user left before (or without) an answer streamed — only their question was logged"
               >
                 NO REPLY
               </span>
@@ -381,7 +381,7 @@ function ConversationRow({
             {data?.status === 'error' && (
               <span
                 className={styles.convRowError}
-                title="Generation failed for this turn — only the visitor's question was logged"
+                title="Generation failed for this turn — only the user's question was logged"
               >
                 ERROR
               </span>
@@ -420,7 +420,7 @@ function ConversationRow({
                       }
                     >
                       <div className={styles.convTurnRole}>
-                        {t.role === 'user' ? 'Visitor' : 'Chatbot'}
+                        {t.role === 'user' ? 'User' : 'Chatbot'}
                       </div>
                       {t.role === 'user' ? (
                         <div className={styles.convTurnContent}>

--- a/src/app/admin/assistant/EditorPanel.tsx
+++ b/src/app/admin/assistant/EditorPanel.tsx
@@ -363,8 +363,7 @@ export default function EditorPanel({
         </div>
         <p className={styles.sectionHint}>
           Sent with each test message — same shape production uses. Geo is
-          pre-filled from your IP; edit anything to simulate a different
-          visitor.
+          pre-filled from your IP; edit anything to simulate a different user.
         </p>
 
         <div className={styles.editorRow}>

--- a/src/app/admin/assistant/TranscriptMessage.tsx
+++ b/src/app/admin/assistant/TranscriptMessage.tsx
@@ -139,7 +139,7 @@ function inlineLink(
       {wasClicked && (
         <span
           className={styles.convLinkClickedTag}
-          title="The visitor clicked this link"
+          title="The user clicked this link"
         >
           ✓
         </span>
@@ -372,7 +372,9 @@ function MessageBody({ text }: { text: string }) {
         }
         if (block.kind === 'paragraph') {
           return (
-            <p key={i}>{renderInline(block.lines.join(' '), listings, clicked)}</p>
+            <p key={i}>
+              {renderInline(block.lines.join(' '), listings, clicked)}
+            </p>
           )
         }
         const Tag = block.kind === 'ul' ? 'ul' : 'ol'
@@ -401,7 +403,7 @@ export default function TranscriptMessage({ text }: { text: string }) {
       <MessageBody text={body} />
       {suggestedListing && (
         <div className={styles.convSuggestNote}>
-          Nothing matched — visitor was shown a &ldquo;Suggest a listing&rdquo;
+          Nothing matched — user was shown a &ldquo;Suggest a listing&rdquo;
           button
         </div>
       )}

--- a/src/app/admin/assistant/conversations/page.tsx
+++ b/src/app/admin/assistant/conversations/page.tsx
@@ -7,7 +7,7 @@ export default function ConversationsPage() {
   return (
     <div className={styles.convPage}>
       <div className={styles.pageHeading}>
-        <h1 className={styles.pageTitle}>Conversations</h1>
+        <h1 className={styles.pageTitle}>Conversation Log</h1>
       </div>
       {configured ? (
         <ConversationList />

--- a/src/app/admin/assistant/layout.tsx
+++ b/src/app/admin/assistant/layout.tsx
@@ -5,7 +5,7 @@ import styles from '../admin.module.css'
 
 const TABS = [
   { href: '/admin/assistant', label: 'Playground' },
-  { href: '/admin/assistant/conversations', label: 'Conversations' },
+  { href: '/admin/assistant/conversations', label: 'Conversation Log' },
 ]
 
 export default async function AssistantAdminLayout({


### PR DESCRIPTION
- Renames the chatbot admin nav tab and page heading from "Conversations" to "Conversation Log".
- Renames the transcript role label from "Visitor" to "User", and updates the matching user-visible tooltips and prose for consistency.
- UI strings only — no code identifiers, component names, or data fields were touched.

_PR description written by Claude Code._