### PR TITLE
Analytics: click-position tracking across all resource pages

### DIFF
--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -110,6 +110,29 @@
   text-align: right;
 }
 
+/* Per-row share of the chart total — a secondary, dimmer column. */
+.pctCol {
+  text-align: right;
+  color: var(--teal-400);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  width: 1%;
+}
+
+.table th.pctCol {
+  text-align: right;
+}
+
+/* Total row: separated by the last body row's border, bold. */
+.table tfoot td {
+  padding-top: 8px;
+  font-weight: 600;
+}
+
+.totalLabel {
+  color: var(--teal-300);
+}
+
 /* Listing placement on the /funding page (F1/F2 featured, then 1, 2, 3…). */
 .rankCol {
   width: 1%;

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -137,6 +137,13 @@
   color: var(--teal-400);
 }
 
+.caption {
+  margin-top: 12px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--teal-400);
+}
+
 .empty {
   background-color: var(--teal-850);
   border: 1px solid var(--teal-800);

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -144,6 +144,46 @@
   color: var(--teal-400);
 }
 
+/* ─── Unique / total click toggle ─────────────────────────────────────── */
+
+.clickToggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: -8px 0 24px;
+  font-size: 13px;
+}
+
+.clickToggleLabel {
+  color: var(--teal-400);
+  margin-right: 2px;
+}
+
+.clickToggleBtn {
+  padding: 4px 12px;
+  font-size: 13px;
+  color: var(--teal-300);
+  background-color: transparent;
+  border: 1px solid var(--teal-800);
+  border-radius: 6px;
+  text-decoration: none;
+  transition:
+    color var(--hover-transition),
+    background-color var(--hover-transition);
+}
+
+.clickToggleBtn:hover {
+  color: var(--white);
+  background-color: var(--teal-800);
+}
+
+.clickToggleBtnActive,
+.clickToggleBtnActive:hover {
+  color: var(--teal-900);
+  background-color: var(--bright-teal-300);
+  border-color: var(--bright-teal-300);
+}
+
 /* ─── Per-page drill-down ─────────────────────────────────────────────── */
 
 .pageSection {

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -158,7 +158,10 @@
 }
 
 .pageTab {
-  padding: 6px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 12px 5px 6px;
   font-size: 13px;
   color: var(--teal-300);
   background-color: transparent;
@@ -169,6 +172,19 @@
   transition:
     color var(--hover-transition),
     background-color var(--hover-transition);
+}
+
+/* White badge behind the nav icon, mirroring the site nav, so the glyph reads
+   on both the dark tabs and the light active tab. */
+.pageTabIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background-color: var(--white);
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .pageTab:hover {

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -184,6 +184,48 @@
   border-color: var(--bright-teal-300);
 }
 
+/* ─── Clicks-by-source split (map pages) ──────────────────────────────── */
+
+.sourceSplit {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 16px;
+  font-size: 13px;
+}
+
+.sourceSplitLabel {
+  color: var(--teal-400);
+  font-weight: 600;
+}
+
+.sourceStat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 10px;
+  background-color: var(--teal-900);
+  border: 1px solid var(--teal-800);
+  border-radius: 6px;
+}
+
+.sourceStatName {
+  color: var(--teal-300);
+}
+
+.sourceStatCount {
+  color: var(--white);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.sourceStatPct {
+  color: var(--teal-400);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
 /* ─── Per-page drill-down ─────────────────────────────────────────────── */
 
 .pageSection {

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -110,6 +110,28 @@
   text-align: right;
 }
 
+/* Listing placement on the /funding page (F1/F2 featured, then 1, 2, 3…). */
+.rankCol {
+  width: 1%;
+  white-space: nowrap;
+  text-align: right;
+  color: var(--teal-400);
+  font-variant-numeric: tabular-nums;
+}
+
+.table th.rankCol {
+  text-align: right;
+}
+
+.table td.rankCol {
+  vertical-align: middle;
+}
+
+.rankFeatured {
+  color: var(--bright-teal-300);
+  font-weight: 600;
+}
+
 .dim {
   font-size: 13px;
   color: var(--teal-400);

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -186,12 +186,15 @@
 
 /* ─── Clicks-by-source split (map pages) ──────────────────────────────── */
 
+.sourceSplitWrap {
+  margin-bottom: 16px;
+}
+
 .sourceSplit {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 10px;
-  margin-bottom: 16px;
   font-size: 13px;
 }
 

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -201,7 +201,8 @@
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  padding: 5px 12px 5px 6px;
+  /* Symmetric by default so text-only tabs (e.g. Home) stay centered. */
+  padding: 5px 12px;
   font-size: 13px;
   color: var(--teal-300);
   background-color: transparent;
@@ -212,6 +213,11 @@
   transition:
     color var(--hover-transition),
     background-color var(--hover-transition);
+}
+
+/* Tabs with an icon badge get a tighter left pad so the badge sits near the edge. */
+.pageTab:has(.pageTabIcon) {
+  padding-left: 6px;
 }
 
 /* White badge behind the nav icon, mirroring the site nav, so the glyph reads

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -144,6 +144,45 @@
   color: var(--teal-400);
 }
 
+/* ─── Per-page drill-down ─────────────────────────────────────────────── */
+
+.pageSection {
+  margin-bottom: 20px;
+}
+
+.pageTabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.pageTab {
+  padding: 6px 12px;
+  font-size: 13px;
+  color: var(--teal-300);
+  background-color: transparent;
+  border: 1px solid var(--teal-800);
+  border-radius: 6px;
+  text-decoration: none;
+  white-space: nowrap;
+  transition:
+    color var(--hover-transition),
+    background-color var(--hover-transition);
+}
+
+.pageTab:hover {
+  color: var(--white);
+  background-color: var(--teal-800);
+}
+
+.pageTabActive,
+.pageTabActive:hover {
+  color: var(--teal-900);
+  background-color: var(--bright-teal-300);
+  border-color: var(--bright-teal-300);
+}
+
 .empty {
   background-color: var(--teal-850);
   border: 1px solid var(--teal-800);

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -152,19 +152,10 @@ export default async function AnalyticsPage({
   const logoById = new Map(funders.map(f => [f.id, f.logo]))
   const logoByName = new Map(funders.map(f => [f.name, f.logo]))
 
-  // Each listing's placement on the live /funding page, so Bryce can see how
-  // position correlates with clicks. The two featured cards sit above the main
-  // list (F1, F2); everything below is numbered 1, 2, 3… in display order.
-  const placementByName = new Map<string, string>()
-  let mainRank = 0
-  for (const f of funders) {
-    if (f.featured === '1') placementByName.set(f.name, 'F1')
-    else if (f.featured === '2') placementByName.set(f.name, 'F2')
-    else {
-      mainRank += 1
-      placementByName.set(f.name, String(mainRank))
-    }
-  }
+  // Slot range each listing was clicked at during this period — stamped onto
+  // the click when it happened, so it stays accurate even as the page is
+  // reordered. Undefined for listings whose clicks predate slot tracking.
+  const positionByName = new Map(data.topFunding.map(r => [r.name, r.position]))
 
   return (
     <div>
@@ -206,11 +197,25 @@ export default async function AnalyticsPage({
               <CountTable
                 rows={data.topFunding}
                 labelHead="Listing"
+                rankHead="Slot"
                 logoFor={name => logoByName.get(name) ?? undefined}
-                rankFor={name => placementByName.get(name)}
+                rankFor={name => positionByName.get(name)}
               />
+              <p className={styles.caption}>
+                Slot = where each listing was clicked this period (F1/F2 =
+                featured cards). Blank for clicks logged before slot tracking.
+              </p>
             </Panel>
           </div>
+
+          <Panel title="Clicks by position">
+            <CountTable rows={data.byPosition} labelHead="Slot" />
+            <p className={styles.caption}>
+              Every funding click counted at the slot it happened in, pooled
+              across all listings — so a busy top slot shows up even as
+              different listings rotate through it.
+            </p>
+          </Panel>
 
           <Panel title="Recent activity">
             {data.recent.length === 0 ? (
@@ -271,11 +276,13 @@ function Panel({
 function CountTable({
   rows,
   labelHead,
+  rankHead = '#',
   logoFor,
   rankFor,
 }: {
   rows: Counted[]
   labelHead: string
+  rankHead?: string
   logoFor?: (name: string) => string | undefined
   rankFor?: (name: string) => string | undefined
 }) {
@@ -284,7 +291,7 @@ function CountTable({
     <table className={styles.table}>
       <thead>
         <tr>
-          {rankFor && <th className={styles.rankCol}>#</th>}
+          {rankFor && <th className={styles.rankCol}>{rankHead}</th>}
           <th>{labelHead}</th>
           <th className={styles.numCol}>Clicks</th>
         </tr>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import {
   readDashboard,
   type Counted,
@@ -183,13 +184,15 @@ export default async function AnalyticsPage({
   )
   const urlByName = new Map(data.topListings.map(r => [r.name, r.url]))
 
-  // Page tabs in site-nav order (pages not in the nav fall to the end), each
-  // carrying its nav icon.
+  // Page tabs: Home first, then the resource pages in site-nav order, then any
+  // other pages. Each carries its nav icon where it has one.
   const pageOrder = new Map(PAGE_NAV.map((p, i) => [p.name, i]))
   const iconByPage = new Map(PAGE_NAV.map(p => [p.name, p.icon]))
+  const orderOf = (name: string) =>
+    name === 'Home' ? -1 : (pageOrder.get(name) ?? 999)
   const tabPages = data.byPage
     .map(p => p.name)
-    .sort((a, b) => (pageOrder.get(a) ?? 999) - (pageOrder.get(b) ?? 999))
+    .sort((a, b) => orderOf(a) - orderOf(b))
     .map(name => ({ name, icon: iconByPage.get(name) }))
 
   return (
@@ -328,22 +331,24 @@ function ClickModeToggle({
   return (
     <div className={styles.clickToggle}>
       <span className={styles.clickToggleLabel}>Count</span>
-      <a
+      <Link
         href={uniqueQ ? `?${uniqueQ}` : '?'}
+        scroll={false}
         className={`${styles.clickToggleBtn}${
           unique ? ` ${styles.clickToggleBtnActive}` : ''
         }`}
       >
         Unique
-      </a>
-      <a
+      </Link>
+      <Link
         href={`?${totalParams.toString()}`}
+        scroll={false}
         className={`${styles.clickToggleBtn}${
           !unique ? ` ${styles.clickToggleBtnActive}` : ''
         }`}
       >
         Total
-      </a>
+      </Link>
     </div>
   )
 }
@@ -405,9 +410,10 @@ function PageTabs({
         const q = new URLSearchParams(base)
         q.set('page', name)
         return (
-          <a
+          <Link
             key={name}
             href={`?${q.toString()}`}
+            scroll={false}
             className={`${styles.pageTab}${
               name === active ? ` ${styles.pageTabActive}` : ''
             }`}
@@ -418,7 +424,7 @@ function PageTabs({
               </span>
             )}
             {name}
-          </a>
+          </Link>
         )
       })}
     </div>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -247,6 +247,12 @@ export default async function AnalyticsPage({
     .sort((a, b) => orderOf(a) - orderOf(b))
     .map(name => ({ name, icon: iconByPage.get(name) }))
 
+  // Chart totals (also the % denominators). The listings total is the selected
+  // page's whole click count, not just the visible top-15 rows.
+  const totalClicks = data.byPage.reduce((sum, r) => sum + r.count, 0)
+  const pageTotal = data.byPage.find(p => p.name === data.selectedPage)?.count
+  const positionTotal = data.byPosition.reduce((sum, r) => sum + r.count, 0)
+
   return (
     <div>
       <div className={styles.headerRow}>
@@ -282,7 +288,11 @@ export default async function AnalyticsPage({
           </Panel>
 
           <Panel title="Clicks by page">
-            <CountTable rows={data.byPage} labelHead="Page" />
+            <CountTable
+              rows={data.byPage}
+              labelHead="Page"
+              total={totalClicks}
+            />
           </Panel>
 
           <div className={styles.pageSection}>
@@ -304,6 +314,7 @@ export default async function AnalyticsPage({
                     logoByName.get(name) ?? faviconFor(urlByName.get(name))
                   }
                   rankFor={name => positionByName.get(name)}
+                  total={pageTotal}
                 />
                 <p className={styles.caption}>
                   Slot = where each listing was clicked this period (F1/F2 =
@@ -311,7 +322,11 @@ export default async function AnalyticsPage({
                 </p>
               </Panel>
               <Panel title="Clicks by position">
-                <CountTable rows={data.byPosition} labelHead="Slot" />
+                <CountTable
+                  rows={data.byPosition}
+                  labelHead="Slot"
+                  total={positionTotal}
+                />
                 <p className={styles.caption}>
                   Every click on this page counted at the slot it happened in —
                   so a busy top slot shows up even as different listings rotate
@@ -415,6 +430,14 @@ function SourceSplit({ rows }: { rows: Counted[] }) {
     <div className={styles.sourceSplitWrap}>
       <div className={styles.sourceSplit}>
         <span className={styles.sourceSplitLabel}>Clicks by source</span>
+        {rows.length > 1 && (
+          <span className={styles.sourceStat}>
+            <span className={styles.sourceStatName}>Total</span>
+            <span className={styles.sourceStatCount}>
+              {total.toLocaleString()}
+            </span>
+          </span>
+        )}
         {rows.map(r => (
           <span key={r.name} className={styles.sourceStat}>
             <span className={styles.sourceStatName}>{r.name}</span>
@@ -504,14 +527,20 @@ function CountTable({
   rankHead = '#',
   logoFor,
   rankFor,
+  total,
 }: {
   rows: Counted[]
   labelHead: string
   rankHead?: string
   logoFor?: (name: string) => string | undefined
   rankFor?: (name: string) => string | undefined
+  /** When set, adds a % column (each row's share of this total) and a Total
+   *  footer row. The total is the denominator, so for a sliced "top N" table it
+   *  can exceed the sum of the visible rows. */
+  total?: number
 }) {
   if (rows.length === 0) return <p className={styles.dim}>No data yet.</p>
+  const showPct = total != null && total > 0
   return (
     <table className={styles.table}>
       <thead>
@@ -519,6 +548,7 @@ function CountTable({
           {rankFor && <th className={styles.rankCol}>{rankHead}</th>}
           <th>{labelHead}</th>
           <th className={styles.numCol}>Clicks</th>
+          {showPct && <th className={styles.pctCol}>%</th>}
         </tr>
       </thead>
       <tbody>
@@ -541,10 +571,25 @@ function CountTable({
                 <span>{r.name}</span>
               </td>
               <td className={styles.numCol}>{r.count.toLocaleString()}</td>
+              {showPct && (
+                <td className={styles.pctCol}>
+                  {Math.round((100 * r.count) / total)}%
+                </td>
+              )}
             </tr>
           )
         })}
       </tbody>
+      {total != null && (
+        <tfoot>
+          <tr className={styles.totalRow}>
+            {rankFor && <td className={styles.rankCol} />}
+            <td className={styles.totalLabel}>Total</td>
+            <td className={styles.numCol}>{total.toLocaleString()}</td>
+            {showPct && <td className={styles.pctCol}>100%</td>}
+          </tr>
+        </tfoot>
+      )}
     </table>
   )
 }

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -152,6 +152,20 @@ export default async function AnalyticsPage({
   const logoById = new Map(funders.map(f => [f.id, f.logo]))
   const logoByName = new Map(funders.map(f => [f.name, f.logo]))
 
+  // Each listing's placement on the live /funding page, so Bryce can see how
+  // position correlates with clicks. The two featured cards sit above the main
+  // list (F1, F2); everything below is numbered 1, 2, 3… in display order.
+  const placementByName = new Map<string, string>()
+  let mainRank = 0
+  for (const f of funders) {
+    if (f.featured === '1') placementByName.set(f.name, 'F1')
+    else if (f.featured === '2') placementByName.set(f.name, 'F2')
+    else {
+      mainRank += 1
+      placementByName.set(f.name, String(mainRank))
+    }
+  }
+
   return (
     <div>
       <div className={styles.headerRow}>
@@ -193,6 +207,7 @@ export default async function AnalyticsPage({
                 rows={data.topFunding}
                 labelHead="Listing"
                 logoFor={name => logoByName.get(name) ?? undefined}
+                rankFor={name => placementByName.get(name)}
               />
             </Panel>
           </div>
@@ -257,30 +272,46 @@ function CountTable({
   rows,
   labelHead,
   logoFor,
+  rankFor,
 }: {
   rows: Counted[]
   labelHead: string
   logoFor?: (name: string) => string | undefined
+  rankFor?: (name: string) => string | undefined
 }) {
   if (rows.length === 0) return <p className={styles.dim}>No data yet.</p>
   return (
     <table className={styles.table}>
       <thead>
         <tr>
+          {rankFor && <th className={styles.rankCol}>#</th>}
           <th>{labelHead}</th>
           <th className={styles.numCol}>Clicks</th>
         </tr>
       </thead>
       <tbody>
-        {rows.map((r, i) => (
-          <tr key={i}>
-            <td className={styles.nameCell}>
-              {logoFor && <Logo src={logoFor(r.name)} />}
-              <span>{r.name}</span>
-            </td>
-            <td className={styles.numCol}>{r.count.toLocaleString()}</td>
-          </tr>
-        ))}
+        {rows.map((r, i) => {
+          const rank = rankFor?.(r.name)
+          const featured = rank?.startsWith('F')
+          return (
+            <tr key={i}>
+              {rankFor && (
+                <td
+                  className={`${styles.rankCol}${
+                    featured ? ` ${styles.rankFeatured}` : ''
+                  }`}
+                >
+                  {rank ?? '—'}
+                </td>
+              )}
+              <td className={styles.nameCell}>
+                {logoFor && <Logo src={logoFor(r.name)} />}
+                <span>{r.name}</span>
+              </td>
+              <td className={styles.numCol}>{r.count.toLocaleString()}</td>
+            </tr>
+          )
+        })}
       </tbody>
     </table>
   )

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -141,21 +141,27 @@ export default async function AnalyticsPage({
 }: {
   searchParams: Promise<SearchParams>
 }) {
-  const range = resolveRange(await searchParams)
+  const sp = await searchParams
+  const range = resolveRange(sp)
   const [data, funders] = await Promise.all([
-    readDashboard(range),
+    readDashboard(range, first(sp.page)),
     getFunders().catch(() => []),
   ])
 
-  // Map funding listings back to their logos by id (for clicks) and by name
-  // (for the top-listings table, which is keyed by display name).
+  // Funding listings have Airtable logos (by id for the activity feed, by name
+  // for the top-listings table). Other pages fall back to a favicon derived
+  // from each listing's most-recent click url.
   const logoById = new Map(funders.map(f => [f.id, f.logo]))
   const logoByName = new Map(funders.map(f => [f.name, f.logo]))
 
-  // Slot range each listing was clicked at during this period — stamped onto
-  // the click when it happened, so it stays accurate even as the page is
-  // reordered. Undefined for listings whose clicks predate slot tracking.
-  const positionByName = new Map(data.topFunding.map(r => [r.name, r.position]))
+  // Per-listing slot range + a url for the favicon, keyed by display name, for
+  // whichever page is selected. The slot is stamped onto the click when it
+  // happens, so it stays accurate even as the page is reordered; it's undefined
+  // for listings whose clicks predate slot tracking.
+  const positionByName = new Map(
+    data.topListings.map(r => [r.name, r.position])
+  )
+  const urlByName = new Map(data.topListings.map(r => [r.name, r.url]))
 
   return (
     <div>
@@ -189,33 +195,48 @@ export default async function AnalyticsPage({
             <Funnel funnel={data.funnel} />
           </Panel>
 
-          <div className={styles.grid}>
-            <Panel title="Clicks by page">
-              <CountTable rows={data.byPage} labelHead="Page" />
-            </Panel>
-            <Panel title="Top funding listings">
-              <CountTable
-                rows={data.topFunding}
-                labelHead="Listing"
-                rankHead="Slot"
-                logoFor={name => logoByName.get(name) ?? undefined}
-                rankFor={name => positionByName.get(name)}
-              />
-              <p className={styles.caption}>
-                Slot = where each listing was clicked this period (F1/F2 =
-                featured cards). Blank for clicks logged before slot tracking.
-              </p>
-            </Panel>
-          </div>
-
-          <Panel title="Clicks by position">
-            <CountTable rows={data.byPosition} labelHead="Slot" />
-            <p className={styles.caption}>
-              Every funding click counted at the slot it happened in, pooled
-              across all listings — so a busy top slot shows up even as
-              different listings rotate through it.
-            </p>
+          <Panel title="Clicks by page">
+            <CountTable rows={data.byPage} labelHead="Page" />
           </Panel>
+
+          <div className={styles.pageSection}>
+            <PageTabs
+              pages={data.byPage.map(p => p.name)}
+              active={data.selectedPage}
+              params={sp}
+            />
+            <div className={styles.grid}>
+              <Panel
+                title={
+                  data.selectedPage
+                    ? `Top ${data.selectedPage} listings`
+                    : 'Top listings'
+                }
+              >
+                <CountTable
+                  rows={data.topListings}
+                  labelHead="Listing"
+                  rankHead="Slot"
+                  logoFor={name =>
+                    logoByName.get(name) ?? faviconFor(urlByName.get(name))
+                  }
+                  rankFor={name => positionByName.get(name)}
+                />
+                <p className={styles.caption}>
+                  Slot = where each listing was clicked this period (F1/F2 =
+                  featured cards). Blank for clicks logged before slot tracking.
+                </p>
+              </Panel>
+              <Panel title="Clicks by position">
+                <CountTable rows={data.byPosition} labelHead="Slot" />
+                <p className={styles.caption}>
+                  Every click on this page counted at the slot it happened in —
+                  so a busy top slot shows up even as different listings rotate
+                  through it.
+                </p>
+              </Panel>
+            </div>
+          </div>
 
           <Panel title="Recent activity">
             {data.recent.length === 0 ? (
@@ -254,6 +275,44 @@ export default async function AnalyticsPage({
           </Panel>
         </>
       )}
+    </div>
+  )
+}
+
+/** Tabs that pick which resource page the listing panels drill into. Each tab
+ *  preserves the current date range and swaps only the `page` query param. */
+function PageTabs({
+  pages,
+  active,
+  params,
+}: {
+  pages: string[]
+  active: string | null
+  params: SearchParams
+}) {
+  if (pages.length <= 1) return null
+  const base = new URLSearchParams()
+  for (const [k, v] of Object.entries(params)) {
+    if (k === 'page' || v == null) continue
+    base.set(k, Array.isArray(v) ? (v[0] ?? '') : v)
+  }
+  return (
+    <div className={styles.pageTabs}>
+      {pages.map(p => {
+        const q = new URLSearchParams(base)
+        q.set('page', p)
+        return (
+          <a
+            key={p}
+            href={`?${q.toString()}`}
+            className={`${styles.pageTab}${
+              p === active ? ` ${styles.pageTabActive}` : ''
+            }`}
+          >
+            {p}
+          </a>
+        )
+      })}
     </div>
   )
 }

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -160,8 +160,11 @@ export default async function AnalyticsPage({
 }) {
   const sp = await searchParams
   const range = resolveRange(sp)
+  // Count each visitor once per listing per day by default; ?clicks=total counts
+  // every click.
+  const unique = first(sp.clicks) !== 'total'
   const [data, funders] = await Promise.all([
-    readDashboard(range, first(sp.page)),
+    readDashboard(range, first(sp.page), unique),
     getFunders().catch(() => []),
   ])
 
@@ -204,6 +207,8 @@ export default async function AnalyticsPage({
       </div>
 
       <DateRangePicker activeKey={range.key} from={range.from} to={range.to} />
+
+      <ClickModeToggle unique={unique} params={sp} />
 
       {data.error ? (
         <div className={styles.empty}>
@@ -297,6 +302,47 @@ export default async function AnalyticsPage({
           </Panel>
         </>
       )}
+    </div>
+  )
+}
+
+/** Switches the click tables between unique counts (one per visitor per listing
+ *  per day) and total counts. Unique is the default, so its link drops the param
+ *  for a clean url; both links preserve the rest of the query. */
+function ClickModeToggle({
+  unique,
+  params,
+}: {
+  unique: boolean
+  params: SearchParams
+}) {
+  const base = new URLSearchParams()
+  for (const [k, v] of Object.entries(params)) {
+    if (k === 'clicks' || v == null) continue
+    base.set(k, Array.isArray(v) ? (v[0] ?? '') : v)
+  }
+  const uniqueQ = base.toString()
+  const totalParams = new URLSearchParams(base)
+  totalParams.set('clicks', 'total')
+  return (
+    <div className={styles.clickToggle}>
+      <span className={styles.clickToggleLabel}>Count</span>
+      <a
+        href={uniqueQ ? `?${uniqueQ}` : '?'}
+        className={`${styles.clickToggleBtn}${
+          unique ? ` ${styles.clickToggleBtnActive}` : ''
+        }`}
+      >
+        Unique
+      </a>
+      <a
+        href={`?${totalParams.toString()}`}
+        className={`${styles.clickToggleBtn}${
+          !unique ? ` ${styles.clickToggleBtnActive}` : ''
+        }`}
+      >
+        Total
+      </a>
     </div>
   )
 }

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image'
 import {
   readDashboard,
   type Counted,
@@ -20,6 +21,22 @@ const SOURCE_LABEL: Record<string, string> = {
   'local-file': 'Local dev',
   none: 'No data yet',
 }
+
+// Resource pages in the same order as the site nav, each with its nav icon.
+// Keyed by the analytics `page` value (the string passed to trackListingClick).
+// Drives the order and icons of the page tabs; pages not listed here (e.g.
+// Home) sort after these, keeping their by-clicks order.
+const PAGE_NAV: { name: string; icon: string }[] = [
+  { name: 'Map', icon: 'map.svg' },
+  { name: 'Communities', icon: 'globe.svg' },
+  { name: 'Self-study', icon: 'book.svg' },
+  { name: 'Jobs', icon: 'briefcase.svg' },
+  { name: 'Funding', icon: 'coins.svg' },
+  { name: 'Media channels', icon: 'megaphone.svg' },
+  { name: 'Advisors', icon: 'person.svg' },
+  { name: 'Projects', icon: 'clipboard.svg' },
+  { name: 'Founders', icon: 'rocket.svg' },
+]
 
 // Bryce is in Colombia — fixed UTC-5, no DST — so day boundaries use -05:00.
 const TZ_OFFSET = '-05:00'
@@ -163,6 +180,15 @@ export default async function AnalyticsPage({
   )
   const urlByName = new Map(data.topListings.map(r => [r.name, r.url]))
 
+  // Page tabs in site-nav order (pages not in the nav fall to the end), each
+  // carrying its nav icon.
+  const pageOrder = new Map(PAGE_NAV.map((p, i) => [p.name, i]))
+  const iconByPage = new Map(PAGE_NAV.map(p => [p.name, p.icon]))
+  const tabPages = data.byPage
+    .map(p => p.name)
+    .sort((a, b) => (pageOrder.get(a) ?? 999) - (pageOrder.get(b) ?? 999))
+    .map(name => ({ name, icon: iconByPage.get(name) }))
+
   return (
     <div>
       <div className={styles.headerRow}>
@@ -200,11 +226,7 @@ export default async function AnalyticsPage({
           </Panel>
 
           <div className={styles.pageSection}>
-            <PageTabs
-              pages={data.byPage.map(p => p.name)}
-              active={data.selectedPage}
-              params={sp}
-            />
+            <PageTabs pages={tabPages} active={data.selectedPage} params={sp} />
             <div className={styles.grid}>
               <Panel
                 title={
@@ -286,7 +308,7 @@ function PageTabs({
   active,
   params,
 }: {
-  pages: string[]
+  pages: { name: string; icon?: string }[]
   active: string | null
   params: SearchParams
 }) {
@@ -298,18 +320,23 @@ function PageTabs({
   }
   return (
     <div className={styles.pageTabs}>
-      {pages.map(p => {
+      {pages.map(({ name, icon }) => {
         const q = new URLSearchParams(base)
-        q.set('page', p)
+        q.set('page', name)
         return (
           <a
-            key={p}
+            key={name}
             href={`?${q.toString()}`}
             className={`${styles.pageTab}${
-              p === active ? ` ${styles.pageTabActive}` : ''
+              name === active ? ` ${styles.pageTabActive}` : ''
             }`}
           >
-            {p}
+            {icon && (
+              <span className={styles.pageTabIcon}>
+                <Image src={`/images/${icon}`} alt="" width={12} height={12} />
+              </span>
+            )}
+            {name}
           </a>
         )
       })}

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -353,22 +353,31 @@ function ClickModeToggle({
 function SourceSplit({ rows }: { rows: Counted[] }) {
   if (rows.length === 0) return null
   const total = rows.reduce((sum, r) => sum + r.count, 0)
+  const hasUntracked = rows.some(r => r.name === 'Untracked')
   return (
-    <div className={styles.sourceSplit}>
-      <span className={styles.sourceSplitLabel}>Clicks by source</span>
-      {rows.map(r => (
-        <span key={r.name} className={styles.sourceStat}>
-          <span className={styles.sourceStatName}>{r.name}</span>
-          <span className={styles.sourceStatCount}>
-            {r.count.toLocaleString()}
-          </span>
-          {total > 0 && (
-            <span className={styles.sourceStatPct}>
-              {Math.round((100 * r.count) / total)}%
+    <div className={styles.sourceSplitWrap}>
+      <div className={styles.sourceSplit}>
+        <span className={styles.sourceSplitLabel}>Clicks by source</span>
+        {rows.map(r => (
+          <span key={r.name} className={styles.sourceStat}>
+            <span className={styles.sourceStatName}>{r.name}</span>
+            <span className={styles.sourceStatCount}>
+              {r.count.toLocaleString()}
             </span>
-          )}
-        </span>
-      ))}
+            {total > 0 && (
+              <span className={styles.sourceStatPct}>
+                {Math.round((100 * r.count) / total)}%
+              </span>
+            )}
+          </span>
+        ))}
+      </div>
+      {hasUntracked && (
+        <p className={styles.caption}>
+          Untracked = clicks logged before map/card source tracking started;
+          they age out as the date range moves forward.
+        </p>
+      )}
     </div>
   )
 }

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -201,6 +201,11 @@ function pct(part: number, whole: number): string {
   return whole > 0 ? `${Math.round((100 * part) / whole)}%` : '—'
 }
 
+/** A share of `total` to one decimal place, e.g. "43.2%". */
+function pct1(part: number, total: number): string {
+  return `${((100 * part) / total).toFixed(1)}%`
+}
+
 export default async function AnalyticsPage({
   searchParams,
 }: {
@@ -446,7 +451,7 @@ function SourceSplit({ rows }: { rows: Counted[] }) {
             </span>
             {total > 0 && (
               <span className={styles.sourceStatPct}>
-                {Math.round((100 * r.count) / total)}%
+                {pct1(r.count, total)}
               </span>
             )}
           </span>
@@ -572,9 +577,7 @@ function CountTable({
               </td>
               <td className={styles.numCol}>{r.count.toLocaleString()}</td>
               {showPct && (
-                <td className={styles.pctCol}>
-                  {Math.round((100 * r.count) / total)}%
-                </td>
+                <td className={styles.pctCol}>{pct1(r.count, total)}</td>
               )}
             </tr>
           )
@@ -586,7 +589,7 @@ function CountTable({
             {rankFor && <td className={styles.rankCol} />}
             <td className={styles.totalLabel}>Total</td>
             <td className={styles.numCol}>{total.toLocaleString()}</td>
-            {showPct && <td className={styles.pctCol}>100%</td>}
+            {showPct && <td className={styles.pctCol}>{pct1(total, total)}</td>}
           </tr>
         </tfoot>
       )}

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -7,6 +7,14 @@ import {
   type ChatbotFunnel,
 } from '@/lib/analytics/events'
 import { getFunders } from '@/lib/data/funding'
+import { getCourses } from '@/lib/data/self-study'
+import { getAdvisors } from '@/lib/data/advisors'
+import { getCommunities } from '@/lib/data/communities'
+import { getMediaChannels } from '@/lib/data/media-channels'
+import { getFounderResources } from '@/lib/data/founders'
+import { getJobs } from '@/lib/data/jobs'
+import { getMapData } from '@/lib/data/map'
+import { getProjects } from '@/lib/data/projects'
 import DateRangePicker from './DateRangePicker'
 import Logo from './Logo'
 import admin from '../admin.module.css'
@@ -94,6 +102,45 @@ function resolveRange(sp: SearchParams): ResolvedRange {
   }
 }
 
+/** Real Airtable logos for the selected page's listings, keyed by the exact
+ *  label each click was tracked under, so the top-listings table shows proper
+ *  logos instead of favicons. Returns an empty map (→ favicons) on any error or
+ *  for pages without listing data. */
+async function logosForPage(
+  page: string | null
+): Promise<Map<string, string | null>> {
+  try {
+    switch (page) {
+      case 'Funding':
+        return new Map((await getFunders()).map(i => [i.name, i.logo]))
+      case 'Self-study':
+        return new Map((await getCourses()).map(i => [i.name, i.image]))
+      case 'Advisors':
+        return new Map((await getAdvisors()).map(i => [i.name, i.logo]))
+      case 'Communities':
+        return new Map((await getCommunities()).map(i => [i.name, i.logo]))
+      case 'Media channels':
+        return new Map((await getMediaChannels()).map(i => [i.name, i.logo]))
+      case 'Founders':
+        return new Map(
+          (await getFounderResources()).map(i => [i.name, i.image])
+        )
+      case 'Projects':
+        return new Map((await getProjects()).map(i => [i.name, i.logo]))
+      case 'Jobs':
+        return new Map(
+          (await getJobs()).map(i => [`${i.name} – ${i.organization}`, i.logo])
+        )
+      case 'Map':
+        return new Map((await getMapData()).records.map(i => [i.title, i.logo]))
+      default:
+        return new Map()
+    }
+  } catch {
+    return new Map()
+  }
+}
+
 /** A favicon for any outbound URL — the universal fallback when a listing has
  *  no Airtable logo (or the event isn't a funding listing). */
 function faviconFor(url?: string): string | undefined {
@@ -169,11 +216,16 @@ export default async function AnalyticsPage({
     getFunders().catch(() => []),
   ])
 
-  // Funding listings have Airtable logos (by id for the activity feed, by name
-  // for the top-listings table). Other pages fall back to a favicon derived
-  // from each listing's most-recent click url.
+  // logoById drives the recent-activity feed (funding listings, by record id).
+  // logoByName drives the top-listings table for the selected page, fetched from
+  // that page's Airtable data so every page shows real logos — not just funding.
+  // Funding reuses the already-fetched funders. Anything without a logo falls
+  // back to a favicon from the click url.
   const logoById = new Map(funders.map(f => [f.id, f.logo]))
-  const logoByName = new Map(funders.map(f => [f.name, f.logo]))
+  const logoByName =
+    data.selectedPage === 'Funding'
+      ? new Map<string, string | null>(funders.map(f => [f.name, f.logo]))
+      : await logosForPage(data.selectedPage)
 
   // Per-listing slot range + a url for the favicon, keyed by display name, for
   // whichever page is selected. The slot is stamped onto the click when it

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -232,6 +232,7 @@ export default async function AnalyticsPage({
 
           <div className={styles.pageSection}>
             <PageTabs pages={tabPages} active={data.selectedPage} params={sp} />
+            <SourceSplit rows={data.bySource} />
             <div className={styles.grid}>
               <Panel
                 title={
@@ -343,6 +344,31 @@ function ClickModeToggle({
       >
         Total
       </a>
+    </div>
+  )
+}
+
+/** For pages with a map, shows how the selected page's clicks split between the
+ *  map and the cards. Renders nothing for pages without a map. */
+function SourceSplit({ rows }: { rows: Counted[] }) {
+  if (rows.length === 0) return null
+  const total = rows.reduce((sum, r) => sum + r.count, 0)
+  return (
+    <div className={styles.sourceSplit}>
+      <span className={styles.sourceSplitLabel}>Clicks by source</span>
+      {rows.map(r => (
+        <span key={r.name} className={styles.sourceStat}>
+          <span className={styles.sourceStatName}>{r.name}</span>
+          <span className={styles.sourceStatCount}>
+            {r.count.toLocaleString()}
+          </span>
+          {total > 0 && (
+            <span className={styles.sourceStatPct}>
+              {Math.round((100 * r.count) / total)}%
+            </span>
+          )}
+        </span>
+      ))}
     </div>
   )
 }

--- a/src/app/advisors/AdvisorsClient.tsx
+++ b/src/app/advisors/AdvisorsClient.tsx
@@ -8,6 +8,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { Advisor } from '@/lib/data/advisors'
 import { trackListingClick } from '@/lib/analytics'
+import { placementsById } from '@/lib/placements'
 
 interface AdvisorsClientProps {
   advisors: Advisor[]
@@ -20,6 +21,10 @@ export default function AdvisorsClient({ advisors }: AdvisorsClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedFocus, setSelectedFocus] = useState<string[]>([])
   const [selectedStatus, setSelectedStatus] = useState<string[]>(['Active'])
+
+  // Each advisor's slot in the full page order, stamped onto a click so the
+  // dashboard can tie clicks to page position even after later reordering.
+  const placements = useMemo(() => placementsById(advisors), [advisors])
 
   const filteredAdvisors = useMemo(() => {
     return advisors.filter(advisor => {
@@ -117,7 +122,13 @@ export default function AdvisorsClient({ advisors }: AdvisorsClientProps) {
               rel="noopener noreferrer"
               className="card"
               onClick={() =>
-                trackListingClick('Advisors', advisor.name, advisor.url)
+                trackListingClick(
+                  'Advisors',
+                  advisor.name,
+                  advisor.url,
+                  advisor.id,
+                  placements.get(advisor.id)
+                )
               }
             >
               <div className="flex items-center gap-16px padding-bottom-24px">

--- a/src/app/advisors/page.tsx
+++ b/src/app/advisors/page.tsx
@@ -55,6 +55,7 @@ export default async function AdvisorsPage() {
                   { label: 'Status', value: advisor.status },
                 ]}
                 trackingPage="Advisors"
+                trackingPosition={`F${advisor.featured}`}
               />
             ))}
         </div>

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -46,6 +46,7 @@ export async function POST(req: NextRequest) {
     listingId: str(b.listingId, 64),
     label: str(b.label, 300),
     position: str(b.position, 16),
+    source: str(b.source, 16),
     url: str(b.url, 600),
     ref: str(req.headers.get('referer'), 600),
     vid: str(b.vid, 64),

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -45,6 +45,7 @@ export async function POST(req: NextRequest) {
     page: str(b.page, 64),
     listingId: str(b.listingId, 64),
     label: str(b.label, 300),
+    position: str(b.position, 16),
     url: str(b.url, 600),
     ref: str(req.headers.get('referer'), 600),
     vid: str(b.vid, 64),

--- a/src/app/communities/CommunitiesClient.tsx
+++ b/src/app/communities/CommunitiesClient.tsx
@@ -9,6 +9,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { Community } from '@/lib/data/communities'
 import { trackListingClick } from '@/lib/analytics'
+import { placementsById } from '@/lib/placements'
 
 interface CommunitiesClientProps {
   communities: Community[]
@@ -38,6 +39,10 @@ export default function CommunitiesClient({
   const [platformFilters, setPlatformFilters] = useState<string[]>([])
   const [activityFilters, setActivityFilters] = useState<string[]>([])
   const [focusFilters, setFocusFilters] = useState<string[]>([])
+
+  // Each community's slot in the full page order, stamped onto a click so the
+  // dashboard can tie clicks to page position even after later reordering.
+  const placements = useMemo(() => placementsById(communities), [communities])
 
   const filteredCommunities = useMemo(() => {
     return communities.filter(community => {
@@ -239,7 +244,9 @@ export default function CommunitiesClient({
                     trackListingClick(
                       'Communities',
                       community.name,
-                      community.joinLink
+                      community.joinLink,
+                      community.id,
+                      placements.get(community.id)
                     )
                   }
                 >

--- a/src/app/communities/CommunitiesClient.tsx
+++ b/src/app/communities/CommunitiesClient.tsx
@@ -246,7 +246,8 @@ export default function CommunitiesClient({
                       community.name,
                       community.joinLink,
                       community.id,
-                      placements.get(community.id)
+                      placements.get(community.id),
+                      'cards'
                     )
                   }
                 >

--- a/src/app/communities/CommunitiesMap.tsx
+++ b/src/app/communities/CommunitiesMap.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 import styles from './page.module.css'
 import { Community } from '@/lib/data/communities'
 import { positionTooltip } from '@/lib/mapTooltip'
+import { trackListingClick } from '@/lib/analytics'
 
 interface CommunitiesMapProps {
   communities: Community[]
@@ -378,7 +379,17 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
 
         if (!isMobile()) {
           const link = feature.properties?.link || feature.properties?.url
-          if (link && link !== '#') openInNewTab(link)
+          if (link && link !== '#') {
+            trackListingClick(
+              'Communities',
+              feature.properties?.name,
+              link,
+              undefined,
+              undefined,
+              'map'
+            )
+            openInNewTab(link)
+          }
           return
         }
 
@@ -394,6 +405,10 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
 
           const link = feature.properties?.link || feature.properties?.url
           tooltip.setAttribute('data-link-url', link || '')
+          tooltip.setAttribute(
+            'data-link-title',
+            feature.properties?.name || ''
+          )
           tooltip.style.display = 'block'
         }
         updateTooltipPosition(e, tooltip, mapContainer)
@@ -410,6 +425,16 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
               resetHover()
               tappedPinId = null
             }
+            const title = tooltip.getAttribute('data-link-title')
+            if (title)
+              trackListingClick(
+                'Communities',
+                title,
+                lnk,
+                undefined,
+                undefined,
+                'map'
+              )
             openInNewTab(lnk)
           }
           e.stopPropagation()

--- a/src/app/communities/page.tsx
+++ b/src/app/communities/page.tsx
@@ -77,6 +77,7 @@ export default async function CommunitiesPage() {
                     { label: 'Focus', value: community.focus },
                   ]}
                   trackingPage="Communities"
+                  trackingPosition={`F${community.featured}`}
                 />
               ))}
           </div>

--- a/src/app/communities/page.tsx
+++ b/src/app/communities/page.tsx
@@ -78,6 +78,7 @@ export default async function CommunitiesPage() {
                   ]}
                   trackingPage="Communities"
                   trackingPosition={`F${community.featured}`}
+                  trackingSource="cards"
                 />
               ))}
           </div>

--- a/src/app/founders/FoundersClient.tsx
+++ b/src/app/founders/FoundersClient.tsx
@@ -8,6 +8,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { FounderResource } from '@/lib/data/founders'
 import { trackListingClick } from '@/lib/analytics'
+import { placementsById } from '@/lib/placements'
 
 interface FoundersClientProps {
   resources: FounderResource[]
@@ -23,6 +24,10 @@ const typeOptions = [
 export default function FoundersClient({ resources }: FoundersClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedTypes, setSelectedTypes] = useState<string[]>([])
+
+  // Each resource's slot in the full page order, stamped onto a click so the
+  // dashboard can tie clicks to page position even after later reordering.
+  const placements = useMemo(() => placementsById(resources), [resources])
 
   const filteredResources = useMemo(() => {
     return resources.filter(resource => {
@@ -99,7 +104,13 @@ export default function FoundersClient({ resources }: FoundersClientProps) {
               rel="noopener noreferrer"
               className="card"
               onClick={() =>
-                trackListingClick('Founders', resource.name, resource.website)
+                trackListingClick(
+                  'Founders',
+                  resource.name,
+                  resource.website,
+                  resource.id,
+                  placements.get(resource.id)
+                )
               }
             >
               <div className="flex items-center gap-16px padding-bottom-24px">

--- a/src/app/founders/page.tsx
+++ b/src/app/founders/page.tsx
@@ -51,6 +51,7 @@ export default async function FoundersPage() {
                 logo={resource.image ?? undefined}
                 metadata={[{ label: 'Type', value: resource.type }]}
                 trackingPage="Founders"
+                trackingPosition={`F${resource.featured}`}
               />
             ))}
         </div>

--- a/src/app/funding/FundingClient.tsx
+++ b/src/app/funding/FundingClient.tsx
@@ -8,6 +8,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { Funder } from '@/lib/data/funding'
 import { trackListingClick } from '@/lib/analytics'
+import { placementsById } from '@/lib/placements'
 
 interface FundingClientProps {
   funders: Funder[]
@@ -22,24 +23,6 @@ const typeOptions = [
   'Platform',
 ]
 
-/** Each funder's slot in the full (unfiltered) page order, keyed by record id:
- *  the two featured cards are 'F1'/'F2'; everything else is numbered '1', '2',
- *  '3'… in display order. Stamped onto a click so the slot survives later
- *  reordering. Expects `funders` in the order getFunders() returns them. */
-function fundingPlacements(funders: Funder[]): Map<string, string> {
-  const placements = new Map<string, string>()
-  let n = 0
-  for (const f of funders) {
-    if (f.featured === '1') placements.set(f.id, 'F1')
-    else if (f.featured === '2') placements.set(f.id, 'F2')
-    else {
-      n += 1
-      placements.set(f.id, String(n))
-    }
-  }
-  return placements
-}
-
 export default function FundingClient({ funders }: FundingClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedAccepting, setSelectedAccepting] = useState<string[]>([])
@@ -47,7 +30,7 @@ export default function FundingClient({ funders }: FundingClientProps) {
 
   // Each funder's slot in the full (unfiltered) page order, so a click is
   // tagged with the rank Bryce set — not its position within an active filter.
-  const placements = useMemo(() => fundingPlacements(funders), [funders])
+  const placements = useMemo(() => placementsById(funders), [funders])
 
   const filteredFunders = useMemo(() => {
     return funders.filter(funder => {

--- a/src/app/funding/FundingClient.tsx
+++ b/src/app/funding/FundingClient.tsx
@@ -22,10 +22,32 @@ const typeOptions = [
   'Platform',
 ]
 
+/** Each funder's slot in the full (unfiltered) page order, keyed by record id:
+ *  the two featured cards are 'F1'/'F2'; everything else is numbered '1', '2',
+ *  '3'… in display order. Stamped onto a click so the slot survives later
+ *  reordering. Expects `funders` in the order getFunders() returns them. */
+function fundingPlacements(funders: Funder[]): Map<string, string> {
+  const placements = new Map<string, string>()
+  let n = 0
+  for (const f of funders) {
+    if (f.featured === '1') placements.set(f.id, 'F1')
+    else if (f.featured === '2') placements.set(f.id, 'F2')
+    else {
+      n += 1
+      placements.set(f.id, String(n))
+    }
+  }
+  return placements
+}
+
 export default function FundingClient({ funders }: FundingClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedAccepting, setSelectedAccepting] = useState<string[]>([])
   const [selectedTypes, setSelectedTypes] = useState<string[]>([])
+
+  // Each funder's slot in the full (unfiltered) page order, so a click is
+  // tagged with the rank Bryce set — not its position within an active filter.
+  const placements = useMemo(() => fundingPlacements(funders), [funders])
 
   const filteredFunders = useMemo(() => {
     return funders.filter(funder => {
@@ -130,7 +152,13 @@ export default function FundingClient({ funders }: FundingClientProps) {
               rel="noopener noreferrer"
               className="card"
               onClick={() =>
-                trackListingClick('Funding', funder.name, funder.url, funder.id)
+                trackListingClick(
+                  'Funding',
+                  funder.name,
+                  funder.url,
+                  funder.id,
+                  placements.get(funder.id)
+                )
               }
             >
               <div className="flex items-center gap-16px padding-bottom-24px">

--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -55,6 +55,7 @@ export default async function FundingPage() {
                   },
                 ]}
                 trackingPage="Funding"
+                trackingPosition={`F${funder.featured}`}
               />
             ))}
         </div>

--- a/src/app/jobs/JobsClient.tsx
+++ b/src/app/jobs/JobsClient.tsx
@@ -7,6 +7,7 @@ import FilterSidebar from '@/components/FilterSidebar'
 import SearchBar from '@/components/SearchBar'
 import { Job } from '@/lib/data/jobs'
 import { trackListingClick } from '@/lib/analytics'
+import { placementsById } from '@/lib/placements'
 import { setPageContext } from '@/lib/assistant/page-context'
 
 interface JobsClientProps {
@@ -52,6 +53,10 @@ export default function JobsClient({ jobs }: JobsClientProps) {
   const [selectedRoles, setSelectedRoles] = useState<string[]>([])
   const [selectedWorkLocation, setSelectedWorkLocation] = useState<string[]>([])
   const savedScrollY = useRef<number | null>(null)
+
+  // Each job's slot in the full page order, stamped onto a click so the
+  // dashboard can tie clicks to page position even after later reordering.
+  const placements = useMemo(() => placementsById(jobs), [jobs])
 
   const filteredJobs = useMemo(() => {
     return jobs.filter(job => {
@@ -227,7 +232,9 @@ export default function JobsClient({ jobs }: JobsClientProps) {
                 trackListingClick(
                   'Jobs',
                   `${job.name} – ${job.organization}`,
-                  job.url
+                  job.url,
+                  job.id,
+                  placements.get(job.id)
                 )
               }
             >

--- a/src/app/map/D3Map.tsx
+++ b/src/app/map/D3Map.tsx
@@ -285,7 +285,14 @@ export default function D3Map({ orgs }: D3MapProps) {
               tappedOrgId = org.id
               return
             }
-            trackListingClick('Map', org.title, org.link)
+            trackListingClick(
+              'Map',
+              org.title,
+              org.link,
+              org.id,
+              undefined,
+              'map'
+            )
           })
       }
 
@@ -445,7 +452,8 @@ export default function D3Map({ orgs }: D3MapProps) {
       const link = tt.getAttribute('data-link-url')
       const title = tt.getAttribute('data-link-title')
       if (link && link !== '#') {
-        if (title) trackListingClick('Map', title, link)
+        if (title)
+          trackListingClick('Map', title, link, undefined, undefined, 'map')
         hideTooltip()
         window.open(link, '_blank')
       }

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -8,6 +8,7 @@ import FilterSidebar from '@/components/FilterSidebar'
 import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { trackListingClick } from '@/lib/analytics'
+import { placementsById } from '@/lib/placements'
 import styles from './page.module.css'
 
 const D3Map = dynamic(() => import('./D3Map'), {
@@ -80,6 +81,11 @@ export default function MapClient({
   const [showActive, setShowActive] = useState(true)
   const [showInactive, setShowInactive] = useState(false)
   const mapWrapperRef = useRef<HTMLDivElement>(null)
+
+  // Each org's slot in the list below the map, stamped onto a list click so the
+  // dashboard can tie clicks to position. (Clicks on the map itself are
+  // geographic, not ranked, so they carry no slot.)
+  const placements = useMemo(() => placementsById(orgs), [orgs])
 
   const scrollToCards = () => {
     if (!mapWrapperRef.current) return
@@ -232,7 +238,15 @@ export default function MapClient({
                   target="_blank"
                   rel="noopener noreferrer"
                   className="card"
-                  onClick={() => trackListingClick('Map', org.title, org.link)}
+                  onClick={() =>
+                    trackListingClick(
+                      'Map',
+                      org.title,
+                      org.link,
+                      org.id,
+                      placements.get(org.id)
+                    )
+                  }
                 >
                   <div className="flex items-center gap-16px padding-bottom-24px">
                     <div className="featured-img">

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -244,7 +244,8 @@ export default function MapClient({
                       org.title,
                       org.link,
                       org.id,
-                      placements.get(org.id)
+                      placements.get(org.id),
+                      'cards'
                     )
                   }
                 >

--- a/src/app/media-channels/MediaChannelsClient.tsx
+++ b/src/app/media-channels/MediaChannelsClient.tsx
@@ -8,6 +8,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { MediaChannel } from '@/lib/data/media-channels'
 import { trackListingClick } from '@/lib/analytics'
+import { placementsById } from '@/lib/placements'
 
 interface MediaChannelsClientProps {
   channels: MediaChannel[]
@@ -29,6 +30,10 @@ export default function MediaChannelsClient({
 }: MediaChannelsClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedTypes, setSelectedTypes] = useState<string[]>([])
+
+  // Each channel's slot in the full page order, stamped onto a click so the
+  // dashboard can tie clicks to page position even after later reordering.
+  const placements = useMemo(() => placementsById(channels), [channels])
 
   const filteredChannels = useMemo(() => {
     return channels.filter(channel => {
@@ -105,7 +110,13 @@ export default function MediaChannelsClient({
               rel="noopener noreferrer"
               className="card"
               onClick={() =>
-                trackListingClick('Media channels', channel.name, channel.url)
+                trackListingClick(
+                  'Media channels',
+                  channel.name,
+                  channel.url,
+                  channel.id,
+                  placements.get(channel.id)
+                )
               }
             >
               <div className="flex items-center gap-16px padding-bottom-24px">

--- a/src/app/media-channels/page.tsx
+++ b/src/app/media-channels/page.tsx
@@ -51,6 +51,7 @@ export default async function MediaChannelsPage() {
                 logo={channel.logo ?? undefined}
                 metadata={[{ label: 'Type', value: channel.type }]}
                 trackingPage="Media channels"
+                trackingPosition={`F${channel.featured}`}
               />
             ))}
         </div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -62,6 +62,7 @@ export default async function ProjectsPage() {
                   { label: 'Status', value: project.status },
                 ]}
                 trackingPage="Projects"
+                trackingPosition={`F${project.featured}`}
               />
             ))}
         </div>

--- a/src/app/self-study/SelfStudyClient.tsx
+++ b/src/app/self-study/SelfStudyClient.tsx
@@ -8,6 +8,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import type { Course } from '@/lib/data/self-study'
 import { trackListingClick } from '@/lib/analytics'
+import { placementsById } from '@/lib/placements'
 
 interface SelfStudyClientProps {
   courses: Course[]
@@ -26,6 +27,10 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategories, setSelectedCategories] = useState<string[]>([])
   const [selectedTypes, setSelectedTypes] = useState<string[]>([])
+
+  // Each course's slot in the full page order, stamped onto a click so the
+  // dashboard can tie clicks to page position even after later reordering.
+  const placements = useMemo(() => placementsById(courses), [courses])
 
   const filteredCourses = useMemo(() => {
     return courses.filter(course => {
@@ -130,7 +135,13 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
               rel="noopener noreferrer"
               className="card"
               onClick={() =>
-                trackListingClick('Self-study', course.name, course.url)
+                trackListingClick(
+                  'Self-study',
+                  course.name,
+                  course.url,
+                  course.id,
+                  placements.get(course.id)
+                )
               }
             >
               <div className="flex items-center gap-16px padding-bottom-24px">

--- a/src/app/self-study/page.tsx
+++ b/src/app/self-study/page.tsx
@@ -55,6 +55,7 @@ export default async function SelfStudyPage() {
                   { label: 'Created by', value: course.organizer },
                 ]}
                 trackingPage="Self-study"
+                trackingPosition={`F${course.featured}`}
               />
             ))}
         </div>

--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -17,6 +17,8 @@ interface FeaturedCardProps {
   trackingPage: string
   /** Slot this featured card occupies ('F1'/'F2'), recorded with the click. */
   trackingPosition?: string
+  /** Click source ('cards' on map pages), so map vs card clicks can be split. */
+  trackingSource?: string
 }
 
 export default function FeaturedCard({
@@ -28,6 +30,7 @@ export default function FeaturedCard({
   metadata,
   trackingPage,
   trackingPosition,
+  trackingSource,
 }: FeaturedCardProps) {
   const cardInner = (
     <div className={`${styles.card} ${href ? '' : styles.cardStatic}`}>
@@ -95,6 +98,7 @@ export default function FeaturedCard({
       trackingPage={trackingPage}
       trackingName={name}
       trackingPosition={trackingPosition}
+      trackingSource={trackingSource}
     >
       {cardInner}
     </TrackedLink>

--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -15,6 +15,8 @@ interface FeaturedCardProps {
   logo?: string
   metadata: MetadataField[]
   trackingPage: string
+  /** Slot this featured card occupies ('F1'/'F2'), recorded with the click. */
+  trackingPosition?: string
 }
 
 export default function FeaturedCard({
@@ -25,6 +27,7 @@ export default function FeaturedCard({
   logo,
   metadata,
   trackingPage,
+  trackingPosition,
 }: FeaturedCardProps) {
   const cardInner = (
     <div className={`${styles.card} ${href ? '' : styles.cardStatic}`}>
@@ -91,6 +94,7 @@ export default function FeaturedCard({
       className="flex flex-col-mobile"
       trackingPage={trackingPage}
       trackingName={name}
+      trackingPosition={trackingPosition}
     >
       {cardInner}
     </TrackedLink>

--- a/src/components/TrackedLink.tsx
+++ b/src/components/TrackedLink.tsx
@@ -6,6 +6,9 @@ import { trackListingClick } from '@/lib/analytics'
 interface TrackedLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   trackingPage: string
   trackingName: string
+  /** Slot the listing sits in ('F1'/'F2' or a number), recorded with the click
+   *  so the analytics dashboard can tie clicks to page position. */
+  trackingPosition?: string
   href: string
   children: ReactNode
 }
@@ -17,6 +20,7 @@ interface TrackedLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 export default function TrackedLink({
   trackingPage,
   trackingName,
+  trackingPosition,
   href,
   children,
   onClick,
@@ -26,7 +30,13 @@ export default function TrackedLink({
     <a
       href={href}
       onClick={e => {
-        trackListingClick(trackingPage, trackingName, href)
+        trackListingClick(
+          trackingPage,
+          trackingName,
+          href,
+          undefined,
+          trackingPosition
+        )
         onClick?.(e)
       }}
       {...rest}

--- a/src/components/TrackedLink.tsx
+++ b/src/components/TrackedLink.tsx
@@ -9,6 +9,9 @@ interface TrackedLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   /** Slot the listing sits in ('F1'/'F2' or a number), recorded with the click
    *  so the analytics dashboard can tie clicks to page position. */
   trackingPosition?: string
+  /** Click source ('cards' for card surfaces on map pages), so the dashboard
+   *  can separate card clicks from map clicks. */
+  trackingSource?: string
   href: string
   children: ReactNode
 }
@@ -21,6 +24,7 @@ export default function TrackedLink({
   trackingPage,
   trackingName,
   trackingPosition,
+  trackingSource,
   href,
   children,
   onClick,
@@ -35,7 +39,8 @@ export default function TrackedLink({
           trackingName,
           href,
           undefined,
-          trackingPosition
+          trackingPosition,
+          trackingSource
         )
         onClick?.(e)
       }}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -22,6 +22,9 @@ interface TrackPayload {
   label?: string
   url?: string
   listingId?: string
+  /** Slot the listing sat in when clicked ('F1'/'F2' or a number) — lets the
+   *  dashboard tie clicks to the rank that produced them. */
+  position?: string
 }
 
 const VID_KEY = 'aisafety_vid'
@@ -84,11 +87,19 @@ export function trackListingClick(
   page: string,
   name: string,
   url: string,
-  listingId?: string
+  listingId?: string,
+  position?: string
 ): void {
   if (typeof window === 'undefined') return
   window._paq?.push(['trackEvent', `Listings - ${page}`, name, url])
-  sendTrackEvent({ type: 'listing_click', page, label: name, url, listingId })
+  sendTrackEvent({
+    type: 'listing_click',
+    page,
+    label: name,
+    url,
+    listingId,
+    position,
+  })
 }
 
 /**

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -25,6 +25,9 @@ interface TrackPayload {
   /** Slot the listing sat in when clicked ('F1'/'F2' or a number) — lets the
    *  dashboard tie clicks to the rank that produced them. */
   position?: string
+  /** 'map' when the click came from a page's map (Map, Communities); left unset
+   *  for card clicks, which the dashboard treats as the default. */
+  source?: string
 }
 
 const VID_KEY = 'aisafety_vid'
@@ -88,7 +91,8 @@ export function trackListingClick(
   name: string,
   url: string,
   listingId?: string,
-  position?: string
+  position?: string,
+  source?: string
 ): void {
   if (typeof window === 'undefined') return
   window._paq?.push(['trackEvent', `Listings - ${page}`, name, url])
@@ -99,6 +103,7 @@ export function trackListingClick(
     url,
     listingId,
     position,
+    source,
   })
 }
 

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -251,6 +251,27 @@ function tallyPositions(positions: string[]): Counted[] {
     .sort((a, b) => positionSortKey(a.name) - positionSortKey(b.name))
 }
 
+/** Collapse repeat clicks so a visitor counts once per listing: keep only the
+ *  most recent click per (visitor, page, listing). Clicks with no visitor id
+ *  (e.g. private browsing, where we can't tell visitors apart) are each kept.
+ *  Expects a newest-first list, so the first time a key is seen is the most
+ *  recent click. */
+function uniqueClicks(clicks: AnalyticsEvent[]): AnalyticsEvent[] {
+  const seen = new Set<string>()
+  const out: AnalyticsEvent[] = []
+  for (const e of clicks) {
+    if (!e.vid) {
+      out.push(e)
+      continue
+    }
+    const key = `${e.vid} ${e.page ?? ''} ${listingMember(e)}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(e)
+  }
+  return out
+}
+
 /** Aggregate a newest-first event list into the dashboard view, filtered to the
  *  given date range. `selectedPageReq` chooses which resource page the
  *  per-listing panels reflect; it falls back to Funding, then the busiest page. */
@@ -266,7 +287,10 @@ function aggregate(
     if (endMs != null && t > endMs) return false
     return true
   })
-  const clicks = inRange.filter(e => e.page)
+  // Unique clicks: one per visitor per listing, so repeat clicks in a visit (or
+  // across visits) don't inflate the counts. Every click table below derives
+  // from this deduped set.
+  const clicks = uniqueClicks(inRange.filter(e => e.page))
   const usersOf = (type: string) =>
     uniqueUsers(inRange.filter(e => e.type === type))
 

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -32,6 +32,10 @@ export interface AnalyticsEvent {
    *  featured cards, otherwise its number in the list ('1', '2', …). Stamped at
    *  click time so it survives later reordering; absent on pre-feature clicks. */
   position?: string
+  /** Where on the page the click came from. Only set to 'map' on the two pages
+   *  with a map (Map, Communities) when the click is on the map itself; every
+   *  other click (cards, featured cards) is left unset and treated as a card. */
+  source?: string
   /** Destination / relevant URL. */
   url?: string
   /** Referrer path, if available. */
@@ -192,6 +196,9 @@ export interface DashboardData {
   /** `selectedPage`'s clicks bucketed by the slot they happened in, ordered F1,
    *  F2, 1, 2, 3… — answers "do higher slots draw more clicks" for that page. */
   byPosition: Counted[]
+  /** For pages with a map (Map, Communities): the selected page's clicks split
+   *  into 'Map' vs 'Cards'. Empty for pages without a map. */
+  bySource: Counted[]
   funnel: ChatbotFunnel
   recent: AnalyticsEvent[]
 }
@@ -202,9 +209,14 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   selectedPage: null,
   topListings: [],
   byPosition: [],
+  bySource: [],
   funnel: { opened: 0, typed: 0, clicked: 0 },
   recent: [],
 }
+
+/** Resource pages that have a map above their card list, so a click can come
+ *  from either surface. These are the only pages that get a source breakdown. */
+const MAP_PAGES = new Set(['Map', 'Communities'])
 
 /** What a listing click is counted under. Prefer the human label; fall back to
  *  id/url so nothing is silently dropped. */
@@ -341,6 +353,18 @@ function aggregate(
     .sort((a, b) => b.count - a.count)
     .slice(0, 15)
 
+  // Source split, only for pages with a map: clicks tagged 'map' came from the
+  // map, everything else from the cards. Honours the unique/total mode since it
+  // derives from the same deduped pageClicks.
+  let bySource: Counted[] = []
+  if (selectedPage && MAP_PAGES.has(selectedPage)) {
+    const fromMap = pageClicks.filter(e => e.source === 'map').length
+    bySource = [
+      { name: 'Map', count: fromMap },
+      { name: 'Cards', count: pageClicks.length - fromMap },
+    ]
+  }
+
   return {
     totalEvents: inRange.length,
     byPage,
@@ -349,6 +373,7 @@ function aggregate(
     byPosition: tallyPositions(
       pageClicks.map(e => e.position).filter((p): p is string => p != null)
     ),
+    bySource,
     funnel: {
       opened: usersOf('chatbot_open'),
       typed: usersOf('chatbot_message'),

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -28,6 +28,10 @@ export interface AnalyticsEvent {
   listingId?: string
   /** Human-readable label for dashboards, e.g. the listing name. */
   label?: string
+  /** The slot the listing occupied when it was clicked — 'F1'/'F2' for the two
+   *  featured cards, otherwise its number in the list ('1', '2', …). Stamped at
+   *  click time so it survives later reordering; absent on pre-feature clicks. */
+  position?: string
   /** Destination / relevant URL. */
   url?: string
   /** Referrer path, if available. */
@@ -146,6 +150,13 @@ export interface Counted {
   count: number
 }
 
+export interface FundingRow extends Counted {
+  /** Lowest–highest slot this listing was clicked at during the period (e.g.
+   *  'F1', '2', '4–8'), from positions stamped at click time. Undefined when
+   *  none of its clicks in range carry a recorded position. */
+  position?: string
+}
+
 export interface DateRange {
   /** Inclusive lower bound in epoch ms, or null for no lower bound. */
   startMs: number | null
@@ -170,7 +181,10 @@ export interface DashboardData {
   /** Total events within the selected range. */
   totalEvents: number
   byPage: Counted[]
-  topFunding: Counted[]
+  topFunding: FundingRow[]
+  /** Funding clicks bucketed by the slot they happened in, ordered F1, F2, 1,
+   *  2, 3… — answers "do higher slots draw more clicks" across all listings. */
+  byPosition: Counted[]
   funnel: ChatbotFunnel
   recent: AnalyticsEvent[]
 }
@@ -179,6 +193,7 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   totalEvents: 0,
   byPage: [],
   topFunding: [],
+  byPosition: [],
   funnel: { opened: 0, typed: 0, clicked: 0 },
   recent: [],
 }
@@ -197,6 +212,37 @@ function tally(items: string[]): Counted[] {
     .sort((a, b) => b.count - a.count)
 }
 
+/** Sort key putting the featured slots above the numbered list: F1, F2, 1, 2…
+ *  Unparseable labels sort last so a stray value never crashes the ordering. */
+function positionSortKey(p: string): number {
+  if (p === 'F1') return -2
+  if (p === 'F2') return -1
+  const n = Number(p)
+  return Number.isFinite(n) ? n : Number.MAX_SAFE_INTEGER
+}
+
+/** Compact "lowest–highest slot" label for a listing's recorded positions, e.g.
+ *  ['3','5','4'] → '3–5', ['F1','F1'] → 'F1'. Undefined for an empty set. */
+function positionRange(positions: string[]): string | undefined {
+  if (positions.length === 0) return undefined
+  const sorted = [...positions].sort(
+    (a, b) => positionSortKey(a) - positionSortKey(b)
+  )
+  const lo = sorted[0]
+  const hi = sorted[sorted.length - 1]
+  return lo === hi ? lo : `${lo}–${hi}`
+}
+
+/** Like tally(), but ordered by slot (F1, F2, 1, 2…) rather than by count, so
+ *  the by-position table reads as a ladder from top slot to bottom. */
+function tallyPositions(positions: string[]): Counted[] {
+  const m = new Map<string, number>()
+  for (const p of positions) m.set(p, (m.get(p) ?? 0) + 1)
+  return [...m.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => positionSortKey(a.name) - positionSortKey(b.name))
+}
+
 /** Aggregate a newest-first event list into the dashboard view, filtered to the
  *  given date range. */
 function aggregate(
@@ -213,12 +259,35 @@ function aggregate(
   const clicks = inRange.filter(e => e.page)
   const usersOf = (type: string) =>
     uniqueUsers(inRange.filter(e => e.type === type))
+
+  // Funding listings: total clicks per listing plus the range of slots each was
+  // clicked at (from positions stamped at click time, so it's period-accurate
+  // even as Bryce reorders the page).
+  const fundingClicks = clicks.filter(e => e.page === 'Funding')
+  const perListing = new Map<string, { count: number; positions: string[] }>()
+  for (const e of fundingClicks) {
+    const k = listingMember(e)
+    const g = perListing.get(k) ?? { count: 0, positions: [] }
+    g.count += 1
+    if (e.position) g.positions.push(e.position)
+    perListing.set(k, g)
+  }
+  const topFunding: FundingRow[] = [...perListing.entries()]
+    .map(([name, g]) => ({
+      name,
+      count: g.count,
+      position: positionRange(g.positions),
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 15)
+
   return {
     totalEvents: inRange.length,
     byPage: tally(clicks.map(e => e.page as string)),
-    topFunding: tally(
-      clicks.filter(e => e.page === 'Funding').map(e => listingMember(e))
-    ).slice(0, 15),
+    topFunding,
+    byPosition: tallyPositions(
+      fundingClicks.map(e => e.position).filter((p): p is string => p != null)
+    ),
     funnel: {
       opened: usersOf('chatbot_open'),
       typed: usersOf('chatbot_message'),

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -251,8 +251,9 @@ function tallyPositions(positions: string[]): Counted[] {
     .sort((a, b) => positionSortKey(a.name) - positionSortKey(b.name))
 }
 
-/** Collapse repeat clicks so a visitor counts once per listing: keep only the
- *  most recent click per (visitor, page, listing). Clicks with no visitor id
+/** Collapse repeat clicks so a visitor counts once per listing per day: keep
+ *  only the most recent click per (visitor, day, page, listing). The day uses
+ *  Bryce's timezone (UTC-5), matching the date-range bounds. Clicks with no id
  *  (e.g. private browsing, where we can't tell visitors apart) are each kept.
  *  Expects a newest-first list, so the first time a key is seen is the most
  *  recent click. */
@@ -264,7 +265,11 @@ function uniqueClicks(clicks: AnalyticsEvent[]): AnalyticsEvent[] {
       out.push(e)
       continue
     }
-    const key = `${e.vid} ${e.page ?? ''} ${listingMember(e)}`
+    const t = Date.parse(e.ts)
+    const day = Number.isNaN(t)
+      ? ''
+      : new Date(t - 5 * 3_600_000).toISOString().slice(0, 10)
+    const key = `${e.vid} ${day} ${e.page ?? ''} ${listingMember(e)}`
     if (seen.has(key)) continue
     seen.add(key)
     out.push(e)
@@ -274,11 +279,14 @@ function uniqueClicks(clicks: AnalyticsEvent[]): AnalyticsEvent[] {
 
 /** Aggregate a newest-first event list into the dashboard view, filtered to the
  *  given date range. `selectedPageReq` chooses which resource page the
- *  per-listing panels reflect; it falls back to Funding, then the busiest page. */
+ *  per-listing panels reflect; it falls back to Funding, then the busiest page.
+ *  `unique` (default) counts each visitor once per listing per day; pass false
+ *  to count every click. */
 function aggregate(
   all: AnalyticsEvent[],
   { startMs, endMs }: DateRange,
-  selectedPageReq?: string
+  selectedPageReq?: string,
+  unique = true
 ): Omit<DashboardData, 'source' | 'error'> {
   const inRange = all.filter(e => {
     const t = Date.parse(e.ts)
@@ -287,10 +295,11 @@ function aggregate(
     if (endMs != null && t > endMs) return false
     return true
   })
-  // Unique clicks: one per visitor per listing, so repeat clicks in a visit (or
-  // across visits) don't inflate the counts. Every click table below derives
-  // from this deduped set.
-  const clicks = uniqueClicks(inRange.filter(e => e.page))
+  // Every click table below derives from this set. In unique mode it's deduped
+  // to one click per visitor per listing per day, so repeat clicks don't inflate
+  // the counts; in total mode every click is counted.
+  const pageHits = inRange.filter(e => e.page)
+  const clicks = unique ? uniqueClicks(pageHits) : pageHits
   const usersOf = (type: string) =>
     uniqueUsers(inRange.filter(e => e.type === type))
 
@@ -363,13 +372,14 @@ function uniqueUsers(events: AnalyticsEvent[]): number {
 
 export async function readDashboard(
   range: DateRange,
-  page?: string
+  page?: string,
+  unique = true
 ): Promise<DashboardData> {
   if (store) {
     try {
       // Newest-first (lpush prepends); up to MAX_EVENTS.
       const all = await store.lrange<AnalyticsEvent>(EVENTS_KEY, 0, -1)
-      return { source: 'redis', ...aggregate(all, range, page) }
+      return { source: 'redis', ...aggregate(all, range, page, unique) }
     } catch (err) {
       // Degrade gracefully — a Redis blip must not 500 the dashboard.
       console.warn(
@@ -381,5 +391,5 @@ export async function readDashboard(
 
   const all = await readDevEvents()
   if (all.length === 0) return { source: 'none', ...EMPTY }
-  return { source: 'local-file', ...aggregate(all, range, page) }
+  return { source: 'local-file', ...aggregate(all, range, page, unique) }
 }

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -353,16 +353,26 @@ function aggregate(
     .sort((a, b) => b.count - a.count)
     .slice(0, 15)
 
-  // Source split, only for pages with a map: clicks tagged 'map' came from the
-  // map, everything else from the cards. Honours the unique/total mode since it
-  // derives from the same deduped pageClicks.
+  // Source split, only for pages with a map. Clicks are explicitly tagged 'map'
+  // or 'cards' at click time; anything untagged (logged before source tracking,
+  // or a surface we don't tag) is its own 'Untracked' bucket rather than being
+  // miscounted as a card. Honours the unique/total mode (same pageClicks). Only
+  // non-empty buckets are shown.
   let bySource: Counted[] = []
   if (selectedPage && MAP_PAGES.has(selectedPage)) {
-    const fromMap = pageClicks.filter(e => e.source === 'map').length
+    let map = 0
+    let cards = 0
+    let untracked = 0
+    for (const e of pageClicks) {
+      if (e.source === 'map') map += 1
+      else if (e.source === 'cards') cards += 1
+      else untracked += 1
+    }
     bySource = [
-      { name: 'Map', count: fromMap },
-      { name: 'Cards', count: pageClicks.length - fromMap },
-    ]
+      { name: 'Map', count: map },
+      { name: 'Cards', count: cards },
+      { name: 'Untracked', count: untracked },
+    ].filter(r => r.count > 0)
   }
 
   return {

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -150,11 +150,14 @@ export interface Counted {
   count: number
 }
 
-export interface FundingRow extends Counted {
+export interface ListingRow extends Counted {
   /** Lowest–highest slot this listing was clicked at during the period (e.g.
    *  'F1', '2', '4–8'), from positions stamped at click time. Undefined when
    *  none of its clicks in range carry a recorded position. */
   position?: string
+  /** A representative destination url (most recent click) — lets the dashboard
+   *  show a favicon for pages whose listings have no Airtable logo. */
+  url?: string
 }
 
 export interface DateRange {
@@ -181,9 +184,13 @@ export interface DashboardData {
   /** Total events within the selected range. */
   totalEvents: number
   byPage: Counted[]
-  topFunding: FundingRow[]
-  /** Funding clicks bucketed by the slot they happened in, ordered F1, F2, 1,
-   *  2, 3… — answers "do higher slots draw more clicks" across all listings. */
+  /** Which resource page the per-listing panels below reflect. Null only when
+   *  no page has any clicks in range. */
+  selectedPage: string | null
+  /** Top listings for `selectedPage`, with each one's slot range this period. */
+  topListings: ListingRow[]
+  /** `selectedPage`'s clicks bucketed by the slot they happened in, ordered F1,
+   *  F2, 1, 2, 3… — answers "do higher slots draw more clicks" for that page. */
   byPosition: Counted[]
   funnel: ChatbotFunnel
   recent: AnalyticsEvent[]
@@ -192,7 +199,8 @@ export interface DashboardData {
 const EMPTY: Omit<DashboardData, 'source'> = {
   totalEvents: 0,
   byPage: [],
-  topFunding: [],
+  selectedPage: null,
+  topListings: [],
   byPosition: [],
   funnel: { opened: 0, typed: 0, clicked: 0 },
   recent: [],
@@ -244,10 +252,12 @@ function tallyPositions(positions: string[]): Counted[] {
 }
 
 /** Aggregate a newest-first event list into the dashboard view, filtered to the
- *  given date range. */
+ *  given date range. `selectedPageReq` chooses which resource page the
+ *  per-listing panels reflect; it falls back to Funding, then the busiest page. */
 function aggregate(
   all: AnalyticsEvent[],
-  { startMs, endMs }: DateRange
+  { startMs, endMs }: DateRange,
+  selectedPageReq?: string
 ): Omit<DashboardData, 'source' | 'error'> {
   const inRange = all.filter(e => {
     const t = Date.parse(e.ts)
@@ -260,33 +270,51 @@ function aggregate(
   const usersOf = (type: string) =>
     uniqueUsers(inRange.filter(e => e.type === type))
 
-  // Funding listings: total clicks per listing plus the range of slots each was
+  const byPage = tally(clicks.map(e => e.page as string))
+  const pageNames = byPage.map(p => p.name)
+  // The page the listing panels drill into: the requested one if it has data,
+  // else Funding (Bryce's main interest), else the busiest page.
+  const selectedPage =
+    selectedPageReq && pageNames.includes(selectedPageReq)
+      ? selectedPageReq
+      : pageNames.includes('Funding')
+        ? 'Funding'
+        : (pageNames[0] ?? null)
+
+  // For the selected page: total clicks per listing, the range of slots each was
   // clicked at (from positions stamped at click time, so it's period-accurate
-  // even as Bryce reorders the page).
-  const fundingClicks = clicks.filter(e => e.page === 'Funding')
-  const perListing = new Map<string, { count: number; positions: string[] }>()
-  for (const e of fundingClicks) {
+  // even as the page is reordered), and a representative url for its favicon.
+  const pageClicks = clicks.filter(e => e.page === selectedPage)
+  const perListing = new Map<
+    string,
+    { count: number; positions: string[]; url?: string }
+  >()
+  for (const e of pageClicks) {
+    // pageClicks is newest-first, so the first url we see is the most recent.
     const k = listingMember(e)
-    const g = perListing.get(k) ?? { count: 0, positions: [] }
+    const g = perListing.get(k) ?? { count: 0, positions: [], url: e.url }
     g.count += 1
     if (e.position) g.positions.push(e.position)
+    if (!g.url && e.url) g.url = e.url
     perListing.set(k, g)
   }
-  const topFunding: FundingRow[] = [...perListing.entries()]
+  const topListings: ListingRow[] = [...perListing.entries()]
     .map(([name, g]) => ({
       name,
       count: g.count,
       position: positionRange(g.positions),
+      url: g.url,
     }))
     .sort((a, b) => b.count - a.count)
     .slice(0, 15)
 
   return {
     totalEvents: inRange.length,
-    byPage: tally(clicks.map(e => e.page as string)),
-    topFunding,
+    byPage,
+    selectedPage,
+    topListings,
     byPosition: tallyPositions(
-      fundingClicks.map(e => e.position).filter((p): p is string => p != null)
+      pageClicks.map(e => e.position).filter((p): p is string => p != null)
     ),
     funnel: {
       opened: usersOf('chatbot_open'),
@@ -309,12 +337,15 @@ function uniqueUsers(events: AnalyticsEvent[]): number {
   return seen.size + anon
 }
 
-export async function readDashboard(range: DateRange): Promise<DashboardData> {
+export async function readDashboard(
+  range: DateRange,
+  page?: string
+): Promise<DashboardData> {
   if (store) {
     try {
       // Newest-first (lpush prepends); up to MAX_EVENTS.
       const all = await store.lrange<AnalyticsEvent>(EVENTS_KEY, 0, -1)
-      return { source: 'redis', ...aggregate(all, range) }
+      return { source: 'redis', ...aggregate(all, range, page) }
     } catch (err) {
       // Degrade gracefully — a Redis blip must not 500 the dashboard.
       console.warn(
@@ -326,5 +357,5 @@ export async function readDashboard(range: DateRange): Promise<DashboardData> {
 
   const all = await readDevEvents()
   if (all.length === 0) return { source: 'none', ...EMPTY }
-  return { source: 'local-file', ...aggregate(all, range) }
+  return { source: 'local-file', ...aggregate(all, range, page) }
 }

--- a/src/lib/placements.ts
+++ b/src/lib/placements.ts
@@ -1,0 +1,29 @@
+// Shared, dependency-free helper for tagging a resource-page listing with the
+// slot it sits in, so a click can be stamped with the rank that produced it.
+// Kept in its own module (no server-only imports) so client components can use
+// it without pulling Airtable/Node code into the browser bundle.
+
+/** A listing that may be one of the two featured cards on a resource page. */
+interface Placeable {
+  id: string
+  featured?: '1' | '2' | null
+}
+
+/** Each listing's slot on its page, keyed by record id: the two featured cards
+ *  (if the page has them) are 'F1'/'F2'; everything else is numbered '1', '2',
+ *  '3'… in display order. Pages without featured cards just get the numbered
+ *  list. Pass items in the order they render so the slot matches what the
+ *  visitor saw. */
+export function placementsById(items: Placeable[]): Map<string, string> {
+  const placements = new Map<string, string>()
+  let n = 0
+  for (const item of items) {
+    if (item.featured === '1') placements.set(item.id, 'F1')
+    else if (item.featured === '2') placements.set(item.id, 'F2')
+    else {
+      n += 1
+      placements.set(item.id, String(n))
+    }
+  }
+  return placements
+}


### PR DESCRIPTION
Adds click-position and source insight to the resource-page analytics on `/admin/analytics`.

**Position tracking**
- Every listing click records the slot it was clicked in — `F1`/`F2` for featured cards, otherwise the listing's number — stamped at click time so it survives reordering. Covers all ranked list pages (funding, jobs, communities, advisors, self-study, media channels, founders, and the list under `/map`).
- Per page, the dashboard shows a **Top \<page\> listings** table with each listing's slot range for the period, and a **Clicks by position** panel pooling clicks by slot.

**Page selector**
- A tab row (in site-nav order, with the site's nav icons) picks which page the panels drill into; defaults to Funding.

**Unique vs total**
- A **Count: Unique | Total** toggle. Unique (default) counts each visitor once per listing per day; total counts every click.

**Map vs cards**
- On the two pages with a map (Map, Communities), map-surface clicks are tagged `source=map`, and a **Clicks by source** split shows Map vs Cards. The `/communities` map previously had no click tracking at all — added.

**Notes**
- Position/source only apply to clicks from this change onward; older clicks show a dash / count as cards.
- Slot reflects the listing's rank in the full default page order, not within an active filter.

_PR description written by Claude Code._