### PR TITLE
Analytics dashboard: exclude-my-activity, tabbed views, source filtering & polish

### DIFF
--- a/src/app/admin/analytics/DateRangePicker.tsx
+++ b/src/app/admin/analytics/DateRangePicker.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRouter, usePathname } from 'next/navigation'
+import { useRouter, usePathname, useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 import styles from './analytics.module.css'
 
@@ -23,18 +23,32 @@ export default function DateRangePicker({
 }) {
   const router = useRouter()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const [customFrom, setCustomFrom] = useState(from ?? '')
   const [customTo, setCustomTo] = useState(to ?? '')
 
+  // Keep the rest of the query (active tab, count mode, source filter) when the
+  // date changes — only the date params (range/from/to) get swapped, so changing
+  // the range no longer kicks you back to the Overview tab.
+  const carryOver = () => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.delete('range')
+    params.delete('from')
+    params.delete('to')
+    return params
+  }
+
   const setPreset = (key: string) => {
-    router.push(`${pathname}?range=${key}`)
+    const params = carryOver()
+    params.set('range', key)
+    router.push(`${pathname}?${params.toString()}`)
   }
   const applyCustom = () => {
-    const params = new URLSearchParams()
+    const params = carryOver()
     if (customFrom) params.set('from', customFrom)
     if (customTo) params.set('to', customTo)
     const qs = params.toString()
-    if (qs) router.push(`${pathname}?${qs}`)
+    router.push(qs ? `${pathname}?${qs}` : pathname)
   }
 
   return (

--- a/src/app/admin/analytics/ExcludeToggle.tsx
+++ b/src/app/admin/analytics/ExcludeToggle.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { isTrackingOptedOut, setTrackingOptOut } from '@/lib/analytics'
+import styles from './analytics.module.css'
+
+// The opt-out flag lives in localStorage (a browser-only store), so we read it
+// through useSyncExternalStore: that's the sanctioned way to subscribe to state
+// outside React and it gives a clean server snapshot for SSR. The native
+// 'storage' event only fires in *other* tabs, so we also keep an in-tab
+// listener set and ping it whenever this tab flips the flag.
+const listeners = new Set<() => void>()
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb)
+  if (typeof window !== 'undefined') window.addEventListener('storage', cb)
+  return () => {
+    listeners.delete(cb)
+    if (typeof window !== 'undefined') window.removeEventListener('storage', cb)
+  }
+}
+
+function setFlag(next: boolean): void {
+  setTrackingOptOut(next)
+  listeners.forEach(cb => cb())
+}
+
+/** One-time control for the owner to keep their own activity out of these stats
+ *  on the current browser. The choice is stored in this browser's localStorage
+ *  (not matched on IP — the owner moves countries monthly, so an IP filter
+ *  wouldn't stick), so it's set once per device. It also shows whether *this*
+ *  device is currently excluded, since that state is otherwise invisible. */
+export default function ExcludeToggle() {
+  const optedOut = useSyncExternalStore(
+    subscribe,
+    () => isTrackingOptedOut(), // client: read the flag from localStorage
+    () => false // server: no localStorage, assume counted
+  )
+
+  return (
+    <div className={styles.excludeRow}>
+      {optedOut ? (
+        <>
+          <span className={styles.excludeStatusOn}>
+            ✓ This browser is excluded from these stats.
+          </span>
+          <button
+            type="button"
+            className={styles.excludeUndo}
+            onClick={() => setFlag(false)}
+          >
+            Undo
+          </button>
+        </>
+      ) : (
+        <>
+          <span className={styles.excludeStatus}>
+            This browser is counted in these stats.
+          </span>
+          <button
+            type="button"
+            className={styles.clickToggleBtn}
+            onClick={() => setFlag(true)}
+          >
+            Exclude this browser
+          </button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/analytics/ExcludeToggle.tsx
+++ b/src/app/admin/analytics/ExcludeToggle.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useSyncExternalStore } from 'react'
-import { isTrackingOptedOut, setTrackingOptOut } from '@/lib/analytics'
+import { getTrackingOptOut, setTrackingOptOut } from '@/lib/analytics'
 import styles from './analytics.module.css'
 
 // The opt-out flag lives in localStorage (a browser-only store), so we read it
@@ -25,47 +25,56 @@ function setFlag(next: boolean): void {
   listeners.forEach(cb => cb())
 }
 
-/** One-time control for the owner to keep their own activity out of these stats
- *  on the current browser. The choice is stored in this browser's localStorage
- *  (not matched on IP — the owner moves countries monthly, so an IP filter
- *  wouldn't stick), so it's set once per device. It also shows whether *this*
- *  device is currently excluded, since that state is otherwise invisible. */
+/** Format an ISO timestamp as "22 Jun 2026" (day-month-year, browser-local). */
+function formatSince(iso: string): string | undefined {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return undefined
+  return d.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+/** Small header control for the owner to keep their own activity out of these
+ *  stats on the current browser. Stored in localStorage (set once per device,
+ *  not matched on IP — the owner moves countries monthly). It only applies going
+ *  forward: when excluded it shows the date it stopped recording this browser,
+ *  and earlier visits stay counted. */
 export default function ExcludeToggle() {
-  const optedOut = useSyncExternalStore(
-    subscribe,
-    () => isTrackingOptedOut(), // client: read the flag from localStorage
-    () => false // server: no localStorage, assume counted
-  )
+  const marker = useSyncExternalStore(subscribe, getTrackingOptOut, () => '')
+  const optedOut = marker !== ''
+  const since = optedOut ? formatSince(marker) : undefined
+
+  if (optedOut) {
+    return (
+      <span className={styles.excludeMeta}>
+        <span
+          className={styles.excludeMetaOn}
+          title="Only affects visits from now on — earlier visits stay counted."
+        >
+          ✓ Not recording this browser{since ? ` since ${since}` : ''}
+        </span>
+        <button
+          type="button"
+          className={styles.excludeLink}
+          onClick={() => setFlag(false)}
+        >
+          Undo
+        </button>
+      </span>
+    )
+  }
 
   return (
-    <div className={styles.excludeRow}>
-      {optedOut ? (
-        <>
-          <span className={styles.excludeStatusOn}>
-            ✓ This browser is excluded from these stats.
-          </span>
-          <button
-            type="button"
-            className={styles.excludeUndo}
-            onClick={() => setFlag(false)}
-          >
-            Undo
-          </button>
-        </>
-      ) : (
-        <>
-          <span className={styles.excludeStatus}>
-            This browser is counted in these stats.
-          </span>
-          <button
-            type="button"
-            className={styles.clickToggleBtn}
-            onClick={() => setFlag(true)}
-          >
-            Exclude this browser
-          </button>
-        </>
-      )}
-    </div>
+    <span className={styles.excludeMeta}>
+      <button
+        type="button"
+        className={styles.excludeLink}
+        onClick={() => setFlag(true)}
+      >
+        Exclude this browser
+      </button>
+    </span>
   )
 }

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -459,6 +459,22 @@
   object-fit: contain;
 }
 
+/* Wraps a row's logo to link out to the listing. Sized to the logo so the row
+   stays aligned; the name text beside it is intentionally left unlinked so it
+   can still be selected and copied. */
+.logoLink {
+  display: inline-flex;
+  flex-shrink: 0;
+  line-height: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity var(--hover-transition);
+}
+
+.logoLink:hover {
+  opacity: 0.75;
+}
+
 .logoFallback {
   display: inline-block;
   background-color: var(--teal-800);

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -313,8 +313,17 @@
 .pageTabs {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 4px;
   margin-bottom: 16px;
+}
+
+/* Separates the two overview tabs from the resource-page tabs. */
+.tabDivider {
+  width: 1px;
+  align-self: stretch;
+  margin: 2px 6px;
+  background-color: var(--teal-800);
 }
 
 .pageTab {

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -184,14 +184,12 @@
 
 .clickToggleBtn {
   padding: 4px 12px;
-  font: inherit;
   font-size: 13px;
   color: var(--teal-300);
   background-color: transparent;
   border: 1px solid var(--teal-800);
   border-radius: 6px;
   text-decoration: none;
-  cursor: pointer;
   transition:
     color var(--hover-transition),
     background-color var(--hover-transition);
@@ -209,30 +207,23 @@
   border-color: var(--bright-teal-300);
 }
 
-/* ─── Exclude-my-activity control ─────────────────────────────────────── */
+/* ─── Exclude-my-activity control (in the header meta row) ─────────────── */
 
-.excludeRow {
-  display: flex;
+.excludeMeta {
+  display: inline-flex;
   align-items: center;
-  gap: 10px;
-  min-height: 28px;
-  margin: -8px 0 24px;
-  font-size: 13px;
+  gap: 6px;
+  font-size: 12px;
 }
 
-.excludeStatus {
-  color: var(--teal-400);
-}
-
-.excludeStatusOn {
+.excludeMetaOn {
   color: var(--bright-teal-300);
 }
 
-.excludeUndo {
+.excludeLink {
   padding: 0;
   font: inherit;
-  font-size: 13px;
-  color: var(--teal-300);
+  color: var(--teal-400);
   background: none;
   border: none;
   text-decoration: underline;
@@ -240,7 +231,7 @@
   transition: color var(--hover-transition);
 }
 
-.excludeUndo:hover {
+.excludeLink:hover {
   color: var(--white);
 }
 

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -184,12 +184,14 @@
 
 .clickToggleBtn {
   padding: 4px 12px;
+  font: inherit;
   font-size: 13px;
   color: var(--teal-300);
   background-color: transparent;
   border: 1px solid var(--teal-800);
   border-radius: 6px;
   text-decoration: none;
+  cursor: pointer;
   transition:
     color var(--hover-transition),
     background-color var(--hover-transition);
@@ -205,6 +207,41 @@
   color: var(--teal-900);
   background-color: var(--bright-teal-300);
   border-color: var(--bright-teal-300);
+}
+
+/* ─── Exclude-my-activity control ─────────────────────────────────────── */
+
+.excludeRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 28px;
+  margin: -8px 0 24px;
+  font-size: 13px;
+}
+
+.excludeStatus {
+  color: var(--teal-400);
+}
+
+.excludeStatusOn {
+  color: var(--bright-teal-300);
+}
+
+.excludeUndo {
+  padding: 0;
+  font: inherit;
+  font-size: 13px;
+  color: var(--teal-300);
+  background: none;
+  border: none;
+  text-decoration: underline;
+  cursor: pointer;
+  transition: color var(--hover-transition);
+}
+
+.excludeUndo:hover {
+  color: var(--white);
 }
 
 /* ─── Clicks-by-source split (map pages) ──────────────────────────────── */

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -280,6 +280,30 @@
   font-variant-numeric: tabular-nums;
 }
 
+.sourceStatLink {
+  text-decoration: none;
+  transition:
+    background-color var(--hover-transition),
+    border-color var(--hover-transition);
+}
+
+.sourceStatLink:hover {
+  background-color: var(--teal-800);
+}
+
+.sourceStatActive,
+.sourceStatActive:hover {
+  background-color: var(--bright-teal-300);
+  border-color: var(--bright-teal-300);
+}
+
+/* On the active (light) pill, recolor every part for contrast. */
+.sourceStatActive .sourceStatName,
+.sourceStatActive .sourceStatCount,
+.sourceStatActive .sourceStatPct {
+  color: var(--teal-900);
+}
+
 /* ─── Per-page drill-down ─────────────────────────────────────────────── */
 
 .pageSection {

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -382,6 +382,7 @@ export default async function AnalyticsPage({
                     logoFor={name =>
                       logoByName.get(name) ?? faviconFor(urlByName.get(name))
                     }
+                    linkFor={name => urlByName.get(name)}
                     rankFor={name => positionByName.get(name)}
                     total={listingTotal}
                   />
@@ -654,6 +655,7 @@ function CountTable({
   labelHead,
   rankHead = '#',
   logoFor,
+  linkFor,
   rankFor,
   total,
 }: {
@@ -661,6 +663,10 @@ function CountTable({
   labelHead: string
   rankHead?: string
   logoFor?: (name: string) => string | undefined
+  /** Destination url for a row's logo. When set, the logo becomes a link to the
+   *  listing; the name text is deliberately left unlinked so it stays
+   *  selectable/copyable. */
+  linkFor?: (name: string) => string | undefined
   rankFor?: (name: string) => string | undefined
   /** When set, adds a % column (each row's share of this total) and a Total
    *  footer row. The total is the denominator, so for a sliced "top N" table it
@@ -683,6 +689,7 @@ function CountTable({
         {rows.map((r, i) => {
           const rank = rankFor?.(r.name)
           const featured = rank?.startsWith('F')
+          const href = linkFor?.(r.name)
           return (
             <tr key={i}>
               {rankFor && (
@@ -695,7 +702,20 @@ function CountTable({
                 </td>
               )}
               <td className={styles.nameCell}>
-                {logoFor && <Logo src={logoFor(r.name)} />}
+                {logoFor &&
+                  (href && href !== '#' ? (
+                    <a
+                      className={styles.logoLink}
+                      href={href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={`Open ${r.name}`}
+                    >
+                      <Logo src={logoFor(r.name)} />
+                    </a>
+                  ) : (
+                    <Logo src={logoFor(r.name)} />
+                  ))}
                 <span>{r.name}</span>
               </td>
               <td className={styles.numCol}>{r.count.toLocaleString()}</td>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -47,14 +47,15 @@ const PAGE_NAV: { name: string; label: string; icon: string }[] = [
   { name: 'Funding', label: 'Funding', icon: 'coins.svg' },
   { name: 'Media channels', label: 'Media channels', icon: 'megaphone.svg' },
   { name: 'Advisors', label: 'Advisors', icon: 'person.svg' },
-  { name: 'Projects', label: 'Volunteer projects', icon: 'clipboard.svg' },
+  // Volunteer projects has no trackable clicks (its cards are plain text with no
+  // links), so it gets no tab. If it's ever tracked, add it back here.
   { name: 'Founders', label: 'Founder toolkit', icon: 'rocket.svg' },
 ]
 
 // The two non-page tabs that lead the tab bar. Their keys are reserved, so a
 // resource page can never collide with them.
 const OVERVIEW_TABS: { key: string; label: string }[] = [
-  { key: 'pages', label: 'Clicks by page' },
+  { key: 'pages', label: 'Overview' },
   { key: 'funnel', label: 'Chatbot funnel' },
 ]
 const OVERVIEW_KEYS = new Set(OVERVIEW_TABS.map(t => t.key))
@@ -308,7 +309,7 @@ export default async function AnalyticsPage({
   return (
     <div>
       <div className={styles.headerRow}>
-        <h1 className={admin.pageTitle}>Overview</h1>
+        <h1 className={admin.pageTitle}>Analytics</h1>
         <div className={styles.meta}>
           <span className={styles.badge}>
             {SOURCE_LABEL[data.source] ?? data.source}
@@ -406,41 +407,44 @@ export default async function AnalyticsPage({
             </div>
           )}
 
-          <Panel title="Recent activity">
-            {data.recent.length === 0 ? (
-              <p className={styles.dim}>No recent events.</p>
-            ) : (
-              <ul className={styles.recent}>
-                {data.recent.map((e, i) => (
-                  <li key={i} className={styles.recentItem}>
-                    <span className={styles.recentTime}>
-                      {formatTime(e.ts)}
-                    </span>
-                    {pillFor(e) && (
-                      <span className={styles.pill}>{pillFor(e)}</span>
-                    )}
-                    <Logo
-                      src={
-                        (e.listingId ? logoById.get(e.listingId) : undefined) ??
-                        faviconFor(e.url)
-                      }
-                    />
-                    <span className={styles.recentLabel}>{labelFor(e)}</span>
-                    {e.url && e.url !== '#' && (
-                      <a
-                        className={styles.recentUrl}
-                        href={e.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {prettyUrl(e.url)}
-                      </a>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </Panel>
+          {activeTab === 'pages' && (
+            <Panel title="Recent activity">
+              {data.recent.length === 0 ? (
+                <p className={styles.dim}>No recent events.</p>
+              ) : (
+                <ul className={styles.recent}>
+                  {data.recent.map((e, i) => (
+                    <li key={i} className={styles.recentItem}>
+                      <span className={styles.recentTime}>
+                        {formatTime(e.ts)}
+                      </span>
+                      {pillFor(e) && (
+                        <span className={styles.pill}>{pillFor(e)}</span>
+                      )}
+                      <Logo
+                        src={
+                          (e.listingId
+                            ? logoById.get(e.listingId)
+                            : undefined) ?? faviconFor(e.url)
+                        }
+                      />
+                      <span className={styles.recentLabel}>{labelFor(e)}</span>
+                      {e.url && e.url !== '#' && (
+                        <a
+                          className={styles.recentUrl}
+                          href={e.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {prettyUrl(e.url)}
+                        </a>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Panel>
+          )}
         </>
       )}
     </div>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -16,6 +16,7 @@ import { getJobs } from '@/lib/data/jobs'
 import { getMapData } from '@/lib/data/map'
 import { getProjects } from '@/lib/data/projects'
 import DateRangePicker from './DateRangePicker'
+import ExcludeToggle from './ExcludeToggle'
 import Logo from './Logo'
 import admin from '../admin.module.css'
 import styles from './analytics.module.css'
@@ -275,6 +276,8 @@ export default async function AnalyticsPage({
       <DateRangePicker activeKey={range.key} from={range.from} to={range.to} />
 
       <ClickModeToggle unique={unique} params={sp} />
+
+      <ExcludeToggle />
 
       {data.error ? (
         <div className={styles.empty}>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -270,14 +270,13 @@ export default async function AnalyticsPage({
           <span className={styles.total}>
             {data.totalEvents.toLocaleString()} events
           </span>
+          <ExcludeToggle />
         </div>
       </div>
 
       <DateRangePicker activeKey={range.key} from={range.from} to={range.to} />
 
       <ClickModeToggle unique={unique} params={sp} />
-
-      <ExcludeToggle />
 
       {data.error ? (
         <div className={styles.empty}>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -32,21 +32,32 @@ const SOURCE_LABEL: Record<string, string> = {
   none: 'No data yet',
 }
 
-// Resource pages in the same order as the site nav, each with its nav icon.
-// Keyed by the analytics `page` value (the string passed to trackListingClick).
-// Drives the order and icons of the page tabs; pages not listed here (e.g.
-// Home) sort after these, keeping their by-clicks order.
-const PAGE_NAV: { name: string; icon: string }[] = [
-  { name: 'Map', icon: 'map.svg' },
-  { name: 'Communities', icon: 'globe.svg' },
-  { name: 'Self-study', icon: 'book.svg' },
-  { name: 'Jobs', icon: 'briefcase.svg' },
-  { name: 'Funding', icon: 'coins.svg' },
-  { name: 'Media channels', icon: 'megaphone.svg' },
-  { name: 'Advisors', icon: 'person.svg' },
-  { name: 'Projects', icon: 'clipboard.svg' },
-  { name: 'Founders', icon: 'rocket.svg' },
+// Resource pages in the same order as the site nav. `name` is the analytics
+// `page` value (the string passed to trackListingClick) and the tab key; `label`
+// is the page's name on the live site (from Navigation.tsx) so the tabs read the
+// way visitors see them — e.g. the 'Founders' page is labelled "Founder toolkit".
+// Drives the order, labels, and icons of the page tabs; every page listed here
+// always gets a tab (even with no clicks yet). Pages not listed (e.g. Home) sort
+// after these, keeping their by-clicks order and showing their raw name.
+const PAGE_NAV: { name: string; label: string; icon: string }[] = [
+  { name: 'Map', label: 'Field map', icon: 'map.svg' },
+  { name: 'Communities', label: 'Communities', icon: 'globe.svg' },
+  { name: 'Self-study', label: 'Self-study', icon: 'book.svg' },
+  { name: 'Jobs', label: 'Jobs', icon: 'briefcase.svg' },
+  { name: 'Funding', label: 'Funding', icon: 'coins.svg' },
+  { name: 'Media channels', label: 'Media channels', icon: 'megaphone.svg' },
+  { name: 'Advisors', label: 'Advisors', icon: 'person.svg' },
+  { name: 'Projects', label: 'Volunteer projects', icon: 'clipboard.svg' },
+  { name: 'Founders', label: 'Founder toolkit', icon: 'rocket.svg' },
 ]
+
+// The two non-page tabs that lead the tab bar. Their keys are reserved, so a
+// resource page can never collide with them.
+const OVERVIEW_TABS: { key: string; label: string }[] = [
+  { key: 'pages', label: 'Clicks by page' },
+  { key: 'funnel', label: 'Chatbot funnel' },
+]
+const OVERVIEW_KEYS = new Set(OVERVIEW_TABS.map(t => t.key))
 
 // Bryce is in Colombia — fixed UTC-5, no DST — so day boundaries use -05:00.
 const TZ_OFFSET = '-05:00'
@@ -217,19 +228,58 @@ export default async function AnalyticsPage({
   // Count each visitor once per listing per day by default; ?clicks=total counts
   // every click.
   const unique = first(sp.clicks) !== 'total'
+
+  // The dashboard is tabbed: two overview tabs (the funnel and the by-page
+  // table) plus one tab per resource page. `tab` holds the active tab — an
+  // overview key, or a resource page's analytics name. A resource tab is the
+  // page we ask the store to drill into; the overview tabs need no page.
+  const tabReq = first(sp.tab)
+  const onResourceTab = tabReq != null && !OVERVIEW_KEYS.has(tabReq)
+
   const [data, funders] = await Promise.all([
-    readDashboard(range, first(sp.page), unique, first(sp.source)),
+    readDashboard(
+      range,
+      onResourceTab ? tabReq : undefined,
+      unique,
+      first(sp.source)
+    ),
     getFunders().catch(() => []),
   ])
+
+  // Resource-page tabs: every page in PAGE_NAV always gets one (so quiet pages
+  // like Projects still appear), plus any other page that has clicks (e.g.
+  // Home). Ordered Home first, then site-nav order, then the rest.
+  const pageOrder = new Map(PAGE_NAV.map((p, i) => [p.name, i]))
+  const labelByPage = new Map(PAGE_NAV.map(p => [p.name, p.label]))
+  const iconByPage = new Map(PAGE_NAV.map(p => [p.name, p.icon]))
+  const orderOf = (name: string) =>
+    name === 'Home' ? -1 : (pageOrder.get(name) ?? 999)
+  const resourceNames = [
+    ...new Set([...PAGE_NAV.map(p => p.name), ...data.byPage.map(p => p.name)]),
+  ].sort((a, b) => orderOf(a) - orderOf(b))
+  const resourceTabs = resourceNames.map(name => ({
+    key: name,
+    label: labelByPage.get(name) ?? name,
+    icon: iconByPage.get(name),
+  }))
+
+  // Resolve the active tab: the requested one if it's a real tab, else the
+  // default overview ('pages'). onResourceView gates the per-page panels.
+  const tabKeys = new Set<string>([...OVERVIEW_KEYS, ...resourceNames])
+  const activeTab = tabReq && tabKeys.has(tabReq) ? tabReq : 'pages'
+  const onResourceView = !OVERVIEW_KEYS.has(activeTab)
+  const selectedLabel = data.selectedPage
+    ? (labelByPage.get(data.selectedPage) ?? data.selectedPage)
+    : null
 
   // logoById drives the recent-activity feed (funding listings, by record id).
   // logoByName drives the top-listings table for the selected page, fetched from
   // that page's Airtable data so every page shows real logos — not just funding.
-  // Funding reuses the already-fetched funders. Anything without a logo falls
-  // back to a favicon from the click url.
+  // Funding reuses the already-fetched funders. Only needed on a resource view.
   const logoById = new Map(funders.map(f => [f.id, f.logo]))
-  const logoByName =
-    data.selectedPage === 'Funding'
+  const logoByName = !onResourceView
+    ? new Map<string, string | null>()
+    : data.selectedPage === 'Funding'
       ? new Map<string, string | null>(funders.map(f => [f.name, f.logo]))
       : await logosForPage(data.selectedPage)
 
@@ -241,17 +291,6 @@ export default async function AnalyticsPage({
     data.topListings.map(r => [r.name, r.position])
   )
   const urlByName = new Map(data.topListings.map(r => [r.name, r.url]))
-
-  // Page tabs: Home first, then the resource pages in site-nav order, then any
-  // other pages. Each carries its nav icon where it has one.
-  const pageOrder = new Map(PAGE_NAV.map((p, i) => [p.name, i]))
-  const iconByPage = new Map(PAGE_NAV.map(p => [p.name, p.icon]))
-  const orderOf = (name: string) =>
-    name === 'Home' ? -1 : (pageOrder.get(name) ?? 999)
-  const tabPages = data.byPage
-    .map(p => p.name)
-    .sort((a, b) => orderOf(a) - orderOf(b))
-    .map(name => ({ name, icon: iconByPage.get(name) }))
 
   // Chart totals (also the % denominators). The listings total is the selected
   // page's whole click count, not just the visible top-15 rows.
@@ -297,62 +336,75 @@ export default async function AnalyticsPage({
         </div>
       ) : (
         <>
-          <Panel title="Chatbot funnel · unique users">
-            <Funnel funnel={data.funnel} />
-          </Panel>
+          <DashboardTabs
+            overview={OVERVIEW_TABS}
+            pages={resourceTabs}
+            active={activeTab}
+            params={sp}
+          />
 
-          <Panel title="Clicks by page">
-            <CountTable
-              rows={data.byPage}
-              labelHead="Page"
-              total={totalClicks}
-            />
-          </Panel>
+          {activeTab === 'funnel' && (
+            <Panel title="Chatbot funnel · unique users">
+              <Funnel funnel={data.funnel} />
+            </Panel>
+          )}
 
-          <div className={styles.pageSection}>
-            <PageTabs pages={tabPages} active={data.selectedPage} params={sp} />
-            <SourceSplit
-              rows={data.bySource}
-              active={data.selectedSource}
-              params={sp}
-            />
-            <div className={styles.grid}>
-              <Panel
-                title={
-                  data.selectedPage
-                    ? `Top ${data.selectedPage} listings`
-                    : 'Top listings'
-                }
-              >
-                <CountTable
-                  rows={data.topListings}
-                  labelHead="Listing"
-                  rankHead="Slot"
-                  logoFor={name =>
-                    logoByName.get(name) ?? faviconFor(urlByName.get(name))
+          {activeTab === 'pages' && (
+            <Panel title="Clicks by page">
+              <CountTable
+                rows={data.byPage}
+                labelHead="Page"
+                total={totalClicks}
+              />
+            </Panel>
+          )}
+
+          {onResourceView && (
+            <div className={styles.pageSection}>
+              <SourceSplit
+                rows={data.bySource}
+                active={data.selectedSource}
+                params={sp}
+              />
+              <div className={styles.grid}>
+                <Panel
+                  title={
+                    selectedLabel
+                      ? `Top ${selectedLabel} listings`
+                      : 'Top listings'
                   }
-                  rankFor={name => positionByName.get(name)}
-                  total={listingTotal}
-                />
-                <p className={styles.caption}>
-                  Slot = where each listing was clicked this period (F1/F2 =
-                  featured cards). Blank for clicks logged before slot tracking.
-                </p>
-              </Panel>
-              <Panel title="Clicks by position">
-                <CountTable
-                  rows={data.byPosition}
-                  labelHead="Slot"
-                  total={positionTotal}
-                />
-                <p className={styles.caption}>
-                  Every click on this page counted at the slot it happened in —
-                  so a busy top slot shows up even as different listings rotate
-                  through it.
-                </p>
-              </Panel>
+                >
+                  <CountTable
+                    rows={data.topListings}
+                    labelHead="Listing"
+                    rankHead="Slot"
+                    logoFor={name =>
+                      logoByName.get(name) ?? faviconFor(urlByName.get(name))
+                    }
+                    rankFor={name => positionByName.get(name)}
+                    total={listingTotal}
+                  />
+                  <p className={styles.caption}>
+                    Slot = where each listing was clicked this period (F1/F2 =
+                    featured cards). Blank for clicks logged before slot
+                    tracking.
+                  </p>
+                </Panel>
+                <Panel title="Clicks by position">
+                  <CountTable
+                    rows={data.byPosition}
+                    labelHead="Slot"
+                    total={positionTotal}
+                  />
+                  <p className={styles.caption}>
+                    Every click on this page counted at the slot it happened in
+                    — so a busy top slot shows up even as different listings
+                    rotate through it.
+                  </p>
+                </Panel>
+              </div>
             </div>
-          </div>
+          )}
 
           <Panel title="Recent activity">
             {data.recent.length === 0 ? (
@@ -517,44 +569,63 @@ function SourceSplit({
 
 /** Tabs that pick which resource page the listing panels drill into. Each tab
  *  preserves the current date range and swaps only the `page` query param. */
-function PageTabs({
+/** The dashboard's top tab bar: two overview tabs (the funnel and the by-page
+ *  table), a divider, then one tab per resource page. Each tab swaps the `tab`
+ *  query param (and drops any active source filter) while preserving the date
+ *  range and count mode. Resource tabs show the site's page name and nav icon. */
+function DashboardTabs({
+  overview,
   pages,
   active,
   params,
 }: {
-  pages: { name: string; icon?: string }[]
-  active: string | null
+  overview: { key: string; label: string }[]
+  pages: { key: string; label: string; icon?: string }[]
+  active: string
   params: SearchParams
 }) {
-  if (pages.length <= 1) return null
+  // Preserve everything except the tab itself and the per-page source filter
+  // (which is meaningless once you switch tabs); `page` is the old param name.
   const base = new URLSearchParams()
   for (const [k, v] of Object.entries(params)) {
-    if (k === 'page' || v == null) continue
+    if (k === 'tab' || k === 'source' || k === 'page' || v == null) continue
     base.set(k, Array.isArray(v) ? (v[0] ?? '') : v)
   }
+  const hrefFor = (key: string) => {
+    const q = new URLSearchParams(base)
+    q.set('tab', key)
+    return `?${q.toString()}`
+  }
+  const tabClass = (key: string) =>
+    `${styles.pageTab}${key === active ? ` ${styles.pageTabActive}` : ''}`
   return (
     <div className={styles.pageTabs}>
-      {pages.map(({ name, icon }) => {
-        const q = new URLSearchParams(base)
-        q.set('page', name)
-        return (
-          <Link
-            key={name}
-            href={`?${q.toString()}`}
-            scroll={false}
-            className={`${styles.pageTab}${
-              name === active ? ` ${styles.pageTabActive}` : ''
-            }`}
-          >
-            {icon && (
-              <span className={styles.pageTabIcon}>
-                <Image src={`/images/${icon}`} alt="" width={12} height={12} />
-              </span>
-            )}
-            {name}
-          </Link>
-        )
-      })}
+      {overview.map(t => (
+        <Link
+          key={t.key}
+          href={hrefFor(t.key)}
+          scroll={false}
+          className={tabClass(t.key)}
+        >
+          {t.label}
+        </Link>
+      ))}
+      <span className={styles.tabDivider} aria-hidden />
+      {pages.map(t => (
+        <Link
+          key={t.key}
+          href={hrefFor(t.key)}
+          scroll={false}
+          className={tabClass(t.key)}
+        >
+          {t.icon && (
+            <span className={styles.pageTabIcon}>
+              <Image src={`/images/${t.icon}`} alt="" width={12} height={12} />
+            </span>
+          )}
+          {t.label}
+        </Link>
+      ))}
     </div>
   )
 }

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -218,7 +218,7 @@ export default async function AnalyticsPage({
   // every click.
   const unique = first(sp.clicks) !== 'total'
   const [data, funders] = await Promise.all([
-    readDashboard(range, first(sp.page), unique),
+    readDashboard(range, first(sp.page), unique, first(sp.source)),
     getFunders().catch(() => []),
   ])
 
@@ -257,6 +257,13 @@ export default async function AnalyticsPage({
   // page's whole click count, not just the visible top-15 rows.
   const totalClicks = data.byPage.reduce((sum, r) => sum + r.count, 0)
   const pageTotal = data.byPage.find(p => p.name === data.selectedPage)?.count
+  // When the listings are filtered to one source, the top-listings table is a
+  // share of that source's clicks, not the page's whole. bySource carries the
+  // per-source totals, so read the active one from there.
+  const listingTotal = data.selectedSource
+    ? data.bySource.find(r => r.name.toLowerCase() === data.selectedSource)
+        ?.count
+    : pageTotal
   const positionTotal = data.byPosition.reduce((sum, r) => sum + r.count, 0)
 
   return (
@@ -304,7 +311,11 @@ export default async function AnalyticsPage({
 
           <div className={styles.pageSection}>
             <PageTabs pages={tabPages} active={data.selectedPage} params={sp} />
-            <SourceSplit rows={data.bySource} />
+            <SourceSplit
+              rows={data.bySource}
+              active={data.selectedSource}
+              params={sp}
+            />
             <div className={styles.grid}>
               <Panel
                 title={
@@ -321,7 +332,7 @@ export default async function AnalyticsPage({
                     logoByName.get(name) ?? faviconFor(urlByName.get(name))
                   }
                   rankFor={name => positionByName.get(name)}
-                  total={pageTotal}
+                  total={listingTotal}
                 />
                 <p className={styles.caption}>
                   Slot = where each listing was clicked this period (F1/F2 =
@@ -428,36 +439,71 @@ function ClickModeToggle({
 }
 
 /** For pages with a map, shows how the selected page's clicks split between the
- *  map and the cards. Renders nothing for pages without a map. */
-function SourceSplit({ rows }: { rows: Counted[] }) {
+ *  map and the cards. Each split is a link that filters the listing panels below
+ *  to that source; "Total" clears the filter. Renders nothing for pages without
+ *  a map. */
+function SourceSplit({
+  rows,
+  active,
+  params,
+}: {
+  rows: Counted[]
+  active: string | null
+  params: SearchParams
+}) {
   if (rows.length === 0) return null
   const total = rows.reduce((sum, r) => sum + r.count, 0)
   const hasUntracked = rows.some(r => r.name === 'Untracked')
+  // Preserve every other query param; only the `source` filter is swapped.
+  const base = new URLSearchParams()
+  for (const [k, v] of Object.entries(params)) {
+    if (k === 'source' || v == null) continue
+    base.set(k, Array.isArray(v) ? (v[0] ?? '') : v)
+  }
+  const totalHref = base.toString() ? `?${base.toString()}` : '?'
   return (
     <div className={styles.sourceSplitWrap}>
       <div className={styles.sourceSplit}>
         <span className={styles.sourceSplitLabel}>Clicks by source</span>
         {rows.length > 1 && (
-          <span className={styles.sourceStat}>
+          <Link
+            href={totalHref}
+            scroll={false}
+            className={`${styles.sourceStat} ${styles.sourceStatLink}${
+              active == null ? ` ${styles.sourceStatActive}` : ''
+            }`}
+          >
             <span className={styles.sourceStatName}>Total</span>
             <span className={styles.sourceStatCount}>
               {total.toLocaleString()}
             </span>
-          </span>
+          </Link>
         )}
-        {rows.map(r => (
-          <span key={r.name} className={styles.sourceStat}>
-            <span className={styles.sourceStatName}>{r.name}</span>
-            <span className={styles.sourceStatCount}>
-              {r.count.toLocaleString()}
-            </span>
-            {total > 0 && (
-              <span className={styles.sourceStatPct}>
-                {pct1(r.count, total)}
+        {rows.map(r => {
+          const key = r.name.toLowerCase()
+          const q = new URLSearchParams(base)
+          q.set('source', key)
+          return (
+            <Link
+              key={r.name}
+              href={`?${q.toString()}`}
+              scroll={false}
+              className={`${styles.sourceStat} ${styles.sourceStatLink}${
+                active === key ? ` ${styles.sourceStatActive}` : ''
+              }`}
+            >
+              <span className={styles.sourceStatName}>{r.name}</span>
+              <span className={styles.sourceStatCount}>
+                {r.count.toLocaleString()}
               </span>
-            )}
-          </span>
-        ))}
+              {total > 0 && (
+                <span className={styles.sourceStatPct}>
+                  {pct1(r.count, total)}
+                </span>
+              )}
+            </Link>
+          )
+        })}
       </div>
       {hasUntracked && (
         <p className={styles.caption}>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -31,6 +31,34 @@ interface TrackPayload {
 }
 
 const VID_KEY = 'aisafety_vid'
+const OPTOUT_KEY = 'aisafety_no_track'
+
+/** True when this browser has opted out of first-party analytics — used by the
+ *  site owner to keep their own clicks out of the dashboard. The flag lives in
+ *  localStorage rather than being matched on IP, because the owner is a nomad
+ *  whose IP changes monthly; a per-browser flag sticks regardless of location. */
+export function isTrackingOptedOut(): boolean {
+  try {
+    return (
+      typeof localStorage !== 'undefined' &&
+      localStorage.getItem(OPTOUT_KEY) === '1'
+    )
+  } catch {
+    return false
+  }
+}
+
+/** Turn first-party tracking off (true) or back on (false) for this browser.
+ *  Set from the admin analytics dashboard. */
+export function setTrackingOptOut(optOut: boolean): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    if (optOut) localStorage.setItem(OPTOUT_KEY, '1')
+    else localStorage.removeItem(OPTOUT_KEY)
+  } catch {
+    // Storage unavailable (private mode); nothing to persist.
+  }
+}
 
 /** A stable, anonymous per-browser id (random UUID in localStorage) so the
  *  dashboard can count UNIQUE users — e.g. not double-counting one person who
@@ -57,6 +85,8 @@ function getVisitorId(): string | undefined {
 /** Fire a first-party event to /api/track. Prefers sendBeacon so it survives the
  *  navigation a click triggers; falls back to keepalive fetch. */
 function sendTrackEvent(payload: TrackPayload): void {
+  // The owner can exclude their own browser from the stats.
+  if (isTrackingOptedOut()) return
   try {
     const body = JSON.stringify({ ...payload, vid: getVisitorId() })
     if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
@@ -95,6 +125,8 @@ export function trackListingClick(
   source?: string
 ): void {
   if (typeof window === 'undefined') return
+  // Opted-out browsers skip Matomo too, so the owner's clicks stay out of both.
+  if (isTrackingOptedOut()) return
   window._paq?.push(['trackEvent', `Listings - ${page}`, name, url])
   sendTrackEvent({
     type: 'listing_click',

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -33,27 +33,34 @@ interface TrackPayload {
 const VID_KEY = 'aisafety_vid'
 const OPTOUT_KEY = 'aisafety_no_track'
 
-/** True when this browser has opted out of first-party analytics — used by the
- *  site owner to keep their own clicks out of the dashboard. The flag lives in
- *  localStorage rather than being matched on IP, because the owner is a nomad
- *  whose IP changes monthly; a per-browser flag sticks regardless of location. */
-export function isTrackingOptedOut(): boolean {
+/** Raw opt-out marker for this browser: the ISO timestamp it was excluded from
+ *  the stats, or '' when it isn't excluded (a legacy '1' may exist from before
+ *  the date was stored). The flag lives in localStorage rather than being
+ *  matched on IP, because the owner is a nomad whose IP changes monthly; a
+ *  per-browser flag sticks regardless of location. The dashboard control reads
+ *  this directly as its reactive snapshot. */
+export function getTrackingOptOut(): string {
   try {
-    return (
-      typeof localStorage !== 'undefined' &&
-      localStorage.getItem(OPTOUT_KEY) === '1'
-    )
+    if (typeof localStorage === 'undefined') return ''
+    return localStorage.getItem(OPTOUT_KEY) ?? ''
   } catch {
-    return false
+    return ''
   }
 }
 
+/** True when this browser has opted out of first-party analytics — used to keep
+ *  the site owner's own clicks out of the dashboard. */
+export function isTrackingOptedOut(): boolean {
+  return getTrackingOptOut() !== ''
+}
+
 /** Turn first-party tracking off (true) or back on (false) for this browser.
- *  Set from the admin analytics dashboard. */
+ *  When turning off we record the moment, so the dashboard can show that the
+ *  exclusion only applies from then on — earlier visits stay counted. */
 export function setTrackingOptOut(optOut: boolean): void {
   try {
     if (typeof localStorage === 'undefined') return
-    if (optOut) localStorage.setItem(OPTOUT_KEY, '1')
+    if (optOut) localStorage.setItem(OPTOUT_KEY, new Date().toISOString())
     else localStorage.removeItem(OPTOUT_KEY)
   } catch {
     // Storage unavailable (private mode); nothing to persist.

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -326,14 +326,15 @@ function aggregate(
 
   const byPage = tally(clicks.map(e => e.page as string))
   const pageNames = byPage.map(p => p.name)
-  // The page the listing panels drill into: the requested one if it has data,
-  // else Funding (Bryce's main interest), else the busiest page.
-  const selectedPage =
-    selectedPageReq && pageNames.includes(selectedPageReq)
-      ? selectedPageReq
-      : pageNames.includes('Funding')
-        ? 'Funding'
-        : (pageNames[0] ?? null)
+  // The page the listing panels drill into. An explicit request always wins —
+  // even with no clicks in range — so selecting a quiet page's tab shows that
+  // page (empty), not a fallback. With no request, default to Funding (Bryce's
+  // main interest), then the busiest page.
+  const selectedPage = selectedPageReq
+    ? selectedPageReq
+    : pageNames.includes('Funding')
+      ? 'Funding'
+      : (pageNames[0] ?? null)
 
   // On a map page the panels can be filtered to one click source. The split
   // itself (bySource, below) is always computed from every click on the page so

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -197,8 +197,12 @@ export interface DashboardData {
    *  F2, 1, 2, 3… — answers "do higher slots draw more clicks" for that page. */
   byPosition: Counted[]
   /** For pages with a map (Map, Communities): the selected page's clicks split
-   *  into 'Map' vs 'Cards'. Empty for pages without a map. */
+   *  into 'Map' vs 'Cards'. Empty for pages without a map. Always the full split,
+   *  even when one source is selected, so the user can switch between them. */
   bySource: Counted[]
+  /** The source the per-listing panels are filtered to ('map' | 'cards' |
+   *  'untracked'), or null for all sources. Only ever set on map pages. */
+  selectedSource: string | null
   funnel: ChatbotFunnel
   recent: AnalyticsEvent[]
 }
@@ -210,9 +214,13 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   topListings: [],
   byPosition: [],
   bySource: [],
+  selectedSource: null,
   funnel: { opened: 0, typed: 0, clicked: 0 },
   recent: [],
 }
+
+/** Source filters offered on map pages. 'untracked' = neither map nor cards. */
+const SOURCE_FILTERS = new Set(['map', 'cards', 'untracked'])
 
 /** Resource pages that have a map above their card list, so a click can come
  *  from either surface. These are the only pages that get a source breakdown. */
@@ -298,7 +306,8 @@ function aggregate(
   all: AnalyticsEvent[],
   { startMs, endMs }: DateRange,
   selectedPageReq?: string,
-  unique = true
+  unique = true,
+  sourceReq?: string
 ): Omit<DashboardData, 'source' | 'error'> {
   const inRange = all.filter(e => {
     const t = Date.parse(e.ts)
@@ -326,10 +335,25 @@ function aggregate(
         ? 'Funding'
         : (pageNames[0] ?? null)
 
+  // On a map page the panels can be filtered to one click source. The split
+  // itself (bySource, below) is always computed from every click on the page so
+  // the user can switch sources; only the per-listing panels narrow.
+  const isMapPage = selectedPage != null && MAP_PAGES.has(selectedPage)
+  const selectedSource =
+    isMapPage && sourceReq && SOURCE_FILTERS.has(sourceReq) ? sourceReq : null
+  const matchesSource = (e: AnalyticsEvent): boolean => {
+    if (selectedSource === 'map') return e.source === 'map'
+    if (selectedSource === 'cards') return e.source === 'cards'
+    if (selectedSource === 'untracked')
+      return e.source !== 'map' && e.source !== 'cards'
+    return true // no filter
+  }
+
   // For the selected page: total clicks per listing, the range of slots each was
   // clicked at (from positions stamped at click time, so it's period-accurate
   // even as the page is reordered), and a representative url for its favicon.
-  const pageClicks = clicks.filter(e => e.page === selectedPage)
+  const pageClicksAll = clicks.filter(e => e.page === selectedPage)
+  const pageClicks = pageClicksAll.filter(matchesSource)
   const perListing = new Map<
     string,
     { count: number; positions: string[]; url?: string }
@@ -359,11 +383,11 @@ function aggregate(
   // miscounted as a card. Honours the unique/total mode (same pageClicks). Only
   // non-empty buckets are shown.
   let bySource: Counted[] = []
-  if (selectedPage && MAP_PAGES.has(selectedPage)) {
+  if (isMapPage) {
     let map = 0
     let cards = 0
     let untracked = 0
-    for (const e of pageClicks) {
+    for (const e of pageClicksAll) {
       if (e.source === 'map') map += 1
       else if (e.source === 'cards') cards += 1
       else untracked += 1
@@ -384,6 +408,7 @@ function aggregate(
       pageClicks.map(e => e.position).filter((p): p is string => p != null)
     ),
     bySource,
+    selectedSource,
     funnel: {
       opened: usersOf('chatbot_open'),
       typed: usersOf('chatbot_message'),
@@ -408,13 +433,17 @@ function uniqueUsers(events: AnalyticsEvent[]): number {
 export async function readDashboard(
   range: DateRange,
   page?: string,
-  unique = true
+  unique = true,
+  sourceFilter?: string
 ): Promise<DashboardData> {
   if (store) {
     try {
       // Newest-first (lpush prepends); up to MAX_EVENTS.
       const all = await store.lrange<AnalyticsEvent>(EVENTS_KEY, 0, -1)
-      return { source: 'redis', ...aggregate(all, range, page, unique) }
+      return {
+        source: 'redis',
+        ...aggregate(all, range, page, unique, sourceFilter),
+      }
     } catch (err) {
       // Degrade gracefully — a Redis blip must not 500 the dashboard.
       console.warn(
@@ -426,5 +455,8 @@ export async function readDashboard(
 
   const all = await readDevEvents()
   if (all.length === 0) return { source: 'none', ...EMPTY }
-  return { source: 'local-file', ...aggregate(all, range, page, unique) }
+  return {
+    source: 'local-file',
+    ...aggregate(all, range, page, unique, sourceFilter),
+  }
 }


### PR DESCRIPTION
- Add an "exclude this browser" control (localStorage opt-out, shows the date it started) so the owner can keep their own activity out of the stats.
- Make the "clicks by source" splits clickable on Map/Communities to filter the listing panels.
- Turn the dashboard into a tabbed view near the top: Overview (clicks by page + recent activity) and Chatbot funnel as their own tabs, plus one tab per resource page; tab labels match the site's nav names.
- Recent activity now only shows on the Overview tab; the page title is "Analytics".
- Keep the active tab/filters when changing the date range.
- Make top-listing logos link to the listing while leaving the name text selectable.

_PR description written by Claude Code._