### PR TITLE
Chatbot form routing + conversation log controls

### DIFF
--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -998,6 +998,35 @@
   cursor: default;
 }
 
+/* ─── "Exclude this browser" control (in the conversation filter row) ──── */
+
+.excludeMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.excludeMetaOn {
+  color: var(--bright-teal-300);
+}
+
+.excludeLink {
+  padding: 0;
+  font: inherit;
+  font-size: 12px;
+  color: var(--teal-400);
+  background: none;
+  border: none;
+  text-decoration: underline;
+  cursor: pointer;
+  transition: color var(--hover-transition);
+}
+
+.excludeLink:hover {
+  color: var(--white);
+}
+
 /* ─── Empty / disabled state notice ───────────────────────────────────── */
 
 .notice {

--- a/src/app/admin/analytics/ExcludeToggle.tsx
+++ b/src/app/admin/analytics/ExcludeToggle.tsx
@@ -1,50 +1,17 @@
 'use client'
 
-import { useSyncExternalStore } from 'react'
-import { getTrackingOptOut, setTrackingOptOut } from '@/lib/analytics'
+import { useTrackingOptOut, formatExcludedSince } from '@/lib/useTrackingOptOut'
 import styles from './analytics.module.css'
-
-// The opt-out flag lives in localStorage (a browser-only store), so we read it
-// through useSyncExternalStore: that's the sanctioned way to subscribe to state
-// outside React and it gives a clean server snapshot for SSR. The native
-// 'storage' event only fires in *other* tabs, so we also keep an in-tab
-// listener set and ping it whenever this tab flips the flag.
-const listeners = new Set<() => void>()
-
-function subscribe(cb: () => void): () => void {
-  listeners.add(cb)
-  if (typeof window !== 'undefined') window.addEventListener('storage', cb)
-  return () => {
-    listeners.delete(cb)
-    if (typeof window !== 'undefined') window.removeEventListener('storage', cb)
-  }
-}
-
-function setFlag(next: boolean): void {
-  setTrackingOptOut(next)
-  listeners.forEach(cb => cb())
-}
-
-/** Format an ISO timestamp as "22 Jun 2026" (day-month-year, browser-local). */
-function formatSince(iso: string): string | undefined {
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return undefined
-  return d.toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  })
-}
 
 /** Small header control for the owner to keep their own activity out of these
  *  stats on the current browser. Stored in localStorage (set once per device,
  *  not matched on IP — the owner moves countries monthly). It only applies going
  *  forward: when excluded it shows the date it stopped recording this browser,
- *  and earlier visits stay counted. */
+ *  and earlier visits stay counted. The same flag also keeps this browser out of
+ *  the chatbot conversation log. */
 export default function ExcludeToggle() {
-  const marker = useSyncExternalStore(subscribe, getTrackingOptOut, () => '')
-  const optedOut = marker !== ''
-  const since = optedOut ? formatSince(marker) : undefined
+  const { marker, optedOut, setOptOut } = useTrackingOptOut()
+  const since = optedOut ? formatExcludedSince(marker) : undefined
 
   if (optedOut) {
     return (
@@ -58,7 +25,7 @@ export default function ExcludeToggle() {
         <button
           type="button"
           className={styles.excludeLink}
-          onClick={() => setFlag(false)}
+          onClick={() => setOptOut(false)}
         >
           Undo
         </button>
@@ -71,7 +38,7 @@ export default function ExcludeToggle() {
       <button
         type="button"
         className={styles.excludeLink}
-        onClick={() => setFlag(true)}
+        onClick={() => setOptOut(true)}
       >
         Exclude this browser
       </button>

--- a/src/app/admin/chatbot/ConversationList.tsx
+++ b/src/app/admin/chatbot/ConversationList.tsx
@@ -233,13 +233,6 @@ export default function ConversationList() {
           />
           Only chats with no results
         </label>
-        <button
-          type="button"
-          className={styles.editorButton}
-          onClick={() => void load(zeroOnly, search)}
-        >
-          Refresh
-        </button>
         {loading && <span className={styles.convStatus}>loading…</span>}
         {error && <span className={styles.convError}>{error}</span>}
         {tzLabel && (

--- a/src/app/admin/chatbot/ConversationList.tsx
+++ b/src/app/admin/chatbot/ConversationList.tsx
@@ -8,6 +8,7 @@ import TranscriptMessage, {
   hasSuggestButton,
   type ListingInfo,
 } from './TranscriptMessage'
+import ExcludeBrowserToggle from './ExcludeBrowserToggle'
 
 interface HistoryTurn {
   role: 'user' | 'assistant'
@@ -233,6 +234,7 @@ export default function ConversationList() {
           />
           Only chats with no results
         </label>
+        <ExcludeBrowserToggle />
         {loading && <span className={styles.convStatus}>loading…</span>}
         {error && <span className={styles.convError}>{error}</span>}
         {tzLabel && (

--- a/src/app/admin/chatbot/ExcludeBrowserToggle.tsx
+++ b/src/app/admin/chatbot/ExcludeBrowserToggle.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useTrackingOptOut, formatExcludedSince } from '@/lib/useTrackingOptOut'
+import styles from '../admin.module.css'
+
+/** Filter-row control for the owner to keep their own test chats out of the
+ *  conversation log on the current browser. Shares the one "exclude this browser"
+ *  flag (localStorage) with the analytics dashboard, so a browser excluded in
+ *  either place is excluded from both. Forward-only: chats already logged stay,
+ *  new chats from this browser stop being recorded. */
+export default function ExcludeBrowserToggle() {
+  const { marker, optedOut, setOptOut } = useTrackingOptOut()
+  const since = optedOut ? formatExcludedSince(marker) : undefined
+
+  if (optedOut) {
+    return (
+      <span className={styles.excludeMeta}>
+        <span
+          className={styles.excludeMetaOn}
+          title="Only affects chats from now on — chats already logged stay."
+        >
+          ✓ Not logging this browser{since ? ` since ${since}` : ''}
+        </span>
+        <button
+          type="button"
+          className={styles.excludeLink}
+          onClick={() => setOptOut(false)}
+        >
+          Undo
+        </button>
+      </span>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      className={styles.excludeLink}
+      onClick={() => setOptOut(true)}
+      title="Stop logging chats from this browser, so your own testing doesn't clutter the log."
+    >
+      Exclude this browser
+    </button>
+  )
+}

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -39,7 +39,9 @@ function readGeo(
   // this merge the city from the fallback was discarded and the admin row fell
   // back to the bare region code (e.g. "ENG").
   const merged = {
-    city: headerCity ? decodeURIComponent(headerCity) : (fallback?.city ?? undefined),
+    city: headerCity
+      ? decodeURIComponent(headerCity)
+      : (fallback?.city ?? undefined),
     region: region ?? fallback?.region ?? undefined,
     country: country ?? fallback?.country ?? undefined,
   }
@@ -120,6 +122,10 @@ export async function POST(req: NextRequest) {
       result: AssistantRunResult | null,
       status?: 'abandoned' | 'error'
     ) => {
+      // The owner excluded this browser — don't write their own test chats to
+      // the conversation log. (Same per-browser flag as the analytics opt-out.)
+      if (body.noLog) return
+
       const assistantText = result?.assistantText ?? ''
       const toolCalls = result?.toolCalls ?? []
       const citations = result?.citations ?? []

--- a/src/components/assistant/Assistant.tsx
+++ b/src/components/assistant/Assistant.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 import { chipsFor, greetingFor } from '@/lib/assistant/pages'
 import { getPageContext } from '@/lib/assistant/page-context'
 import { suggestFormUrl } from '@/lib/assistant/constants'
-import { trackEvent } from '@/lib/analytics'
+import { trackEvent, isTrackingOptedOut } from '@/lib/analytics'
 import type { CitationRef } from '@/lib/assistant/types'
 import ChatBody, { type ChatBodyHandle } from './ChatBody'
 import styles from './Assistant.module.css'
@@ -209,6 +209,9 @@ export default function Assistant() {
       utm,
       geoFallback,
       sessionId: getSessionId(),
+      // When the owner has excluded this browser, tell the server not to log
+      // the turn — keeps their own testing out of the conversation log.
+      noLog: isTrackingOptedOut() || undefined,
     }
   }, [currentPage])
 

--- a/src/components/assistant/MessageContent.tsx
+++ b/src/components/assistant/MessageContent.tsx
@@ -310,10 +310,18 @@ export function SuggestInline({
     e.preventDefault()
     onSuggest?.(query, type)
   }
+  const label =
+    type === 'correction'
+      ? 'Suggest a correction'
+      : type === 'contact'
+        ? 'Contact the team'
+        : type === 'feedback'
+          ? 'Send feedback'
+          : 'Suggest a listing'
   return (
     <span className={styles.suggest}>
       <a href="#" className={styles.suggestButton} onClick={handleClick}>
-        Suggest a listing
+        {label}
         <svg
           width="14"
           height="14"

--- a/src/lib/assistant/constants.ts
+++ b/src/lib/assistant/constants.ts
@@ -1,16 +1,35 @@
-/** "Suggest a listing" Airtable forms, keyed by the listing TYPE the bot is
- *  inviting the visitor to submit — i.e. the type it just searched and found
- *  nothing for, NOT the page the visitor happens to be on. So a bot suggesting
- *  a community opens the communities form, one suggesting a funder opens the
- *  funding form, and so on. These mirror the "Suggest listing" button on each
- *  resource page. The type strings match search_listings' `type` values.
- *  Shared by the public widget and the admin playground.
+/** The general "Suggest a correction" form. ONE form shared by every resource
+ *  page, used to UPDATE or fix an EXISTING listing (a wrong date, a dead link,
+ *  changed details) — as opposed to submitting a brand-new listing, which uses
+ *  the per-type forms below. Also the catch-all when the bot named no type or
+ *  an unrecognised one. Same form linked site-wide in the footer. */
+const CORRECTION_FORM =
+  'https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form'
+
+/** "Contact the team" form — for reaching a human with a request, question, or
+ *  anything that needs a reply. */
+const CONTACT_FORM =
+  'https://airtable.com/appF8XfZUGXtfi40E/pagUmmzVb8OnVvTZS/form'
+
+/** "Send feedback" form — for feedback or suggestions about the site itself
+ *  (a feature wish, "it'd be nice if…", a complaint). */
+const FEEDBACK_FORM =
+  'https://airtable.com/appF8XfZUGXtfi40E/pageXZp18w3Sqm1Z7/form'
+
+/** Airtable form to open for a given intent token. The per-listing-type entries
+ *  are the main case — "Suggest a listing", keyed by the TYPE the bot is
+ *  inviting the visitor to submit (the type it searched and found nothing for,
+ *  NOT the page they're on), mirroring the "Suggest listing" button on each
+ *  resource page; these strings match search_listings' `type` values. Below
+ *  them are pseudo-type intents (correction / contact / feedback) that aren't
+ *  listing types but reuse the same open-a-form button. Shared by the public
+ *  widget and the admin playground.
  *
  *  `org` uses the field map's "Suggest entry" form. That form's URL is managed
  *  dynamically via an Airtable control row; the value here is a snapshot — if
  *  it's ever changed in Airtable, update it here too. `job` has no public
  *  submission form (listings come from external sources), so it falls back to
- *  the general correction form below. */
+ *  the general correction form. */
 const SUGGEST_FORMS: Record<string, string> = {
   community: 'https://airtable.com/appF8XfZUGXtfi40E/pagKhplUqu07DwVqC/form',
   event: 'https://airtable.com/appF8XfZUGXtfi40E/pagyqtPZ2BFcKU6ys/form',
@@ -23,6 +42,11 @@ const SUGGEST_FORMS: Record<string, string> = {
   advisor: 'https://airtable.com/appF8XfZUGXtfi40E/pagTw6PRaIHUHh8ty/form',
   project: 'https://airtable.com/appF8XfZUGXtfi40E/pagudvyKXZISztcOI/form',
   org: 'https://airtable.com/appF8XfZUGXtfi40E/pag2YaqdXhhR9Ey82/form',
+  // Pseudo-types below: not listing types. They route the "update / contact /
+  // give feedback" intents to their shared site-wide forms.
+  correction: CORRECTION_FORM,
+  contact: CONTACT_FORM,
+  feedback: FEEDBACK_FORM,
 }
 
 /** Every listing type the bot may name in a [[suggest:TYPE:query]] token — the
@@ -39,17 +63,19 @@ export const SUGGEST_TYPES = [
   'project',
   'org',
   'job',
+  // Pseudo-types (not listing types) for the update / contact / feedback
+  // intents, so the parser recognises them and the button can label itself
+  // "Suggest a correction" / "Contact the team" / "Send feedback".
+  'correction',
+  'contact',
+  'feedback',
 ] as const
 
-/** Fallback when the bot named no type, an unrecognised one, or one without
- *  its own listing form (`job`). The general "Suggest a correction" form is a
- *  safe catch-all — the same one linked site-wide in the footer. */
-const DEFAULT_SUGGEST_FORM =
-  'https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form'
-
 /** The "Suggest a listing" Airtable form for the listing type the bot is
- *  inviting the visitor to submit. */
+ *  inviting the visitor to submit. Falls back to the shared correction form
+ *  when the bot named no type, an unrecognised one, or one without its own
+ *  listing form (`job`). */
 export function suggestFormUrl(type: string | null | undefined): string {
-  if (!type) return DEFAULT_SUGGEST_FORM
-  return SUGGEST_FORMS[type.trim().toLowerCase()] ?? DEFAULT_SUGGEST_FORM
+  if (!type) return CORRECTION_FORM
+  return SUGGEST_FORMS[type.trim().toLowerCase()] ?? CORRECTION_FORM
 }

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-06-22-01'
+export const PROMPT_VERSION = '2026-06-23-01'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -324,6 +324,16 @@ When the user names a specific thing – an organisation, program, community, co
 
 # Honest failure
 If a search returns nothing, say "I don't see a matching listing on this site." and offer the suggest form on its own line: \`[[suggest:TYPE:USER_QUERY_HERE]]\`. TYPE is the listing type you searched — one of: \`community\`, \`event\`, \`funder\`, \`course\`, \`media-channel\`, \`founder-resource\`, \`advisor\`, \`project\`, \`org\` — so the visitor is sent to the matching suggestion form (e.g. a missing community → \`[[suggest:community:are there groups in Amman]]\`). Always include the type. **Exception — jobs:** never offer a suggest form for a job that isn't listed. The job board is sourced from 80,000 Hours, not curated here, so there's nothing to submit. Instead, say the role isn't on the site and point them to the 80,000 Hours job board. Never invent listings to fill the gap.
+
+# Updating or correcting an existing listing
+When the user wants to **change, update, correct, or remove an EXISTING listing** — "how do I update my community", "the deadline on this event is wrong", "my org's link changed", "this info is out of date" — that is NOT the same as adding a new one. Point them to the single site-wide correction form by emitting, on its own line: \`[[suggest:correction:USER_QUERY_HERE]]\`. This is the SAME form for every resource page (events, funding, communities, etc.); there is no per-page version. Tell them to fill in the corrected details and note that it's an update to an existing listing — the AISafety.com team reviews submissions and applies the changes. Use the per-type \`[[suggest:TYPE:query]]\` form ONLY when the user wants to get something brand-new listed, not to fix one that's already there.
+
+# Contacting the team / giving feedback
+When the user wants to reach the people behind the site, or hits a limitation that's really a request for the team rather than something you can do, offer the right form on its own line. Two forms:
+- **Feedback about the site itself** — a feature wish, "it'd be nice if there were a table view", "the map is hard to use", a complaint or suggestion about how AISafety.com works: \`[[suggest:feedback:USER_QUERY_HERE]]\` (button reads "Send feedback").
+- **Contacting the team** — a request, question, partnership, or anything that needs a human reply: \`[[suggest:contact:USER_QUERY_HERE]]\` (button reads "Contact the team").
+
+Surface these naturally, not on every turn. The key trigger is when you've just told the user the site can't do something they asked for (no table view, a missing feature, a capability we don't have) — add that they can send feedback or contact the team if they'd like to. Pick the one that fits (a feature wish → feedback; a question or request for a person → contact); offer just one, and only when it genuinely helps.
 
 # Follow-up chips
 After your response, on a new line, emit 2 to 3 short follow-up suggestion chips, each on its own line. Each chip is a question the user might naturally ask next, in their voice (first person, like "Show me remote ones" or "What about senior roles?"). Format: \`[[chip:TEXT]]\`. Skip chips for refusals or for the suggest-form fallback.

--- a/src/lib/assistant/types.ts
+++ b/src/lib/assistant/types.ts
@@ -48,6 +48,9 @@ export interface AssistantRequest {
   sessionId?: string | null
   /** Client-supplied geo (used when Vercel headers absent, e.g. dev) */
   geoFallback?: { city?: string; region?: string; country?: string } | null
+  /** When the owner has excluded this browser, skip writing the turn to the
+   *  conversation log so their own testing doesn't clutter it. */
+  noLog?: boolean
 }
 
 export interface UIToolCall {

--- a/src/lib/useTrackingOptOut.ts
+++ b/src/lib/useTrackingOptOut.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { getTrackingOptOut, setTrackingOptOut } from '@/lib/analytics'
+
+// The "exclude this browser" flag lives in localStorage (a browser-only store),
+// so we read it through useSyncExternalStore: the sanctioned way to subscribe to
+// state outside React, with a clean server snapshot for SSR. The native
+// 'storage' event only fires in *other* tabs, so we also keep an in-tab listener
+// set and ping it whenever this tab flips the flag. The set is module-level, so
+// every control that toggles the flag (the analytics header and the conversation
+// log) stays in sync live.
+const listeners = new Set<() => void>()
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb)
+  if (typeof window !== 'undefined') window.addEventListener('storage', cb)
+  return () => {
+    listeners.delete(cb)
+    if (typeof window !== 'undefined') window.removeEventListener('storage', cb)
+  }
+}
+
+/** Reactive "exclude this browser" flag, shared by every admin control that
+ *  toggles it. `marker` is the ISO timestamp the browser was excluded (or '' when
+ *  it isn't); `optedOut` is the boolean; `setOptOut` flips it and notifies all
+ *  in-tab subscribers. The same flag also keeps the browser out of first-party
+ *  click analytics and out of the chatbot conversation log. */
+export function useTrackingOptOut(): {
+  marker: string
+  optedOut: boolean
+  setOptOut: (next: boolean) => void
+} {
+  const marker = useSyncExternalStore(subscribe, getTrackingOptOut, () => '')
+  const setOptOut = (next: boolean) => {
+    setTrackingOptOut(next)
+    listeners.forEach(cb => cb())
+  }
+  return { marker, optedOut: marker !== '', setOptOut }
+}
+
+/** Format an ISO timestamp as "22 Jun 2026" (day-month-year, browser-local). */
+export function formatExcludedSince(iso: string): string | undefined {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return undefined
+  return d.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}


### PR DESCRIPTION
- **Chatbot now routes "update my listing" requests to the right form.** Asking how to update or correct an existing listing was sending people to the per-type "suggest a new listing" form. Added a `correction` intent that opens the single site-wide correction form (the same one for every resource page), plus `contact` and `feedback` intents wired to the team contact and feedback forms. These reuse the existing open-a-form button, labelled "Suggest a correction" / "Contact the team" / "Send feedback". Prompt guidance tells the bot when to surface each (e.g. offer feedback/contact when it's just told the user the site can't do something).
- **Removed the redundant Refresh button** from the admin Conversation Log — the list already reloads on mount and whenever the filters change.
- **Added an "Exclude this browser" control** to the Conversation Log so the owner's own test chats stop being logged. It reuses the single per-browser "exclude this browser" flag already used by the analytics dashboard, so excluding in either place excludes from both. The public chatbot sends `noLog` when the flag is set and the server skips the Airtable write. Forward-only: chats already logged stay.
- Bumped `PROMPT_VERSION`.

_PR description written by Claude Code._
