### PR TITLE
Personalize "Suggest listing" text per resource page

### DIFF
--- a/src/app/advisors/AdvisorsClient.tsx
+++ b/src/app/advisors/AdvisorsClient.tsx
@@ -192,7 +192,7 @@ export default function AdvisorsClient({ advisors }: AdvisorsClientProps) {
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagTw6PRaIHUHh8ty/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="advisor"
-          suggestEntryDescription="Suggest a resource to be published here"
+          suggestEntryDescription="Suggest an advisor to be published here"
           suggestCorrectionDescription="Let us know of changes that should be made"
           extraLinks={[
             {

--- a/src/app/communities/CommunitiesClient.tsx
+++ b/src/app/communities/CommunitiesClient.tsx
@@ -295,6 +295,7 @@ export default function CommunitiesClient({
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagKhplUqu07DwVqC/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="community"
+          suggestEntryDescription="Suggest a community to be published here"
         />
       </aside>
     </div>

--- a/src/app/events-and-training/page.tsx
+++ b/src/app/events-and-training/page.tsx
@@ -68,7 +68,7 @@ export default async function EventsAndTrainingPage() {
               Suggest listing <span className="color-teal-400">&rarr;</span>
             </p>
             <p className={styles['action-description']}>
-              Suggest a resource to be published here
+              Suggest an event or program to be published here
             </p>
           </Link>
 

--- a/src/app/funding/FundingClient.tsx
+++ b/src/app/funding/FundingClient.tsx
@@ -207,6 +207,7 @@ export default function FundingClient({ funders }: FundingClientProps) {
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagBI1UdaBbFplw20/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="funder"
+          suggestEntryDescription="Suggest a funder to be published here"
           suggestCorrectionDescription="Let us know of any changes that should be made"
         />
       </div>

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -314,7 +314,7 @@ export default function MapClient({
               suggestEntryUrl={suggestEntryLink}
               suggestCorrectionUrl={suggestCorrectionLink}
               noun="listing"
-              suggestEntryDescription="Suggest a resource to be published here"
+              suggestEntryDescription="Suggest an org, project, or program to be published here"
               extraLinks={[
                 {
                   label: 'View raw data',

--- a/src/app/projects/ProjectsClient.tsx
+++ b/src/app/projects/ProjectsClient.tsx
@@ -121,6 +121,7 @@ export default function ProjectsClient({ projects }: ProjectsClientProps) {
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagudvyKXZISztcOI/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="project"
+          suggestEntryDescription="Suggest a project to be published here"
           suggestCorrectionDescription="Propose changes to a project listing"
         />
       </div>

--- a/src/app/self-study/SelfStudyClient.tsx
+++ b/src/app/self-study/SelfStudyClient.tsx
@@ -207,6 +207,7 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pag6L4BzdkxocBzqr/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="course"
+          suggestEntryDescription="Suggest a course to be published here"
         />
       </div>
     </div>


### PR DESCRIPTION
- Replaces the generic "Suggest a resource to be published here" with page-specific wording in the Contribute section of each resource page:
  - **Events & training** → "Suggest an event or program to be published here"
  - **Map** → "Suggest an org, project, or program to be published here"
  - **Communities** → "Suggest a community to be published here"
  - **Self-study** → "Suggest a course to be published here"
  - **Funding** → "Suggest a funder to be published here"
  - **Advisors** → "Suggest an advisor to be published here"
  - **Projects** → "Suggest a project to be published here"
- Founders and media channels are left unchanged.

_PR description written by Claude Code._