### PR TITLE
Admin chatbot log: show opening greeting + badge only the clicked card

### DIFF
--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -732,6 +732,18 @@
   gap: 8px;
 }
 
+/* The chatbot's opening message for the page — shown subtly at the top of the
+ * transcript for context, since visitors are often replying to it. Not a logged
+ * turn, so it's plain muted text rather than a bordered bubble. */
+.convGreeting {
+  font-size: 12px;
+  font-style: italic;
+  color: var(--teal-500);
+  line-height: 1.5;
+  padding: 0 2px 2px;
+  opacity: 0.7;
+}
+
 .convTurnUser,
 .convTurnAssistant {
   padding: 8px 10px;

--- a/src/app/admin/chatbot/ConversationList.tsx
+++ b/src/app/admin/chatbot/ConversationList.tsx
@@ -9,6 +9,7 @@ import TranscriptMessage, {
   type ListingInfo,
 } from './TranscriptMessage'
 import ExcludeBrowserToggle from './ExcludeBrowserToggle'
+import { greetingFor } from '@/lib/assistant/pages'
 
 interface HistoryTurn {
   role: 'user' | 'assistant'
@@ -314,14 +315,27 @@ function ConversationRow({
   // for old rows that have no stored history.
   const firstUser =
     data?.history.find(t => t.role === 'user')?.content ?? data?.user ?? ''
-  // Cards the visitor clicked, keyed by both full id and bare rec so the
-  // transcript can badge them regardless of how the token was written.
+  // Cards the visitor clicked. New clicks are stored turn-scoped as
+  // `<turnIndex>:<listing id>` so only the card the visitor actually opened is
+  // badged — a listing shown in three replies no longer looks like three
+  // clicks. We seed the set with each entry verbatim plus a `<turn>:<rec>`
+  // variant (tokens are sometimes written without the type prefix). Legacy
+  // entries have no leading `<turn>:` — for those we also add the bare rec, and
+  // CardPill falls back to matching every copy, preserving old rows' behaviour.
+  // `link:` entries pass through untouched for inline-link badging.
   const clickedSet = useMemo(() => {
     const s = new Set<string>()
-    for (const id of conv.clickedCitations) {
-      s.add(id)
-      const rec = /rec[A-Za-z0-9]+/.exec(id)?.[0]
-      if (rec) s.add(rec)
+    for (const raw of conv.clickedCitations) {
+      s.add(raw)
+      const turnScoped = /^(\d+):(.+)$/.exec(raw)
+      if (turnScoped) {
+        const [, turn, id] = turnScoped
+        const rec = /rec[A-Za-z0-9]+/.exec(id)?.[0]
+        if (rec) s.add(`${turn}:${rec}`)
+      } else if (!raw.startsWith('link:')) {
+        const rec = /rec[A-Za-z0-9]+/.exec(raw)?.[0]
+        if (rec) s.add(rec)
+      }
     }
     return s
   }, [conv.clickedCitations])
@@ -416,6 +430,9 @@ function ConversationRow({
                 Transcript ({turnCount} turn{turnCount === 1 ? '' : 's'})
               </div>
               <div className={styles.convTranscript}>
+                <div className={styles.convGreeting}>
+                  {greetingFor(conv.page)}
+                </div>
                 {data.history.length > 0 ? (
                   data.history.map((t, i) => (
                     <div
@@ -434,7 +451,7 @@ function ConversationRow({
                           {t.content}
                         </div>
                       ) : (
-                        <TranscriptMessage text={t.content} />
+                        <TranscriptMessage text={t.content} turnIndex={i} />
                       )}
                     </div>
                   ))

--- a/src/app/admin/chatbot/TranscriptMessage.tsx
+++ b/src/app/admin/chatbot/TranscriptMessage.tsx
@@ -340,7 +340,7 @@ function parseBlocks(text: string): Block[] {
   return blocks
 }
 
-function CardPill({ card }: { card: CardSpec }) {
+function CardPill({ card, turnIndex }: { card: CardSpec; turnIndex?: number }) {
   const listings = useContext(ListingInfoContext)
   const clicked = useContext(ClickedCardsContext)
   const [imgFailed, setImgFailed] = useState(false)
@@ -351,7 +351,15 @@ function CardPill({ card }: { card: CardSpec }) {
   const primary = info?.name ?? (card.note || rec)
   const showNote = Boolean(card.note) && card.note !== primary
   const showLogo = Boolean(info?.logo) && !imgFailed
-  const wasClicked = clicked.has(card.id) || clicked.has(rec)
+  // Turn-scoped match badges only the card the visitor opened. The bare-id
+  // match is the legacy path for rows recorded before clicks were turn-scoped
+  // (their set has no `<turn>:` entries), where every copy is still badged.
+  const wasClicked =
+    (turnIndex != null &&
+      (clicked.has(`${turnIndex}:${card.id}`) ||
+        clicked.has(`${turnIndex}:${rec}`))) ||
+    clicked.has(card.id) ||
+    clicked.has(rec)
   // No resolvable listing for this id — the model fabricated/guessed it without
   // a search, so the live renderer dropped this card entirely. Flag it so a
   // reviewer can tell it apart from a real card (it can't be made clickable).
@@ -404,7 +412,13 @@ function CardPill({ card }: { card: CardSpec }) {
   )
 }
 
-function MessageBody({ text }: { text: string }) {
+function MessageBody({
+  text,
+  turnIndex,
+}: {
+  text: string
+  turnIndex?: number
+}) {
   const blocks = parseBlocks(text)
   const listings = useContext(ListingInfoContext)
   const clicked = useContext(ClickedCardsContext)
@@ -415,7 +429,7 @@ function MessageBody({ text }: { text: string }) {
           return (
             <div key={i} className={styles.convCards}>
               {block.cards.map((card, j) => (
-                <CardPill key={j} card={card} />
+                <CardPill key={j} card={card} turnIndex={turnIndex} />
               ))}
             </div>
           )
@@ -444,7 +458,16 @@ function MessageBody({ text }: { text: string }) {
   )
 }
 
-export default function TranscriptMessage({ text }: { text: string }) {
+export default function TranscriptMessage({
+  text,
+  turnIndex,
+}: {
+  text: string
+  /** This message's index in the stored conversation history, so clicked-card
+   *  badges can be matched to the exact turn. Omitted for legacy rows with no
+   *  stored history. */
+  turnIndex?: number
+}) {
   // The reasoning/search trail before the [[/thinking]] boundary is dropped
   // here: it's never shown to visitors (the live chat hides it), and it adds
   // noise to the admin transcript. parseMessage still splits it off so it
@@ -452,7 +475,7 @@ export default function TranscriptMessage({ text }: { text: string }) {
   const { body, chips } = parseMessage(text)
   return (
     <div className={styles.convMsg}>
-      <MessageBody text={body} />
+      <MessageBody text={body} turnIndex={turnIndex} />
       {chips.length > 0 && (
         <div className={styles.convChips}>
           {chips.map((chip, i) => (

--- a/src/components/assistant/Assistant.tsx
+++ b/src/components/assistant/Assistant.tsx
@@ -154,10 +154,11 @@ export default function Assistant() {
   )
 
   const handleCitationClick = useCallback(
-    (c: CitationRef) => {
+    (c: CitationRef, turnIndex: number) => {
       void fireLog({
         kind: 'click',
         citationId: c.id,
+        turnIndex,
         url: c.url,
         currentPage,
         sessionId: getSessionId(),

--- a/src/components/assistant/ChatBody.tsx
+++ b/src/components/assistant/ChatBody.tsx
@@ -242,7 +242,10 @@ interface Props {
   /** sessionStorage key for persisting messages (omit to disable). */
   storageKey?: string
   onSuggest?: (query: string, type?: string) => void
-  onCitationClick?: (c: CitationRef) => void
+  /** `turnIndex` is the clicked card's position in the message list, which
+   *  matches its index in the stored conversation history — so the admin can
+   *  badge the exact card the visitor opened. */
+  onCitationClick?: (c: CitationRef, turnIndex: number) => void
   /** Fires when the visitor clicks an inline markdown link in a reply. */
   onLinkClick?: (href: string, label: string) => void
   /** Fires when the user sends a message (typed or via a chip), excluding
@@ -679,7 +682,7 @@ const ChatBody = forwardRef<ChatBodyHandle, Props>(function ChatBody(
             )}
           </>
         ) : (
-          messages.map(m =>
+          messages.map((m, turnIndex) =>
             m.role === 'user' ? (
               <div key={m.id} className={styles.userMessageWrap}>
                 <button
@@ -712,7 +715,11 @@ const ChatBody = forwardRef<ChatBodyHandle, Props>(function ChatBody(
                   message={m}
                   allCitations={allCitations}
                   onSuggest={onSuggest}
-                  onCitationClick={onCitationClick}
+                  onCitationClick={
+                    onCitationClick
+                      ? (c: CitationRef) => onCitationClick(c, turnIndex)
+                      : undefined
+                  }
                   onLinkClick={onLinkClick}
                 />
                 {!m.isStreaming && m.followUpChips.length > 0 && (

--- a/src/lib/assistant/log.ts
+++ b/src/lib/assistant/log.ts
@@ -20,6 +20,11 @@ export interface AssistantClickEvent {
   target?: 'card' | 'link'
   /** The listing id, for card clicks. Absent for link clicks. */
   citationId?: string
+  /** Which assistant turn the clicked card sat in (its index in the stored
+   *  conversation history). Lets the admin badge the one card the visitor
+   *  actually clicked instead of every copy of that listing across the chat.
+   *  Absent for link clicks and for older clients that didn't send it. */
+  turnIndex?: number
   /** Destination: the card's url, or the inline link's href. */
   url: string
   /** The link's visible text, for link clicks (shown in the admin viewer). */
@@ -55,15 +60,23 @@ export async function logAssistantEvent(event: AssistantEvent): Promise<void> {
   console.log(`[assistant] ${line}`)
 
   // Persist clicks onto the conversation row so the admin viewer can show what
-  // the visitor actually opened. Cards are keyed by listing id; inline links by
-  // a `link:`-prefixed href, which never collides with a `type:recXXX` id.
+  // the visitor actually opened. Cards are keyed `<turnIndex>:<listing id>` so
+  // the exact instance is known (a listing can be shown in several replies);
+  // inline links by a `link:`-prefixed href, which never collides with a
+  // `type:recXXX` id. Older clients omit turnIndex — fall back to the bare
+  // listing id, which the admin still matches (badging every copy) for legacy
+  // rows.
   if (
     event.kind === 'click' &&
     event.sessionId &&
     isConversationsTableConfigured()
   ) {
     const clickKey =
-      event.target === 'link' ? `link:${event.url}` : event.citationId
+      event.target === 'link'
+        ? `link:${event.url}`
+        : event.citationId != null && event.turnIndex != null
+          ? `${event.turnIndex}:${event.citationId}`
+          : event.citationId
     try {
       if (clickKey) await recordCitationClick(event.sessionId, clickKey)
     } catch (err) {


### PR DESCRIPTION
- The transcript now shows the page's opening chatbot message at the top (subtle, muted grey), since visitors are usually replying to it — this gives that first turn context.
- The "clicked" badge now marks only the card the visitor actually opened. Clicks are recorded per reply (`turnIndex:listingId`) instead of just by listing, so a listing shown across several replies no longer looks like it was clicked in each one.
- Conversations logged before this change have no per-click detail, so they keep the previous behaviour (badging every copy of a clicked listing). Inline-link click badges are unchanged.

Verified live in dev: a two-turn chat that surfaced the same community card twice — after clicking it in the first reply, only that copy shows the badge, not the second. The opening-message line renders correctly per page.

_PR description written by Claude Code._