### PR TITLE
Analytics: site-wide leaderboards + expandable listing tables

### DIFF
--- a/src/app/admin/analytics/ExpandableBody.tsx
+++ b/src/app/admin/analytics/ExpandableBody.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { Children, useState, type ReactNode } from 'react'
+import styles from './analytics.module.css'
+
+/** A table <tbody> that shows only the first `initial` rows, with a button that
+ *  reveals `step` more on each click. The rows are rendered on the server and
+ *  handed in as children, so every per-row detail (logos, links, pills) stays
+ *  server-side; this component only decides how many are visible. When the row
+ *  count is at or below `initial`, no button renders and it behaves like a plain
+ *  <tbody>. `colSpan` must match the table's column count so the button row
+ *  spans the full width. */
+export default function ExpandableBody({
+  children,
+  colSpan,
+  initial = 50,
+  step = 50,
+}: {
+  children: ReactNode
+  colSpan: number
+  initial?: number
+  step?: number
+}) {
+  const rows = Children.toArray(children)
+  const [visible, setVisible] = useState(initial)
+  const remaining = rows.length - visible
+  return (
+    <tbody>
+      {rows.slice(0, visible)}
+      {remaining > 0 && (
+        <tr className={styles.showMoreRow}>
+          <td colSpan={colSpan}>
+            <button
+              type="button"
+              className={styles.showMoreBtn}
+              onClick={() => setVisible(v => v + step)}
+            >
+              Show {Math.min(step, remaining)} more · {remaining} hidden
+            </button>
+          </td>
+        </tr>
+      )}
+    </tbody>
+  )
+}

--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -160,6 +160,32 @@
   color: var(--teal-400);
 }
 
+/* "Show more" row: a full-width button under a truncated listing table. */
+.showMoreRow td {
+  padding-top: 12px;
+  text-align: center;
+  border-bottom: none;
+}
+
+.showMoreBtn {
+  padding: 6px 16px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--teal-300);
+  background-color: transparent;
+  border: 1px solid var(--teal-800);
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    color var(--hover-transition),
+    background-color var(--hover-transition);
+}
+
+.showMoreBtn:hover {
+  color: var(--white);
+  background-color: var(--teal-800);
+}
+
 .caption {
   margin-top: 12px;
   font-size: 11px;

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -5,6 +5,7 @@ import {
   type Counted,
   type DateRange,
   type ChatbotFunnel,
+  type OverallListingRow,
 } from '@/lib/analytics/events'
 import { getFunders } from '@/lib/data/funding'
 import { getCourses } from '@/lib/data/self-study'
@@ -17,6 +18,7 @@ import { getMapData } from '@/lib/data/map'
 import { getProjects } from '@/lib/data/projects'
 import DateRangePicker from './DateRangePicker'
 import ExcludeToggle from './ExcludeToggle'
+import ExpandableBody from './ExpandableBody'
 import Logo from './Logo'
 import admin from '../admin.module.css'
 import styles from './analytics.module.css'
@@ -294,7 +296,7 @@ export default async function AnalyticsPage({
   const urlByName = new Map(data.topListings.map(r => [r.name, r.url]))
 
   // Chart totals (also the % denominators). The listings total is the selected
-  // page's whole click count, not just the visible top-15 rows.
+  // page's whole click count, not just the rows currently revealed.
   const totalClicks = data.byPage.reduce((sum, r) => sum + r.count, 0)
   const pageTotal = data.byPage.find(p => p.name === data.selectedPage)?.count
   // When the listings are filtered to one source, the top-listings table is a
@@ -305,6 +307,19 @@ export default async function AnalyticsPage({
         ?.count
     : pageTotal
   const positionTotal = data.byPosition.reduce((sum, r) => sum + r.count, 0)
+
+  // Site-wide leaderboards for the Overview tab. The listings total is every
+  // page's clicks (same denominator as "Clicks by page"); the position total is
+  // only the clicks that carry a slot. Resolve each row's page to its site label
+  // (e.g. 'Founders' → 'Founder toolkit') so the page pills read the site's way.
+  const overallListings = data.topListingsOverall.map(r => ({
+    ...r,
+    pageLabel: r.page ? (labelByPage.get(r.page) ?? r.page) : undefined,
+  }))
+  const overallPositionTotal = data.byPositionOverall.reduce(
+    (sum, r) => sum + r.count,
+    0
+  )
 
   return (
     <div>
@@ -405,6 +420,33 @@ export default async function AnalyticsPage({
                   </p>
                 </Panel>
               </div>
+            </div>
+          )}
+
+          {activeTab === 'pages' && (
+            <div className={styles.grid}>
+              <Panel title="Most clicked listings overall">
+                <OverallListingsTable
+                  rows={overallListings}
+                  total={totalClicks}
+                />
+                <p className={styles.caption}>
+                  Every listing across all resource pages, ranked by clicks this
+                  period. Open a page&apos;s tab for its own breakdown.
+                </p>
+              </Panel>
+              <Panel title="Clicks by position overall">
+                <CountTable
+                  rows={data.byPositionOverall}
+                  labelHead="Slot"
+                  total={overallPositionTotal}
+                />
+                <p className={styles.caption}>
+                  Every click across all pages counted at the slot it happened
+                  in (F1/F2 = featured cards) — how much attention each slot
+                  draws site-wide.
+                </p>
+              </Panel>
             </div>
           )}
 
@@ -675,6 +717,7 @@ function CountTable({
 }) {
   if (rows.length === 0) return <p className={styles.dim}>No data yet.</p>
   const showPct = total != null && total > 0
+  const colSpan = (rankFor ? 1 : 0) + 2 + (showPct ? 1 : 0)
   return (
     <table className={styles.table}>
       <thead>
@@ -685,7 +728,7 @@ function CountTable({
           {showPct && <th className={styles.pctCol}>%</th>}
         </tr>
       </thead>
-      <tbody>
+      <ExpandableBody colSpan={colSpan}>
         {rows.map((r, i) => {
           const rank = rankFor?.(r.name)
           const featured = rank?.startsWith('F')
@@ -725,7 +768,7 @@ function CountTable({
             </tr>
           )
         })}
-      </tbody>
+      </ExpandableBody>
       {total != null && (
         <tfoot>
           <tr className={styles.totalRow}>
@@ -736,6 +779,78 @@ function CountTable({
           </tr>
         </tfoot>
       )}
+    </table>
+  )
+}
+
+/** The Overview tab's site-wide listings leaderboard. Like CountTable, but each
+ *  row carries the page it came from (shown as a pill) and always uses a favicon
+ *  — listings here span every page, so there's no single page's logos to load.
+ *  `total` is every page's click count, so the top-N rows can sum to less than
+ *  it; the Total footer shows the true denominator. */
+function OverallListingsTable({
+  rows,
+  total,
+}: {
+  rows: (OverallListingRow & { pageLabel?: string })[]
+  total: number
+}) {
+  if (rows.length === 0) return <p className={styles.dim}>No data yet.</p>
+  const showPct = total > 0
+  const colSpan = 3 + (showPct ? 1 : 0)
+  return (
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>Listing</th>
+          <th>Page</th>
+          <th className={styles.numCol}>Clicks</th>
+          {showPct && <th className={styles.pctCol}>%</th>}
+        </tr>
+      </thead>
+      <ExpandableBody colSpan={colSpan}>
+        {rows.map((r, i) => {
+          const favicon = faviconFor(r.url)
+          const href = r.url
+          return (
+            <tr key={i}>
+              <td className={styles.nameCell}>
+                {href && href !== '#' ? (
+                  <a
+                    className={styles.logoLink}
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={`Open ${r.name}`}
+                  >
+                    <Logo src={favicon} />
+                  </a>
+                ) : (
+                  <Logo src={favicon} />
+                )}
+                <span>{r.name}</span>
+              </td>
+              <td>
+                {r.pageLabel && (
+                  <span className={styles.pill}>{r.pageLabel}</span>
+                )}
+              </td>
+              <td className={styles.numCol}>{r.count.toLocaleString()}</td>
+              {showPct && (
+                <td className={styles.pctCol}>{pct1(r.count, total)}</td>
+              )}
+            </tr>
+          )
+        })}
+      </ExpandableBody>
+      <tfoot>
+        <tr className={styles.totalRow}>
+          <td className={styles.totalLabel}>Total</td>
+          <td />
+          <td className={styles.numCol}>{total.toLocaleString()}</td>
+          {showPct && <td className={styles.pctCol}>{pct1(total, total)}</td>}
+        </tr>
+      </tfoot>
     </table>
   )
 }

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -164,6 +164,14 @@ export interface ListingRow extends Counted {
   url?: string
 }
 
+export interface OverallListingRow extends Counted {
+  /** The resource page this listing belongs to (e.g. 'Funding'), so the
+   *  site-wide leaderboard can show which page each top listing came from. */
+  page?: string
+  /** A representative destination url (most recent click), for the favicon. */
+  url?: string
+}
+
 export interface DateRange {
   /** Inclusive lower bound in epoch ms, or null for no lower bound. */
   startMs: number | null
@@ -196,6 +204,12 @@ export interface DashboardData {
   /** `selectedPage`'s clicks bucketed by the slot they happened in, ordered F1,
    *  F2, 1, 2, 3… — answers "do higher slots draw more clicks" for that page. */
   byPosition: Counted[]
+  /** Site-wide most-clicked listings, across every page (not scoped to
+   *  `selectedPage`). Each row carries the page it came from. */
+  topListingsOverall: OverallListingRow[]
+  /** Every click across every page bucketed by the slot it happened in, ordered
+   *  F1, F2, 1, 2, 3… — the site-wide version of `byPosition`. */
+  byPositionOverall: Counted[]
   /** For pages with a map (Map, Communities): the selected page's clicks split
    *  into 'Map' vs 'Cards'. Empty for pages without a map. Always the full split,
    *  even when one source is selected, so the user can switch between them. */
@@ -213,6 +227,8 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   selectedPage: null,
   topListings: [],
   byPosition: [],
+  topListingsOverall: [],
+  byPositionOverall: [],
   bySource: [],
   selectedSource: null,
   funnel: { opened: 0, typed: 0, clicked: 0 },
@@ -368,6 +384,9 @@ function aggregate(
     if (!g.url && e.url) g.url = e.url
     perListing.set(k, g)
   }
+  // Every listing for the page, ranked by clicks — the dashboard shows the first
+  // 50 and lets the user reveal more, so we return the full list rather than a
+  // fixed top-N here.
   const topListings: ListingRow[] = [...perListing.entries()]
     .map(([name, g]) => ({
       name,
@@ -376,7 +395,34 @@ function aggregate(
       url: g.url,
     }))
     .sort((a, b) => b.count - a.count)
-    .slice(0, 15)
+
+  // Site-wide leaderboards, independent of the selected page: the most-clicked
+  // listings and the busiest slots across every page. Keyed by page+listing so
+  // the same name on two pages stays two rows (each keeps its own page pill).
+  const perOverall = new Map<
+    string,
+    { name: string; page?: string; count: number; url?: string }
+  >()
+  for (const e of clicks) {
+    const name = listingMember(e)
+    const key = `${e.page ?? ''} ${name}`
+    // clicks is newest-first, so the first url seen for a listing is the latest.
+    const g = perOverall.get(key) ?? {
+      name,
+      page: e.page,
+      count: 0,
+      url: e.url,
+    }
+    g.count += 1
+    if (!g.url && e.url) g.url = e.url
+    perOverall.set(key, g)
+  }
+  const topListingsOverall: OverallListingRow[] = [...perOverall.values()]
+    .map(g => ({ name: g.name, page: g.page, count: g.count, url: g.url }))
+    .sort((a, b) => b.count - a.count)
+  const byPositionOverall = tallyPositions(
+    clicks.map(e => e.position).filter((p): p is string => p != null)
+  )
 
   // Source split, only for pages with a map. Clicks are explicitly tagged 'map'
   // or 'cards' at click time; anything untagged (logged before source tracking,
@@ -408,6 +454,8 @@ function aggregate(
     byPosition: tallyPositions(
       pageClicks.map(e => e.position).filter((p): p is string => p != null)
     ),
+    topListingsOverall,
+    byPositionOverall,
     bySource,
     selectedSource,
     funnel: {


### PR DESCRIPTION
- Adds two panels to the Overview tab, above Recent activity: **Most clicked listings overall** (top listings across every resource page, each with a page pill and favicon) and **Clicks by position overall** (every click site-wide bucketed by the slot it happened in, F1/F2 first).
- Listing tables now show 50 rows by default with a "Show more" button that reveals 50 more per click. Rows are rendered server-side; a small client component only controls how many are visible. Tables with 50 or fewer rows look exactly as before.
- The analytics store returns full ranked lists instead of a fixed top-15; Total rows and percentages keep the full denominators.

_PR description written by Claude Code._

🤖 Generated with [Claude Code](https://claude.com/claude-code)