### PR TITLE
Chat cards: long listing names wrap instead of getting cut off

### DIFF
--- a/src/components/assistant/Assistant.module.css
+++ b/src/components/assistant/Assistant.module.css
@@ -449,9 +449,9 @@
   line-height: 1.3;
   letter-spacing: -0.2px;
   color: var(--white);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  /* Long listing names wrap onto extra lines rather than truncating. */
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .citationMeta {


### PR DESCRIPTION
- Long listing names on chat cards (e.g. "Alignment Research Engineer Accelerator (ARE…") were truncated with an ellipsis. They now wrap onto another line, same as the note text below them already does.
- One CSS change in the chat widget's stylesheet; follows docs/css-guidelines.md (no new classes, colors, or breakpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)