### PR TITLE
Site search: link group headers to their resource pages

### DIFF
--- a/src/components/SearchModal.module.css
+++ b/src/components/SearchModal.module.css
@@ -163,6 +163,16 @@
   color: var(--teal-500);
 }
 
+.group-link {
+  transition: color var(--hover-transition);
+}
+
+.group-link:hover {
+  color: var(--teal-300);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .group-count {
   color: var(--teal-600);
   font-weight: 400;

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -8,6 +8,7 @@ import {
   BROWSE_TYPES,
   TYPE_ICON,
   TYPE_LABEL,
+  TYPE_PATH,
   countsByType,
   groupByType,
   search,
@@ -327,7 +328,13 @@ export default function SearchModal({
                 <div
                   className={`${styles['group-label']} paragraph-xs-bold flex items-center gap-8px padding-top-16px padding-bottom-8px padding-left-12px padding-right-12px`}
                 >
-                  <span>{TYPE_LABEL[type]}</span>
+                  {TYPE_PATH[type] ? (
+                    <a href={TYPE_PATH[type]} className={styles['group-link']}>
+                      {TYPE_LABEL[type]}
+                    </a>
+                  ) : (
+                    <span>{TYPE_LABEL[type]}</span>
+                  )}
                   <span className={styles['group-count']}>{items.length}</span>
                 </div>
               )}


### PR DESCRIPTION
- The section headers in the search modal ("Founder toolkit", "Field map", "Jobs", etc.) are now links to their resource pages, using the type-to-path mapping the search already had.
- On hover the header brightens and underlines so it reads as clickable; non-hovered headers look exactly as before.
- The "Pages" group header (which has no landing page of its own) stays plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)