### PR TITLE
Chatbot: make the admin log faithfully mirror what the visitor saw

### DIFF
--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -945,25 +945,52 @@
   white-space: nowrap;
 }
 
-/* Card whose id didn't resolve to a listing (fabricated by the model). Dimmed
-   with a dashed border so it reads as broken, not a real card. */
-.convCardUnresolved {
+/* Card the visitor never got: their chat showed a generic "Browse X"
+   resource-page link instead (the model wrote the card without retrieving
+   the listing). The link is rendered as they saw it; the note next to it is
+   admin-only annotation. */
+.convCardDegradedRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.convCardFallback {
   border-style: dashed;
-  border-color: var(--teal-600);
+  border-color: rgba(255, 170, 90, 0.4);
+}
+
+.convCardFallbackNote {
+  font-size: 11px;
+  color: #ffb96b;
+}
+
+/* Card the visitor's chat dropped entirely (no listing AND no parseable type
+   to fall back to). Nothing rendered live, so nothing card-like here either —
+   just a dimmed admin-only marker. */
+.convCardGhost {
+  display: inline-flex;
+  padding: 5px 10px;
+  border: 1px dashed var(--teal-600);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--teal-300);
   opacity: 0.65;
 }
 
-.convCardUnresolvedTag {
-  padding: 1px 7px;
-  background-color: rgba(255, 170, 90, 0.15);
-  border: 1px solid rgba(255, 170, 90, 0.4);
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-  color: #ffb96b;
-  white-space: nowrap;
+/* Token the live renderer stripped (malformed directive) or a reference that
+   resolved to nothing — the visitor saw no trace of it. */
+.convStripped {
+  color: var(--teal-300);
+  opacity: 0.6;
+}
+
+/* Block the visitor's chat hid entirely (a cards block where nothing could
+   render, plus its dangling lead-in sentence). Dimmed rather than hidden so
+   the reviewer still sees what the model wrote. */
+.convNotShown {
+  opacity: 0.45;
 }
 
 .convCardInline {

--- a/src/app/admin/chatbot/ConversationList.tsx
+++ b/src/app/admin/chatbot/ConversationList.tsx
@@ -34,16 +34,24 @@ interface LoggedToolCall {
  *  backwards. A reply's tools sit at the entry of the user message it answers;
  *  a window that opens mid-turn (leading assistant message) resolves to the
  *  entry before the window's first user turn. */
+function turnEntryForMessage(
+  history: HistoryTurn[],
+  entries: unknown[],
+  msgIdx: number
+): unknown {
+  const totalUsers = history.filter(t => t.role === 'user').length
+  const usersUpToHere = history
+    .slice(0, msgIdx)
+    .filter(t => t.role === 'user').length
+  return entries[entries.length - 1 - (totalUsers - usersUpToHere)]
+}
+
 function toolCallsForMessage(
   history: HistoryTurn[],
   tools: unknown[],
   msgIdx: number
 ): LoggedToolCall[] {
-  const totalUsers = history.filter(t => t.role === 'user').length
-  const usersUpToHere = history
-    .slice(0, msgIdx)
-    .filter(t => t.role === 'user').length
-  const turn = tools[tools.length - 1 - (totalUsers - usersUpToHere)]
+  const turn = turnEntryForMessage(history, tools, msgIdx)
   if (!Array.isArray(turn)) return []
   return turn.filter(
     (t): t is LoggedToolCall =>
@@ -51,6 +59,30 @@ function toolCallsForMessage(
       typeof t === 'object' &&
       typeof (t as LoggedToolCall).name === 'string'
   )
+}
+
+/** Card ids in the reply at history index msgIdx that degraded to a generic
+ *  "Browse X" link (or nothing) in the visitor's chat. Undefined when the turn
+ *  predates fallback tracking, so the renderer can fall back to its
+ *  resolvability heuristic. The set carries each id plus its bare rec form,
+ *  since card tokens are sometimes written without the type prefix. */
+function fallbackCardsForMessage(
+  history: HistoryTurn[],
+  fallbackCards: unknown[] | undefined,
+  msgIdx: number
+): Set<string> | undefined {
+  if (!fallbackCards) return undefined
+  const turn = turnEntryForMessage(history, fallbackCards, msgIdx)
+  if (!Array.isArray(turn)) return undefined
+  const set = new Set<string>()
+  for (const id of turn) {
+    if (typeof id !== 'string') continue
+    const cleaned = id.replace(/\s+/g, '')
+    set.add(cleaned)
+    const rec = /rec[A-Za-z0-9]+/.exec(cleaned)?.[0]
+    if (rec) set.add(rec)
+  }
+  return set
 }
 
 /** Web visits (live page reads) the bot made while composing a reply — shown
@@ -88,6 +120,9 @@ interface ConversationData {
   response: string
   history: HistoryTurn[]
   tools: unknown[]
+  /** Per-turn (aligned with tools): card ids that degraded to a "Browse X"
+   *  link in the visitor's chat. Absent on rows from before this was logged. */
+  fallbackCards?: unknown[]
   citations: string[]
   citationRefs?: { id: string; name: string; url: string; logo?: string }[]
   geo: { city?: string; region?: string; country?: string } | null
@@ -528,7 +563,15 @@ function ConversationRow({
                             {t.content}
                           </div>
                         ) : (
-                          <TranscriptMessage text={t.content} turnIndex={i} />
+                          <TranscriptMessage
+                            text={t.content}
+                            turnIndex={i}
+                            fallbackCardIds={fallbackCardsForMessage(
+                              data.history,
+                              data.fallbackCards,
+                              i
+                            )}
+                          />
                         )}
                       </div>
                     )

--- a/src/app/admin/chatbot/ConversationList.tsx
+++ b/src/app/admin/chatbot/ConversationList.tsx
@@ -417,14 +417,14 @@ function ConversationRow({
   // for old rows that have no stored history.
   const firstUser =
     data?.history.find(t => t.role === 'user')?.content ?? data?.user ?? ''
-  // Cards the visitor clicked. New clicks are stored turn-scoped as
-  // `<turnIndex>:<listing id>` so only the card the visitor actually opened is
-  // badged — a listing shown in three replies no longer looks like three
-  // clicks. We seed the set with each entry verbatim plus a `<turn>:<rec>`
-  // variant (tokens are sometimes written without the type prefix). Legacy
-  // entries have no leading `<turn>:` — for those we also add the bare rec, and
-  // CardPill falls back to matching every copy, preserving old rows' behaviour.
-  // `link:` entries pass through untouched for inline-link badging.
+  // Cards and links the visitor clicked. New clicks are stored turn-scoped as
+  // `<turnIndex>:<listing id>` / `<turnIndex>:link:<href>` so only the
+  // instance the visitor actually opened is badged — a listing or href shown
+  // in three replies no longer looks like three clicks. For card entries we
+  // seed the set with each entry verbatim plus a `<turn>:<rec>` variant
+  // (tokens are sometimes written without the type prefix). Legacy entries
+  // have no leading `<turn>:` — for those the renderers fall back to matching
+  // every copy, preserving old rows' behaviour.
   const clickedSet = useMemo(() => {
     const s = new Set<string>()
     for (const raw of conv.clickedCitations) {
@@ -432,8 +432,10 @@ function ConversationRow({
       const turnScoped = /^(\d+):(.+)$/.exec(raw)
       if (turnScoped) {
         const [, turn, id] = turnScoped
-        const rec = /rec[A-Za-z0-9]+/.exec(id)?.[0]
-        if (rec) s.add(`${turn}:${rec}`)
+        if (!id.startsWith('link:')) {
+          const rec = /rec[A-Za-z0-9]+/.exec(id)?.[0]
+          if (rec) s.add(`${turn}:${rec}`)
+        }
       } else if (!raw.startsWith('link:')) {
         const rec = /rec[A-Za-z0-9]+/.exec(raw)?.[0]
         if (rec) s.add(rec)

--- a/src/app/admin/chatbot/TranscriptMessage.tsx
+++ b/src/app/admin/chatbot/TranscriptMessage.tsx
@@ -10,6 +10,7 @@ import {
   SuggestInline,
   parseSuggestToken,
 } from '@/components/assistant/MessageContent'
+import { cardTypePage } from '@/components/assistant/cardFallback'
 import { suggestFormUrl } from '@/lib/assistant/constants'
 import styles from '../admin.module.css'
 
@@ -67,10 +68,38 @@ function lastThinkingDone(
 }
 const CHIP_RE = /\[\[\s*chip\s*:([^\]\n]*)\]\]/gi
 const SUGGEST_TOKEN_RE = /^\[\[\s*suggest\s*:([^\]\n]*)\]\]$/i
+// Same strict grammar as the live renderer's CARD_LINE (MessageContent): a
+// card line must carry a proper rec id. Sloppier tokens (a space inside the
+// rec id, no rec at all) were NOT cards in the visitor's chat — the live
+// malformed-directive sweep stripped them — so they must not become pills
+// here either; they fall through to the paragraph path and render as
+// struck-through "stripped" tokens instead.
 const CARD_LINE_RE =
-  /^\s*\[\[\s*card\s*:\s*([^\]|\n]+?)(?:\s*\|([^\]\n]*))?\s*\]\]\s*$/i
+  /^\s*\[\[\s*card\s*:\s*((?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+)(?:\s*\|([^\]\n]*))?\s*\]\]\s*$/i
+// Anchored well-formedness tests for inline card/id tokens, mirroring the
+// live renderer's CARD_TOKEN_RE / ID_TOKEN_RE.
+const STRICT_CARD_TOKEN_RE =
+  /^\[\[\s*card\s*:\s*(?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+(?:\s*\|[^\]\n]*)?\s*\]\]$/i
+const STRICT_ID_TOKEN_RE =
+  /^\[\[\s*id\s*:\s*(?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+\s*\]\]$/i
 const INLINE_RE =
   /(\[\[[^\]\n]*\]\])|(\[[^\]\n]+\]\(\/?[^)\n]+\))|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(\baisafety\.info(?:\/[^\s<>),]*)?)/gi
+
+/** Did the visitor get a real card for this token, or a degraded fallback?
+ *  Turns logged since fallback tracking (Data.fallbackCards) say exactly
+ *  which ids degraded; for older turns, an id that resolves to nothing was
+ *  certainly degraded live (the widget had no listing for it either). */
+function cardDegraded(
+  cardId: string,
+  listings: Record<string, ListingInfo>,
+  fallbackIds?: Set<string>
+): boolean {
+  if (fallbackIds) {
+    const rec = /rec[A-Za-z0-9]+/.exec(cardId)?.[0]
+    return fallbackIds.has(cardId) || (!!rec && fallbackIds.has(rec))
+  }
+  return !resolveListing(listings, cardId)
+}
 
 /** "job:recXXX" → "job"; bare rec ids have no type. */
 function cardType(rawId: string): string | null {
@@ -177,7 +206,8 @@ export function hasSuggestButton(text: string): boolean {
 function renderInline(
   text: string,
   listings: Record<string, ListingInfo>,
-  clicked: Set<string>
+  clicked: Set<string>,
+  fallbackIds?: Set<string>
 ): ReactNode[] {
   const parts: ReactNode[] = []
   let lastIndex = 0
@@ -209,36 +239,88 @@ function renderInline(
             />
           )
         }
-      } else {
-        // Well-formed card/id tokens become inline badges; any other [[...]]
-        // directive is malformed or already handled — drop it silently rather
-        // than leaking raw brackets.
-        const label = /^\[\[\s*(?:card|id)\s*:/i.test(token)
-          ? inlineCardLabel(token, listings)
-          : ''
-        if (label) {
+      } else if (/^\[\[\s*(?:card|id)\s*:/i.test(token)) {
+        if (
+          STRICT_CARD_TOKEN_RE.test(token) ||
+          STRICT_ID_TOKEN_RE.test(token)
+        ) {
+          const rawId =
+            /^\[\[\s*(?:card|id)\s*:\s*([^\]|\n]+?)(?:\s*\|[^\]\n]*)?\s*\]\]$/i
+              .exec(token)?.[1]
+              ?.replace(/\s+/g, '') ?? ''
+          if (cardDegraded(rawId, listings, fallbackIds)) {
+            // Live, an inline reference the widget couldn't resolve rendered
+            // nothing — mark it so the reviewer knows the visitor saw no link.
+            parts.push(
+              <s
+                key={`c-${key++}`}
+                className={styles.convStripped}
+                title="This inline reference did not resolve in the visitor's chat — they saw no link here"
+              >
+                {inlineCardLabel(token, listings) || rawId}
+              </s>
+            )
+          } else {
+            parts.push(
+              <span key={`c-${key++}`} className={styles.convCardInline}>
+                {inlineCardLabel(token, listings)}
+              </span>
+            )
+          }
+        } else {
+          // Malformed card/id token (e.g. a space inside the rec id): the live
+          // renderer's malformed-directive sweep stripped it, so the visitor
+          // saw nothing — show it struck-through rather than as a real badge.
           parts.push(
-            <span key={`c-${key++}`} className={styles.convCardInline}>
-              {label}
-            </span>
+            <s
+              key={`c-${key++}`}
+              className={styles.convStripped}
+              title="Malformed token — stripped from the visitor's view"
+            >
+              {token}
+            </s>
           )
         }
       }
+      // Any other [[...]] directive is already handled or defensive-stripped
+      // by the live renderer — drop it silently rather than leaking brackets.
     } else if (token.startsWith('[')) {
       const m = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(token)
-      if (m) {
+      // Mirror the live renderer's scheme guard: only http(s) and
+      // site-relative destinations became links for the visitor; anything
+      // else (e.g. javascript:) rendered as plain text.
+      if (m && /^(https?:\/\/|\/|#)/.test(m[2])) {
         parts.push(inlineLink(m[2], m[1], clicked, `l-${key++}`))
       } else {
         parts.push(token)
       }
     } else if (token.startsWith('**')) {
-      parts.push(<strong key={`b-${key++}`}>{token.slice(2, -2)}</strong>)
+      // Recurse so markdown inside bold (e.g. `**[Jobs](/jobs)**`) renders as
+      // it did live. INLINE_RE is shared global state — save/restore its
+      // cursor around the recursive call.
+      const saved = INLINE_RE.lastIndex
+      const inner = renderInline(
+        token.slice(2, -2),
+        listings,
+        clicked,
+        fallbackIds
+      )
+      INLINE_RE.lastIndex = saved
+      parts.push(<strong key={`b-${key++}`}>{inner}</strong>)
     } else if (/^aisafety\.info/i.test(token)) {
       // Auto-linkify bare aisafety.info mentions, matching the live renderer
       // (the bot writes it as plain text rather than a markdown link).
       parts.push(inlineLink(`https://${token}`, token, clicked, `u-${key++}`))
     } else {
-      parts.push(<em key={`i-${key++}`}>{token.slice(1, -1)}</em>)
+      const saved = INLINE_RE.lastIndex
+      const inner = renderInline(
+        token.slice(1, -1),
+        listings,
+        clicked,
+        fallbackIds
+      )
+      INLINE_RE.lastIndex = saved
+      parts.push(<em key={`i-${key++}`}>{inner}</em>)
     }
     lastIndex = match.index + token.length
   }
@@ -340,12 +422,62 @@ function parseBlocks(text: string): Block[] {
   return blocks
 }
 
-function CardPill({ card, turnIndex }: { card: CardSpec; turnIndex?: number }) {
+function CardPill({
+  card,
+  turnIndex,
+  fallbackIds,
+}: {
+  card: CardSpec
+  turnIndex?: number
+  fallbackIds?: Set<string>
+}) {
   const listings = useContext(ListingInfoContext)
   const clicked = useContext(ClickedCardsContext)
   const [imgFailed, setImgFailed] = useState(false)
   const info = resolveListing(listings, card.id)
   const rec = /rec[A-Za-z0-9]+/.exec(card.id)?.[0] ?? card.id
+
+  // The visitor never got this card: the model wrote it without a tool having
+  // returned the listing, so the live widget degraded it to a generic
+  // "Browse X" link — or, when even the type wasn't parseable, dropped it.
+  // Render what the visitor actually saw, annotated with what the model wrote.
+  if (cardDegraded(card.id, listings, fallbackIds)) {
+    const fb = cardTypePage(card.id)
+    const attempted = info?.name ?? card.id
+    if (!fb) {
+      return (
+        <span
+          className={styles.convCardGhost}
+          title="The model wrote this card without retrieving the listing and its type wasn't parseable, so the visitor's chat dropped it entirely"
+        >
+          hidden from visitor: {attempted}
+        </span>
+      )
+    }
+    const wasClicked = clicked.has(`link:${fb.path}`)
+    return (
+      <span className={styles.convCardDegradedRow}>
+        <a
+          href={fb.path}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`${styles.convCard} ${styles.convCardLink} ${styles.convCardFallback}`}
+          title="This is what the visitor saw: a generic resource-page link, not a card — the model wrote the card without retrieving the listing"
+        >
+          <span className={styles.convCardName}>{fb.label}</span>
+          {wasClicked && (
+            <span className={styles.convCardClicked}>✓ clicked</span>
+          )}
+        </a>
+        <span className={styles.convCardFallbackNote}>
+          {info
+            ? `shown instead of “${info.name}” — the model carded it without a search`
+            : `fabricated id: ${card.id}`}
+        </span>
+      </span>
+    )
+  }
+
   // Prefer the real listing name; fall back to the note, then the raw id, so
   // a card is never blank.
   const primary = info?.name ?? (card.note || rec)
@@ -360,15 +492,11 @@ function CardPill({ card, turnIndex }: { card: CardSpec; turnIndex?: number }) {
         clicked.has(`${turnIndex}:${rec}`))) ||
     clicked.has(card.id) ||
     clicked.has(rec)
-  // No resolvable listing for this id — the model fabricated/guessed it without
-  // a search, so the live renderer dropped this card entirely. Flag it so a
-  // reviewer can tell it apart from a real card (it can't be made clickable).
-  const unresolved = !info
   // Link to the listing's external URL (what the live card opens); fall back
   // to its AISafety.com resource page when there's no usable external URL.
   const href =
     info?.url && /^https?:\/\//.test(info.url) ? info.url : info?.pageUrl
-  const className = `${styles.convCard}${wasClicked ? ` ${styles.convCardClickedRow}` : ''}${href ? ` ${styles.convCardLink}` : ''}${unresolved ? ` ${styles.convCardUnresolved}` : ''}`
+  const className = `${styles.convCard}${wasClicked ? ` ${styles.convCardClickedRow}` : ''}${href ? ` ${styles.convCardLink}` : ''}`
   const inner = (
     <>
       {showLogo ? (
@@ -387,14 +515,6 @@ function CardPill({ card, turnIndex }: { card: CardSpec; turnIndex?: number }) {
       {card.type && <span className={styles.convCardType}>{card.type}</span>}
       <span className={styles.convCardName}>{primary}</span>
       {showNote && <span className={styles.convCardNote}>{card.note}</span>}
-      {unresolved && (
-        <span
-          className={styles.convCardUnresolvedTag}
-          title="No listing matched this id — the model fabricated it without a search, so the live card was dropped"
-        >
-          unresolved
-        </span>
-      )}
       {wasClicked && <span className={styles.convCardClicked}>✓ clicked</span>}
     </>
   )
@@ -415,43 +535,105 @@ function CardPill({ card, turnIndex }: { card: CardSpec; turnIndex?: number }) {
 function MessageBody({
   text,
   turnIndex,
+  fallbackIds,
 }: {
   text: string
   turnIndex?: number
+  fallbackIds?: Set<string>
 }) {
   const blocks = parseBlocks(text)
   const listings = useContext(ListingInfoContext)
   const clicked = useContext(ClickedCardsContext)
+
+  // Mirror the live renderer's hiddenBlocks: a cards block where NOTHING was
+  // renderable (every card degraded with no "Browse X" fallback either) was
+  // hidden from the visitor along with its dangling colon-terminated lead-in
+  // sentence. The admin dims those blocks instead of hiding them, so the
+  // reviewer sees what the model wrote AND that the visitor never saw it.
+  const dimmed = new Set<number>()
+  blocks.forEach((block, i) => {
+    if (block.kind !== 'cards') return
+    const anyRenderable = block.cards.some(
+      card =>
+        !cardDegraded(card.id, listings, fallbackIds) || cardTypePage(card.id)
+    )
+    if (anyRenderable) return
+    dimmed.add(i)
+    const prev = blocks[i - 1]
+    if (prev && prev.kind !== 'cards' && prev.lines.length > 0) {
+      const lead = prev.lines[prev.lines.length - 1]
+        .trimEnd()
+        .replace(/[*_`]+$/, '')
+        .trimEnd()
+      if (
+        lead.endsWith(':') &&
+        (prev.kind === 'paragraph' || prev.lines.length === 1)
+      ) {
+        dimmed.add(i - 1)
+      }
+    }
+  })
+
+  const wrap = (i: number, node: ReactNode) =>
+    dimmed.has(i) ? (
+      <div
+        key={i}
+        className={styles.convNotShown}
+        title="Hidden from the visitor — their chat dropped this block (no card in it could render)"
+      >
+        {node}
+      </div>
+    ) : (
+      node
+    )
+
   return (
     <>
       {blocks.map((block, i) => {
         if (block.kind === 'cards') {
-          return (
+          return wrap(
+            i,
             <div key={i} className={styles.convCards}>
               {block.cards.map((card, j) => (
-                <CardPill key={j} card={card} turnIndex={turnIndex} />
+                <CardPill
+                  key={j}
+                  card={card}
+                  turnIndex={turnIndex}
+                  fallbackIds={fallbackIds}
+                />
               ))}
             </div>
           )
         }
         if (block.kind === 'paragraph') {
-          return (
+          return wrap(
+            i,
             <p key={i}>
-              {renderInline(block.lines.join(' '), listings, clicked)}
+              {renderInline(
+                block.lines.join(' '),
+                listings,
+                clicked,
+                fallbackIds
+              )}
             </p>
           )
         }
         const items = block.lines.map((item, j) => (
           <li key={j}>
-            <Fragment>{renderInline(item, listings, clicked)}</Fragment>
+            <Fragment>
+              {renderInline(item, listings, clicked, fallbackIds)}
+            </Fragment>
           </li>
         ))
-        return block.kind === 'ol' ? (
-          <ol key={i} start={block.start}>
-            {items}
-          </ol>
-        ) : (
-          <ul key={i}>{items}</ul>
+        return wrap(
+          i,
+          block.kind === 'ol' ? (
+            <ol key={i} start={block.start}>
+              {items}
+            </ol>
+          ) : (
+            <ul key={i}>{items}</ul>
+          )
         )
       })}
     </>
@@ -461,12 +643,17 @@ function MessageBody({
 export default function TranscriptMessage({
   text,
   turnIndex,
+  fallbackCardIds,
 }: {
   text: string
   /** This message's index in the stored conversation history, so clicked-card
    *  badges can be matched to the exact turn. Omitted for legacy rows with no
    *  stored history. */
   turnIndex?: number
+  /** Card ids in THIS turn that degraded to a "Browse X" link (or nothing) in
+   *  the visitor's chat, from Data.fallbackCards. Undefined when the turn
+   *  predates fallback tracking — then unresolvability is used as the signal. */
+  fallbackCardIds?: Set<string>
 }) {
   // The reasoning/search trail before the [[/thinking]] boundary is dropped
   // here: it's never shown to visitors (the live chat hides it), and it adds
@@ -475,7 +662,11 @@ export default function TranscriptMessage({
   const { body, chips } = parseMessage(text)
   return (
     <div className={styles.convMsg}>
-      <MessageBody text={body} turnIndex={turnIndex} />
+      <MessageBody
+        text={body}
+        turnIndex={turnIndex}
+        fallbackIds={fallbackCardIds}
+      />
       {chips.length > 0 && (
         <div className={styles.convChips}>
           {chips.map((chip, i) => (

--- a/src/app/admin/chatbot/TranscriptMessage.tsx
+++ b/src/app/admin/chatbot/TranscriptMessage.tsx
@@ -151,14 +151,20 @@ function parseMessage(text: string): ParsedMessage {
 }
 
 /** Wraps an inline link with a "clicked" badge when the visitor opened it.
- *  Link clicks are stored in the same Clicked set as cards, keyed `link:<href>`. */
+ *  Link clicks are stored in the same Clicked set as cards, keyed
+ *  `<turnIndex>:link:<href>`. The bare `link:<href>` form is the legacy path
+ *  for rows recorded before link clicks were turn-scoped — there every copy
+ *  of the href is still badged, matching cards' legacy behaviour. */
 function inlineLink(
   href: string,
   text: ReactNode,
   clicked: Set<string>,
-  key: string
+  key: string,
+  turnIndex?: number
 ): ReactNode {
-  const wasClicked = clicked.has(`link:${href}`)
+  const wasClicked =
+    (turnIndex != null && clicked.has(`${turnIndex}:link:${href}`)) ||
+    clicked.has(`link:${href}`)
   return (
     <a
       key={key}
@@ -207,7 +213,8 @@ function renderInline(
   text: string,
   listings: Record<string, ListingInfo>,
   clicked: Set<string>,
-  fallbackIds?: Set<string>
+  fallbackIds?: Set<string>,
+  turnIndex?: number
 ): ReactNode[] {
   const parts: ReactNode[] = []
   let lastIndex = 0
@@ -290,7 +297,7 @@ function renderInline(
       // site-relative destinations became links for the visitor; anything
       // else (e.g. javascript:) rendered as plain text.
       if (m && /^(https?:\/\/|\/|#)/.test(m[2])) {
-        parts.push(inlineLink(m[2], m[1], clicked, `l-${key++}`))
+        parts.push(inlineLink(m[2], m[1], clicked, `l-${key++}`, turnIndex))
       } else {
         parts.push(token)
       }
@@ -303,21 +310,25 @@ function renderInline(
         token.slice(2, -2),
         listings,
         clicked,
-        fallbackIds
+        fallbackIds,
+        turnIndex
       )
       INLINE_RE.lastIndex = saved
       parts.push(<strong key={`b-${key++}`}>{inner}</strong>)
     } else if (/^aisafety\.info/i.test(token)) {
       // Auto-linkify bare aisafety.info mentions, matching the live renderer
       // (the bot writes it as plain text rather than a markdown link).
-      parts.push(inlineLink(`https://${token}`, token, clicked, `u-${key++}`))
+      parts.push(
+        inlineLink(`https://${token}`, token, clicked, `u-${key++}`, turnIndex)
+      )
     } else {
       const saved = INLINE_RE.lastIndex
       const inner = renderInline(
         token.slice(1, -1),
         listings,
         clicked,
-        fallbackIds
+        fallbackIds,
+        turnIndex
       )
       INLINE_RE.lastIndex = saved
       parts.push(<em key={`i-${key++}`}>{inner}</em>)
@@ -454,7 +465,9 @@ function CardPill({
         </span>
       )
     }
-    const wasClicked = clicked.has(`link:${fb.path}`)
+    const wasClicked =
+      (turnIndex != null && clicked.has(`${turnIndex}:link:${fb.path}`)) ||
+      clicked.has(`link:${fb.path}`)
     return (
       <span className={styles.convCardDegradedRow}>
         <a
@@ -613,7 +626,8 @@ function MessageBody({
                 block.lines.join(' '),
                 listings,
                 clicked,
-                fallbackIds
+                fallbackIds,
+                turnIndex
               )}
             </p>
           )
@@ -621,7 +635,7 @@ function MessageBody({
         const items = block.lines.map((item, j) => (
           <li key={j}>
             <Fragment>
-              {renderInline(item, listings, clicked, fallbackIds)}
+              {renderInline(item, listings, clicked, fallbackIds, turnIndex)}
             </Fragment>
           </li>
         ))

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -168,6 +168,7 @@ export async function POST(req: NextRequest) {
           history: [...messages, { role: 'assistant', content: assistantText }],
           toolCalls,
           response: assistantText,
+          fallbackCards: result?.fallbackCardIds ?? [],
           citations: citations.map(c => c.id),
           citationRefs,
           zeroMatches,

--- a/src/components/assistant/Assistant.tsx
+++ b/src/components/assistant/Assistant.tsx
@@ -170,12 +170,13 @@ export default function Assistant() {
   )
 
   const handleLinkClick = useCallback(
-    (href: string, label: string) => {
+    (href: string, label: string, turnIndex?: number) => {
       void fireLog({
         kind: 'click',
         target: 'link',
         url: href,
         label,
+        turnIndex,
         currentPage,
         sessionId: getSessionId(),
       })

--- a/src/components/assistant/ChatBody.tsx
+++ b/src/components/assistant/ChatBody.tsx
@@ -251,8 +251,11 @@ interface Props {
    *  matches its index in the stored conversation history — so the admin can
    *  badge the exact card the visitor opened. */
   onCitationClick?: (c: CitationRef, turnIndex: number) => void
-  /** Fires when the visitor clicks an inline markdown link in a reply. */
-  onLinkClick?: (href: string, label: string) => void
+  /** Fires when the visitor clicks an inline markdown link in a reply.
+   *  `turnIndex` is the reply's position in the message list (matching its
+   *  index in the stored history), so the admin can badge the one link the
+   *  visitor clicked instead of every copy of that href across the chat. */
+  onLinkClick?: (href: string, label: string, turnIndex?: number) => void
   /** Fires when the user sends a message (typed or via a chip), excluding
    *  retries — lets the public chatbot count engagement while the admin
    *  playground (which doesn't pass this) stays out of the numbers. */
@@ -764,7 +767,12 @@ const ChatBody = forwardRef<ChatBodyHandle, Props>(function ChatBody(
                       ? (c: CitationRef) => onCitationClick(c, turnIndex)
                       : undefined
                   }
-                  onLinkClick={onLinkClick}
+                  onLinkClick={
+                    onLinkClick
+                      ? (href: string, label: string) =>
+                          onLinkClick(href, label, turnIndex)
+                      : undefined
+                  }
                 />
                 {!m.isStreaming && m.followUpChips.length > 0 && (
                   <div className={styles.followUpRow}>

--- a/src/components/assistant/ChatBody.tsx
+++ b/src/components/assistant/ChatBody.tsx
@@ -478,6 +478,10 @@ const ChatBody = forwardRef<ChatBodyHandle, Props>(function ChatBody(
         const decoder = new TextDecoder()
         let buffer = ''
         let streamingText = ''
+        // Text length when the last tool call started — everything before it
+        // is reasoning. Used below to repair a reply whose [[/thinking]]
+        // marker never arrived.
+        let lastToolTextOffset = 0
 
         while (true) {
           const { done, value } = await reader.read()
@@ -508,6 +512,7 @@ const ChatBody = forwardRef<ChatBodyHandle, Props>(function ChatBody(
                 })
               )
             } else if (eventType === 'tool_call_start') {
+              lastToolTextOffset = streamingText.length
               const newCall: UIToolCall = {
                 id: data.id,
                 name: data.name,
@@ -584,6 +589,20 @@ const ChatBody = forwardRef<ChatBodyHandle, Props>(function ChatBody(
             // server emits 'done' or just closes the stream.
           }
         }
+        // A reply that ran tools but never emitted [[/thinking]] after its
+        // last tool call leaves reasoning narration ("I'll search for…")
+        // glued to the answer in the flat content string. The rendered view
+        // already hides it (its boundary falls back to the last tool call),
+        // but `content` is what gets sent back as history on later turns —
+        // and stored in the conversation log — so repair it the same way:
+        // inject the marker where the last tool call sat. Mirrors the
+        // identical repair in runAssistantStream.
+        if (
+          lastToolTextOffset > 0 &&
+          !THINKING_DONE_RE.test(streamingText.slice(lastToolTextOffset))
+        ) {
+          streamingText = `${streamingText.slice(0, lastToolTextOffset).trimEnd()}\n[[/thinking]]\n${streamingText.slice(lastToolTextOffset).trimStart()}`
+        }
         // The visible answer is whatever follows the last [[/thinking]] marker
         // (or the whole reply if there's no marker). If that's empty, the turn
         // produced no answer — a transient hiccup or an empty completion. Show a
@@ -599,10 +618,16 @@ const ChatBody = forwardRef<ChatBodyHandle, Props>(function ChatBody(
               ? answer.trim() === ''
                 ? {
                     ...m,
+                    content: streamingText,
                     isStreaming: false,
                     error: 'Sorry, something went wrong. Please try again.',
                   }
-                : { ...m, isStreaming: false, followUpChips: followUp }
+                : {
+                    ...m,
+                    content: streamingText,
+                    isStreaming: false,
+                    followUpChips: followUp,
+                  }
               : m
           )
         )

--- a/src/lib/admin/airtable.ts
+++ b/src/lib/admin/airtable.ts
@@ -105,6 +105,11 @@ export interface ConversationData {
   response: string
   history: HistoryTurn[]
   tools: unknown[]
+  /** One entry per logged turn (aligned with `tools`): card ids in that
+   *  turn's reply that rendered as a generic "Browse X" fallback link (or
+   *  nothing) in the visitor's chat instead of a real card. Absent on rows
+   *  written before this was tracked. */
+  fallbackCards?: unknown[]
   citations: string[]
   /** Resolved name/url for each cited listing, so cards survive deletion. */
   citationRefs: StoredCitation[]
@@ -311,6 +316,7 @@ export async function upsertConversation(input: {
   response: string
   history: HistoryTurn[]
   tools: unknown
+  fallbackCards: string[]
   citations: string[]
   citationRefs: StoredCitation[]
   geo: ConversationData['geo']
@@ -335,6 +341,13 @@ export async function upsertConversation(input: {
     response: input.response,
     history: input.history,
     tools: previous ? [...previous.tools, input.tools] : [input.tools],
+    // Same per-turn alignment as tools. Older rows have no fallbackCards key;
+    // starting the array now still aligns because the viewer matches turns
+    // from the END (same trick it already uses for tools vs a windowed
+    // history) — pre-tracking turns simply resolve to no entry.
+    fallbackCards: previous
+      ? [...(previous.fallbackCards ?? []), input.fallbackCards]
+      : [input.fallbackCards],
     citations: previous
       ? Array.from(new Set([...previous.citations, ...input.citations]))
       : input.citations,

--- a/src/lib/assistant/conversation-store.ts
+++ b/src/lib/assistant/conversation-store.ts
@@ -19,6 +19,9 @@ export interface StoredTurn {
   history: { role: 'user' | 'assistant'; content: string }[]
   toolCalls: { name: string; input: unknown; ok: boolean }[]
   response: string
+  /** Card ids in this turn's reply that rendered as a generic "Browse X"
+   *  fallback link (or nothing) instead of a real card in the visitor's chat. */
+  fallbackCards: string[]
   citations: string[]
   citationRefs: { id: string; name: string; url: string; logo?: string }[]
   zeroMatches: boolean
@@ -52,6 +55,7 @@ export async function storeConversationTurn(turn: StoredTurn): Promise<void> {
         response: turn.response,
         history: turn.history,
         tools: turn.toolCalls,
+        fallbackCards: turn.fallbackCards,
         citations: turn.citations,
         citationRefs: turn.citationRefs,
         geo: turn.geo,

--- a/src/lib/assistant/log.ts
+++ b/src/lib/assistant/log.ts
@@ -20,10 +20,10 @@ export interface AssistantClickEvent {
   target?: 'card' | 'link'
   /** The listing id, for card clicks. Absent for link clicks. */
   citationId?: string
-  /** Which assistant turn the clicked card sat in (its index in the stored
-   *  conversation history). Lets the admin badge the one card the visitor
-   *  actually clicked instead of every copy of that listing across the chat.
-   *  Absent for link clicks and for older clients that didn't send it. */
+  /** Which assistant turn the clicked card or link sat in (its index in the
+   *  stored conversation history). Lets the admin badge the one instance the
+   *  visitor actually clicked instead of every copy of that listing or href
+   *  across the chat. Absent for older clients that didn't send it. */
   turnIndex?: number
   /** Destination: the card's url, or the inline link's href. */
   url: string
@@ -60,12 +60,12 @@ export async function logAssistantEvent(event: AssistantEvent): Promise<void> {
   console.log(`[assistant] ${line}`)
 
   // Persist clicks onto the conversation row so the admin viewer can show what
-  // the visitor actually opened. Cards are keyed `<turnIndex>:<listing id>` so
-  // the exact instance is known (a listing can be shown in several replies);
-  // inline links by a `link:`-prefixed href, which never collides with a
-  // `type:recXXX` id. Older clients omit turnIndex — fall back to the bare
-  // listing id, which the admin still matches (badging every copy) for legacy
-  // rows.
+  // the visitor actually opened. Cards are keyed `<turnIndex>:<listing id>` and
+  // inline links `<turnIndex>:link:<href>`, so the exact instance is known (the
+  // same listing or href can appear in several replies; without the turn scope
+  // one click badged every copy). The `link:` prefix never collides with a
+  // `type:recXXX` id. Older clients omit turnIndex — fall back to the unscoped
+  // key, which the admin still matches (badging every copy) for legacy rows.
   if (
     event.kind === 'click' &&
     event.sessionId &&
@@ -73,7 +73,9 @@ export async function logAssistantEvent(event: AssistantEvent): Promise<void> {
   ) {
     const clickKey =
       event.target === 'link'
-        ? `link:${event.url}`
+        ? event.turnIndex != null
+          ? `${event.turnIndex}:link:${event.url}`
+          : `link:${event.url}`
         : event.citationId != null && event.turnIndex != null
           ? `${event.turnIndex}:${event.citationId}`
           : event.citationId

--- a/src/lib/assistant/stream.ts
+++ b/src/lib/assistant/stream.ts
@@ -176,6 +176,11 @@ export async function runAssistantStream(
   const cited: Listing[] = []
   const toolCalls: ToolCallLogEntry[] = []
   let redoneFabrication = false
+  // Where the final answer can begin at the earliest: the text length after
+  // the last tool round (or fabrication redo). Text before this point is
+  // definitionally reasoning — it preceded a tool call — which lets us
+  // repair a reply whose [[/thinking]] marker never arrived.
+  let answerStartOffset = 0
 
   for (let iter = 0; iter < MAX_TOOL_ITERATIONS; iter++) {
     if (signal?.aborted) return { assistantText, toolCalls, citations: [] }
@@ -315,6 +320,7 @@ export async function runAssistantStream(
           role: 'user',
           content: fabricationRedoMessage(fabricated),
         })
+        answerStartOffset = assistantText.length
         continue
       }
       break
@@ -370,6 +376,7 @@ export async function runAssistantStream(
       })
     }
     apiMessages.push({ role: 'user', content: toolResults })
+    answerStartOffset = assistantText.length
   }
 
   // Citations come from the listings the model actually used (via tools).
@@ -377,6 +384,39 @@ export async function runAssistantStream(
   const byId = new Map<string, CitationRef>()
   for (const l of cited) byId.set(l.id, toCitationRef(l))
   for (const c of extractCitations(assistantText, catalog)) byId.set(c.id, c)
+
+  // Telemetry: a reply should carry exactly one [[/thinking]] marker (two when
+  // the fabrication redo above injected a second generation). More than that
+  // means the model re-entered thinking mid-answer — the renderer keeps only
+  // what follows the LAST marker, so everything the model wrote before its
+  // spurious re-emission was hidden from the visitor. Counted before the
+  // missing-marker repair below so it reflects what the model actually wrote.
+  const markerCount =
+    assistantText.match(/\[\[\s*\/\s*thinking\s*\]\]/gi)?.length ?? 0
+  const expectedMarkers = redoneFabrication ? 2 : 1
+  if (markerCount > expectedMarkers) {
+    console.warn(
+      `[assistant] re-emitted [[/thinking]] mid-answer (${markerCount} markers, expected ${expectedMarkers}) — earlier answer text was hidden from the visitor`
+    )
+  }
+
+  // The opposite failure: the model ran tools but never emitted [[/thinking]]
+  // after its last tool round, leaving pre-search narration ("I'll search
+  // for…") glued to the answer. The live widget hides that (its boundary
+  // falls back to the last tool call), but the stored transcript is a flat
+  // string with no tool positions, so the admin log — and the model reading
+  // its own history next turn — would see the leak. The server knows where
+  // the last tool round ended, which is exactly where the marker belongs, so
+  // repair the transcript by injecting it there.
+  if (
+    answerStartOffset > 0 &&
+    !/\[\[\s*\/\s*thinking\s*\]\]/i.test(assistantText.slice(answerStartOffset))
+  ) {
+    console.warn(
+      '[assistant] missing [[/thinking]] after the last tool call — injected the marker so the reasoning trail stays out of the stored answer'
+    )
+    assistantText = `${assistantText.slice(0, answerStartOffset).trimEnd()}\n[[/thinking]]\n${assistantText.slice(answerStartOffset).trimStart()}`
+  }
 
   // The visible answer is whatever follows the last [[/thinking]] marker — a
   // redone draft sits before its marker, so it drops out here.
@@ -397,20 +437,6 @@ export async function runAssistantStream(
   if (fabricated.length > 0) {
     console.warn(
       `[assistant] fabricated card id(s) with no matching listing: ${fabricated.join(', ')}`
-    )
-  }
-
-  // Telemetry: a reply should carry exactly one [[/thinking]] marker (two when
-  // the fabrication redo above injected a second generation). More than that
-  // means the model re-entered thinking mid-answer — the renderer keeps only
-  // what follows the LAST marker, so everything the model wrote before its
-  // spurious re-emission was hidden from the visitor.
-  const markerCount =
-    assistantText.match(/\[\[\s*\/\s*thinking\s*\]\]/gi)?.length ?? 0
-  const expectedMarkers = redoneFabrication ? 2 : 1
-  if (markerCount > expectedMarkers) {
-    console.warn(
-      `[assistant] re-emitted [[/thinking]] mid-answer (${markerCount} markers, expected ${expectedMarkers}) — earlier answer text was hidden from the visitor`
     )
   }
 

--- a/src/lib/assistant/stream.ts
+++ b/src/lib/assistant/stream.ts
@@ -140,6 +140,12 @@ export interface AssistantRunResult {
   assistantText: string
   toolCalls: ToolCallLogEntry[]
   citations: CitationRef[]
+  /** Card ids in the visible answer that the live widget degraded to a
+   *  generic "Browse X" fallback link (or dropped entirely) instead of a real
+   *  card — the model wrote them without a tool having returned the listing.
+   *  Logged per turn so the admin transcript can show the same degraded state
+   *  the visitor saw rather than a full card the model only pretended to have. */
+  fallbackCardIds: string[]
 }
 
 interface RunOptions {
@@ -183,7 +189,9 @@ export async function runAssistantStream(
   let answerStartOffset = 0
 
   for (let iter = 0; iter < MAX_TOOL_ITERATIONS; iter++) {
-    if (signal?.aborted) return { assistantText, toolCalls, citations: [] }
+    if (signal?.aborted) {
+      return { assistantText, toolCalls, citations: [], fallbackCardIds: [] }
+    }
     const response = await client.messages.create(
       {
         model,
@@ -440,6 +448,28 @@ export async function runAssistantStream(
     )
   }
 
+  // Which of the answer's cards did the live widget degrade to a "Browse X"
+  // fallback link? The widget resolves cards only against listings its tools
+  // returned during the conversation, so fabricated ids always degrade, and
+  // backfilled ids (real listings no tool surfaced this turn) degrade too —
+  // unless an earlier reply already carded the listing, in which case the
+  // widget still holds its citation and renders the real card. Prior replies
+  // are the history messages, whose content is a plain string (this run's own
+  // assistant turns were appended as content-block arrays).
+  const priorAssistantText = apiMessages
+    .filter(m => m.role === 'assistant' && typeof m.content === 'string')
+    .map(m => m.content as string)
+    .join('\n')
+  const fallbackCardIds = [
+    ...fabricated,
+    ...backfill
+      .map(ref => ref.id)
+      .filter(id => {
+        const rec = id.match(/rec[A-Za-z0-9]+$/)?.[0]
+        return !(rec && priorAssistantText.includes(rec))
+      }),
+  ]
+
   // Telemetry: a turn that finishes with no user-facing answer (truly empty, or
   // only a reasoning trail before [[/thinking]]) leaves the visitor with a blank
   // reply. Log it so we can measure how often it happens instead of letting it
@@ -450,7 +480,12 @@ export async function runAssistantStream(
     )
   }
 
-  return { assistantText, toolCalls, citations: Array.from(byId.values()) }
+  return {
+    assistantText,
+    toolCalls,
+    citations: Array.from(byId.values()),
+    fallbackCardIds,
+  }
 }
 
 function toCitationRef(l: Listing): CitationRef {


### PR DESCRIPTION
Two fixes with one goal: the admin Conversation Log should always show exactly what the visitor's chat rendered, with anything else clearly marked as an annotation.

**1. Repair replies that omit the `[[/thinking]]` marker**
- A reply that runs searches but never emits `[[/thinking]]` after its last tool call leaves pre-search narration ("I'll search for events in the Philippines / Asia region.") glued onto the answer. Seen in the log on 9 July (session `f00b71bd`, prompt version current — model non-compliance, not a stale deployment).
- The live widget already hid the narration (its render boundary falls back to the last tool call), but the stored transcript is a flat string with no tool positions, so the admin log — and the model rereading its own history — showed the leak.
- Both the server (`runAssistantStream`) and the client (`ChatBody`) now inject the marker at the last-tool position when the tail carries none, covering also the variant where the marker arrives *before* the last tool call. Injections are logged; the existing marker telemetry still counts what the model actually wrote.

**2. Make the admin transcript render every card state as the visitor saw it**
- The admin resolves cards against a superset of what the visitor's widget had (stored citations + live catalog), so a card the model wrote *without any tool returning the listing* — which the visitor's chat degrades to a generic "Browse X" resource-page link — used to show in the admin as a normal, healthy card.
- The server now logs per turn which card ids degraded (`Data.fallbackCards`: fabricated ids + real-but-unsurfaced ids, minus listings already carded earlier in the conversation, which the widget still resolves). Stored end-aligned like `Data.tools`, so old rows and mid-flight conversations stay compatible; turns from before the tracking fall back to a resolvability heuristic.
- The admin transcript now renders: degraded cards as the actual "Browse X" link (with click badge) plus an orange annotation naming the listing the model intended or the fabricated id; blocks the live chat hid entirely (nothing renderable + dangling colon lead-in) dimmed with a "hidden from visitor" marker instead of as normal content; malformed card/id tokens struck-through instead of as pills (the live sweep strips them); links with the same scheme guard as live (`javascript:` stays plain text); and markdown inside bold/italic rendered as it was live.
- Verified by driving the real `runAssistantStream` with a stubbed model client (10 checks: marker repair ×4, fallback tracking ×6 — tool-surfaced, unsurfaced-real, re-shown-from-earlier-turn, fabricated-after-redo) and by screenshotting a fixture page exercising all six admin card states. `npm run build` passes.

Known limits: records stored before this PR can't be repaired retroactively (the boundary/tool positions aren't recoverable from flat text), and replies the visitor abandoned mid-stream are already flagged by the existing NO REPLY / ERROR badges.

**3. Turn-scope link-click badges**
- One click on an inline link (e.g. "Communities") used to badge every rendering of that href across the conversation, because link clicks were stored unscoped while card clicks had already been turn-scoped. Link clicks are now keyed `<turnIndex>:link:<href>` end to end (widget → click log → admin renderers, including the degraded-card Browse link), so only the instance the visitor actually clicked is badged. Unscoped legacy entries keep badging every copy, same as legacy card clicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
