### PR TITLE
Add revocable volunteer admin password with analytics access

### DIFF
--- a/src/app/admin/analytics/layout.tsx
+++ b/src/app/admin/analytics/layout.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { isAdmin, isOwner } from '@/lib/admin/auth'
+import { canViewAnalytics, isAdmin } from '@/lib/admin/auth'
 import AdminHeader from '../AdminHeader'
 import { adminTabs } from '../nav'
 import styles from '../admin.module.css'
@@ -14,12 +14,13 @@ export default async function AnalyticsLayout({
 }: {
   children: React.ReactNode
 }) {
-  // Owner-only. A signed-in partner holding the Successif password is sent to
-  // the chat area they're allowed to use; everyone else to the login page.
-  if (!(await isOwner())) {
+  // Owner and volunteers only. A signed-in partner holding the Successif
+  // password is sent to the chat area they're allowed to use; everyone else to
+  // the login page.
+  if (!(await canViewAnalytics())) {
     redirect((await isAdmin()) ? '/admin/chatbot/playground' : '/admin/login')
   }
-  // owner is guaranteed here, so the Analytics tab is always present.
+  // analytics access is guaranteed here, so the Analytics tab is always present.
   return (
     <>
       <AdminHeader tabs={adminTabs(true)} />

--- a/src/app/admin/chatbot/layout.tsx
+++ b/src/app/admin/chatbot/layout.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { isAdmin, isOwner } from '@/lib/admin/auth'
+import { canViewAnalytics, isAdmin } from '@/lib/admin/auth'
 import AdminHeader from '../AdminHeader'
 import { adminTabs } from '../nav'
 import styles from '../admin.module.css'
@@ -12,10 +12,11 @@ export default async function ChatbotAdminLayout({
   if (!(await isAdmin())) {
     redirect('/admin/login')
   }
-  // adminTabs() hides the Analytics tab from non-owners (e.g. Successif).
+  // adminTabs() hides the Analytics tab from sessions that can't reach it
+  // (e.g. Successif; owner and volunteers see it).
   return (
     <>
-      <AdminHeader tabs={adminTabs(await isOwner())} />
+      <AdminHeader tabs={adminTabs(await canViewAnalytics())} />
       <main className={styles.consoleWrap}>{children}</main>
     </>
   )

--- a/src/app/admin/nav.ts
+++ b/src/app/admin/nav.ts
@@ -10,9 +10,10 @@ export interface AdminNavTab {
 }
 
 /** Tabs shown in the admin header. Playground and Conversation Log always show;
- *  the Analytics tab is owner-only (the shared Successif password can't reach
- *  /admin/analytics), so it's only included when the session is the owner. */
-export function adminTabs(owner: boolean): AdminNavTab[] {
+ *  the Analytics tab is only included when the session may reach
+ *  /admin/analytics (owner and volunteer passwords; the shared Successif
+ *  password can't). */
+export function adminTabs(analytics: boolean): AdminNavTab[] {
   return [
     {
       href: '/admin/chatbot/playground',
@@ -20,7 +21,7 @@ export function adminTabs(owner: boolean): AdminNavTab[] {
       group: 'chatbot',
     },
     { href: '/admin/chatbot/log', label: 'Conversation Log', group: 'chatbot' },
-    ...(owner
+    ...(analytics
       ? [
           {
             href: '/admin/analytics',

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -5,16 +5,17 @@ const COOKIE_NAME = 'aisafety_admin'
 // 30 days. Re-auth when expired.
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 30
 
-/** Passwords that grant admin access: the primary owner password plus an
- *  optional secondary one (e.g. a shareable "successif…" password handed to a
- *  partner reviewing the chat logs). Each lives in its own env var, so either
- *  can be revoked on its own — drop `ADMIN_PASSWORD_SUCCESSIF` and that
- *  password (and any cookie derived from it) stops working immediately, while
- *  the primary is untouched. */
+/** Passwords that grant admin access: the primary owner password plus optional
+ *  shareable ones (a "successif…" password for the partner reviewing chat logs,
+ *  a "volunteer…" password for site volunteers). Each lives in its own env var,
+ *  so any one can be revoked on its own — drop the env var and that password
+ *  (and any cookie derived from it) stops working immediately, while the others
+ *  are untouched. */
 function validPasswords(): string[] {
   return [
     process.env.ADMIN_PASSWORD,
     process.env.ADMIN_PASSWORD_SUCCESSIF,
+    process.env.ADMIN_PASSWORD_VOLUNTEER,
   ].filter((p): p is string => typeof p === 'string' && p.length > 0)
 }
 
@@ -35,17 +36,21 @@ export async function isAdmin(): Promise<boolean> {
   return got != null && accepted.includes(got)
 }
 
-/** True only when the session was authenticated with the PRIMARY owner password
- *  (ADMIN_PASSWORD) — NOT the shared, revocable ADMIN_PASSWORD_SUCCESSIF. Use
- *  this to gate owner-only areas (e.g. the analytics dashboard) so a partner
- *  holding the Successif password can't reach them. Fails closed if the primary
- *  password isn't configured. */
-export async function isOwner(): Promise<boolean> {
-  const primary = process.env.ADMIN_PASSWORD
-  if (!primary) return false
+/** True when the session was authenticated with a password allowed into the
+ *  analytics dashboard: the primary owner password or the shared volunteer
+ *  password. The Successif password is deliberately excluded — that partner
+ *  reviews chat logs only. Fails closed if neither password is configured. */
+export async function canViewAnalytics(): Promise<boolean> {
+  const accepted = [
+    process.env.ADMIN_PASSWORD,
+    process.env.ADMIN_PASSWORD_VOLUNTEER,
+  ]
+    .filter((p): p is string => typeof p === 'string' && p.length > 0)
+    .map(cookieValueFor)
+  if (accepted.length === 0) return false
   const c = await cookies()
   const got = c.get(COOKIE_NAME)?.value
-  return got != null && got === cookieValueFor(primary)
+  return got != null && accepted.includes(got)
 }
 
 export async function setAdminCookie(password: string): Promise<void> {


### PR DESCRIPTION
- Adds a third accepted admin password via the `ADMIN_PASSWORD_VOLUNTEER` env var (set in Vercel Production/Preview/Development and `.env.local`), for site volunteers reviewing the chatbot.
- Independently revocable, same as the Successif password: delete the env var and every session created with it stops working immediately; other passwords are untouched.
- Volunteers can also use the analytics dashboard: `isOwner()` is replaced by `canViewAnalytics()`, which accepts the owner and volunteer passwords. The Successif password remains chat-logs-only and is still redirected away from `/admin/analytics`.
- The Analytics tab in the admin header now shows for any session that can reach it (owner + volunteers), and stays hidden for Successif.

Verified locally: volunteer password logs in and reaches `/admin/analytics` and the conversation log; Successif password still 307-redirects from analytics to the playground; owner unaffected; wrong password gets 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)