### PR TITLE
Admin log: track suggest-button presses, tick-only chip badge

### DIFF
--- a/src/app/admin/chatbot/ConversationList.tsx
+++ b/src/app/admin/chatbot/ConversationList.tsx
@@ -603,9 +603,7 @@ function ConversationRow({
                       >
                         {chip}
                         {pressed && (
-                          <span className={styles.convChipPressedTag}>
-                            ✓ pressed
-                          </span>
+                          <span className={styles.convChipPressedTag}>✓</span>
                         )}
                       </span>
                     )

--- a/src/app/admin/chatbot/TranscriptMessage.tsx
+++ b/src/app/admin/chatbot/TranscriptMessage.tsx
@@ -237,12 +237,31 @@ function renderInline(
         // there — mirror that.
         const { type, query } = parseSuggestToken(suggest[1])
         if (type !== 'job') {
+          // Badge the button when the visitor pressed it (opening the form).
+          // Presses are stored in the same Clicked set as cards and links,
+          // keyed `<turnIndex>:suggest:<type>` ('listing' when the token has
+          // no recognized type — mirroring the live logger's fallback). The
+          // bare `suggest:<type>` form is the legacy/unscoped path.
+          const suggestKey = `suggest:${type ?? 'listing'}`
+          const wasPressed =
+            (turnIndex != null && clicked.has(`${turnIndex}:${suggestKey}`)) ||
+            clicked.has(suggestKey)
           parts.push(
             <SuggestInline
               key={`s-${key++}`}
               query={query}
               type={type}
               onSuggest={openSuggestForm}
+              badge={
+                wasPressed ? (
+                  <span
+                    className={styles.convCardClicked}
+                    title="The visitor pressed this button and opened the form"
+                  >
+                    ✓
+                  </span>
+                ) : undefined
+              }
             />
           )
         }

--- a/src/components/assistant/Assistant.tsx
+++ b/src/components/assistant/Assistant.tsx
@@ -146,8 +146,15 @@ export default function Assistant() {
   }, [])
 
   const handleSuggest = useCallback(
-    (query: string, type?: string) => {
-      void fireLog({ kind: 'suggest', query, currentPage })
+    (query: string, type?: string, turnIndex?: number) => {
+      void fireLog({
+        kind: 'suggest',
+        query,
+        type,
+        turnIndex,
+        currentPage,
+        sessionId: getSessionId(),
+      })
       window.open(suggestFormUrl(type), '_blank', 'noopener')
     },
     [currentPage, fireLog]

--- a/src/components/assistant/ChatBody.tsx
+++ b/src/components/assistant/ChatBody.tsx
@@ -246,7 +246,11 @@ interface Props {
   greeting?: string
   /** sessionStorage key for persisting messages (omit to disable). */
   storageKey?: string
-  onSuggest?: (query: string, type?: string) => void
+  /** Fires when the visitor presses a "Suggest a listing" button in a reply.
+   *  `turnIndex` is the reply's position in the message list (matching its
+   *  index in the stored history), so the admin can badge the button the
+   *  visitor pressed. */
+  onSuggest?: (query: string, type?: string, turnIndex?: number) => void
   /** `turnIndex` is the clicked card's position in the message list, which
    *  matches its index in the stored conversation history — so the admin can
    *  badge the exact card the visitor opened. */
@@ -761,7 +765,12 @@ const ChatBody = forwardRef<ChatBodyHandle, Props>(function ChatBody(
                 <AssistantMessageView
                   message={m}
                   allCitations={allCitations}
-                  onSuggest={onSuggest}
+                  onSuggest={
+                    onSuggest
+                      ? (query: string, type?: string) =>
+                          onSuggest(query, type, turnIndex)
+                      : undefined
+                  }
                   onCitationClick={
                     onCitationClick
                       ? (c: CitationRef) => onCitationClick(c, turnIndex)

--- a/src/components/assistant/MessageContent.tsx
+++ b/src/components/assistant/MessageContent.tsx
@@ -305,10 +305,14 @@ export function SuggestInline({
   query,
   type,
   onSuggest,
+  badge,
 }: {
   query: string
   type?: string
   onSuggest?: (query: string, type?: string) => void
+  /** Rendered inside the button, after the label — the admin log viewer uses
+   *  this to badge a button the visitor pressed. The live chat passes none. */
+  badge?: React.ReactNode
 }) {
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -340,6 +344,7 @@ export function SuggestInline({
           <path d="M7 17L17 7" />
           <path d="M8 7h9v9" />
         </svg>
+        {badge}
       </a>
     </span>
   )

--- a/src/lib/assistant/log.ts
+++ b/src/lib/assistant/log.ts
@@ -43,7 +43,16 @@ export interface AssistantOpenEvent {
 export interface AssistantSuggestEvent {
   kind: 'suggest'
   query: string
+  /** The suggest form's type ('community', 'correction', …). Absent when the
+   *  token carried no recognized type (the generic listing form). */
+  type?: string
+  /** Which assistant turn offered the button (its index in the stored
+   *  conversation history), so the admin badges the one instance the visitor
+   *  pressed. Absent for older clients that didn't send it. */
+  turnIndex?: number
   currentPage: string
+  /** Conversation this press belongs to, so it can be recorded on the row. */
+  sessionId?: string | null
 }
 
 export type AssistantEvent =
@@ -60,25 +69,31 @@ export async function logAssistantEvent(event: AssistantEvent): Promise<void> {
   console.log(`[assistant] ${line}`)
 
   // Persist clicks onto the conversation row so the admin viewer can show what
-  // the visitor actually opened. Cards are keyed `<turnIndex>:<listing id>` and
-  // inline links `<turnIndex>:link:<href>`, so the exact instance is known (the
-  // same listing or href can appear in several replies; without the turn scope
-  // one click badged every copy). The `link:` prefix never collides with a
-  // `type:recXXX` id. Older clients omit turnIndex — fall back to the unscoped
-  // key, which the admin still matches (badging every copy) for legacy rows.
+  // the visitor actually opened. Cards are keyed `<turnIndex>:<listing id>`,
+  // inline links `<turnIndex>:link:<href>` and suggest-form buttons
+  // `<turnIndex>:suggest:<type>`, so the exact instance is known (the same
+  // listing or href can appear in several replies; without the turn scope one
+  // click badged every copy). The `link:`/`suggest:` prefixes never collide
+  // with a `type:recXXX` id. Older clients omit turnIndex — fall back to the
+  // unscoped key, which the admin still matches (badging every copy) for
+  // legacy rows.
   if (
-    event.kind === 'click' &&
+    (event.kind === 'click' || event.kind === 'suggest') &&
     event.sessionId &&
     isConversationsTableConfigured()
   ) {
     const clickKey =
-      event.target === 'link'
+      event.kind === 'suggest'
         ? event.turnIndex != null
-          ? `${event.turnIndex}:link:${event.url}`
-          : `link:${event.url}`
-        : event.citationId != null && event.turnIndex != null
-          ? `${event.turnIndex}:${event.citationId}`
-          : event.citationId
+          ? `${event.turnIndex}:suggest:${event.type ?? 'listing'}`
+          : `suggest:${event.type ?? 'listing'}`
+        : event.target === 'link'
+          ? event.turnIndex != null
+            ? `${event.turnIndex}:link:${event.url}`
+            : `link:${event.url}`
+          : event.citationId != null && event.turnIndex != null
+            ? `${event.turnIndex}:${event.citationId}`
+            : event.citationId
     try {
       if (clickKey) await recordCitationClick(event.sessionId, clickKey)
     } catch (err) {


### PR DESCRIPTION
- When a visitor presses a "Suggest a listing" button in the chatbot, the press is now recorded on the conversation row (keyed `<turnIndex>:suggest:<type>`, same mechanism as card and link clicks) and the admin log shows a tick badge inside that button, so a reviewer can see the visitor actually opened the form.
- The greeting-chip badge in the admin log now shows just the tick instead of "✓ pressed" – the hover tooltip still explains what it means.
- Verified end-to-end on localhost: pressed the button in the live widget, confirmed the press landed on the Airtable row and the tick rendered in the admin viewer (test conversation deleted afterwards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)