### PR TITLE
Airtable: reference all fields by permanent ID so renames can't break the site

### DIFF
--- a/src/app/api/check-rebuild/route.ts
+++ b/src/app/api/check-rebuild/route.ts
@@ -6,7 +6,8 @@ export const dynamic = 'force-dynamic'
 
 // Airtable tables whose changes should trigger a rebuild. The filter mirrors
 // what the corresponding page actually displays, so internal-only edits on
-// unpublished records don't cause unnecessary rebuilds.
+// unpublished records don't cause unnecessary rebuilds. Filters reference
+// fields by permanent field ID (rename-proof).
 const TABLES: Array<{
   name: string
   tableId: string
@@ -15,38 +16,38 @@ const TABLES: Array<{
   {
     name: 'communities',
     tableId: 'tbluI5Dll697WiSm8',
-    filter: '{Publish?} = TRUE()',
+    filter: '{fldV8RYP1CVzOvHpf} = TRUE()', // Publish?
   },
   {
     name: 'funding',
     tableId: 'tblzMTLDZWZKqTxrq',
-    filter: '{Publish?} = TRUE()',
+    filter: '{fldoH88AbtQLEViD7} = TRUE()', // Publish?
   },
   {
     name: 'self-study',
     tableId: 'tblRNYJ0m1cmJXKKk',
-    filter: '{Publish?} = TRUE()',
+    filter: '{fldWShxP7GkMeh6rg} = TRUE()', // Publish?
   },
   { name: 'map', tableId: 'tblvzbGL9q9dOO9Nc' },
   {
     name: 'advisors',
     tableId: 'tblf3KKYnmgcjVGhD',
-    filter: '{Publish?} = TRUE()',
+    filter: '{fldaOmFd67ORPMfTC} = TRUE()', // Publish?
   },
   {
     name: 'projects',
     tableId: 'tblHT29QNgMYKB8iW',
-    filter: '{Publish?} = TRUE()',
+    filter: '{fldrGDtZxpFLQfjMz} = TRUE()', // Publish?
   },
   {
     name: 'media-channels',
     tableId: 'tblCTOMzyH3vILL5I',
-    filter: '{Publish?} = TRUE()',
+    filter: '{fldMN0TF3kz41HTQc} = TRUE()', // Publish?
   },
   {
     name: 'founders',
     tableId: 'tbl59Ye8oxvPjoVJv',
-    filter: '{Publish?} = TRUE()',
+    filter: '{fld9Epdrxu9n0FV20} = TRUE()', // Publish?
   },
   { name: 'events', tableId: 'tblx0L8qJEaLBxJFS' },
 ]

--- a/src/lib/admin/airtable.ts
+++ b/src/lib/admin/airtable.ts
@@ -26,6 +26,21 @@ const TOKEN = process.env.AIRTABLE_TOKEN
 const BASE = process.env.AIRTABLE_BASE_ID
 const CONVERSATIONS_TABLE = process.env.ADMIN_CONVERSATIONS_TABLE_ID
 
+// Permanent Airtable field IDs for the conversations table. All reads set
+// returnFieldsByFieldId and all writes key fields by ID, so renaming a
+// field in Airtable can't break the log.
+const FIELD = {
+  session: 'flds7cVOnzozLsaAl', // Session
+  page: 'fld36UU20Zc9JNvHt', // Page
+  latencyMs: 'fldD1AMzmTp4EVQUq', // Latency ms
+  promptVersion: 'fldZi6qb5G5bsdfFH', // Prompt version
+  notes: 'fldpjWWpS9R0cFXRU', // Notes
+  tags: 'fldAkUlONRN894SZN', // Tags
+  data: 'fld9TbBixMYVOssja', // Data
+  clicked: 'fld3PKIZx3Oo1oxkm', // Clicked
+  createdAt: 'fldterZrwZHKm2taI', // Created at
+} as const
+
 function ensureConfig(table: string | undefined): asserts table is string {
   if (!TOKEN || !BASE) {
     throw new Error('Airtable credentials missing (AIRTABLE_TOKEN/BASE_ID)')
@@ -128,18 +143,11 @@ export interface ConversationData {
   status?: 'abandoned' | 'error'
 }
 
-interface ConversationFields {
-  Session?: string
-  Page?: string
-  'Latency ms'?: number
-  'Prompt version'?: string
-  Notes?: string
-  Tags?: string[]
-  Data?: string
-  /** JSON array of listing ids whose cards the visitor clicked. Kept in its
-   *  own field (not Data) so a click write never clobbers a turn write. */
-  Clicked?: string
-}
+/** Raw record fields, keyed by permanent field ID (see FIELD above). The
+ *  Clicked field holds a JSON array of listing ids whose cards the visitor
+ *  clicked — kept separate from Data so a click write never clobbers a turn
+ *  write. */
+type ConversationFields = Record<string, unknown>
 
 export interface ConversationRow {
   id: string
@@ -200,20 +208,29 @@ function parseClicked(raw: string | undefined): string[] {
   }
 }
 
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
 function rowToConversation(
   row: AirtableRow<ConversationFields>
 ): ConversationRow {
+  const f = row.fields
+  const latency = f[FIELD.latencyMs]
+  const tags = f[FIELD.tags]
   return {
     id: row.id,
     createdAt: row.createdTime,
-    session: row.fields.Session ?? '',
-    page: row.fields.Page ?? '',
-    latencyMs: row.fields['Latency ms'] ?? null,
-    promptVersion: row.fields['Prompt version'] ?? '',
-    notes: row.fields.Notes ?? '',
-    tags: row.fields.Tags ?? [],
-    data: parseData(row.fields.Data),
-    clickedCitations: parseClicked(row.fields.Clicked),
+    session: str(f[FIELD.session]),
+    page: str(f[FIELD.page]),
+    latencyMs: typeof latency === 'number' ? latency : null,
+    promptVersion: str(f[FIELD.promptVersion]),
+    notes: str(f[FIELD.notes]),
+    tags: Array.isArray(tags)
+      ? tags.filter((t): t is string => typeof t === 'string')
+      : [],
+    data: parseData(str(f[FIELD.data]) || undefined),
+    clickedCitations: parseClicked(str(f[FIELD.clicked]) || undefined),
   }
 }
 
@@ -232,7 +249,7 @@ function searchFormula(search: string | undefined): string | undefined {
     .split(/\s+/)
     .filter(Boolean)
   if (words.length === 0) return undefined
-  const haystack = 'LOWER({Data} & " " & {Page} & " " & {Notes})'
+  const haystack = `LOWER({${FIELD.data}} & " " & {${FIELD.page}} & " " & {${FIELD.notes}})`
   const terms = words.map(w => `SEARCH(LOWER("${w}"), ${haystack})`)
   return terms.length === 1 ? terms[0] : `AND(${terms.join(', ')})`
 }
@@ -254,8 +271,9 @@ export async function listConversationsPage(opts: {
   do {
     const params = new URLSearchParams()
     params.set('pageSize', String(Math.min(100, want - out.length)))
-    params.set('sort[0][field]', 'Created at')
+    params.set('sort[0][field]', FIELD.createdAt)
     params.set('sort[0][direction]', 'desc')
+    params.set('returnFieldsByFieldId', 'true')
     if (formula) params.set('filterByFormula', formula)
     if (cursor) params.set('offset', cursor)
     const res = await airtableRequest(
@@ -280,11 +298,11 @@ export async function updateConversation(
 ): Promise<ConversationRow> {
   ensureConfig(CONVERSATIONS_TABLE)
   const fields: ConversationFields = {}
-  if (patch.notes !== undefined) fields.Notes = patch.notes
-  if (patch.tags !== undefined) fields.Tags = patch.tags
+  if (patch.notes !== undefined) fields[FIELD.notes] = patch.notes
+  if (patch.tags !== undefined) fields[FIELD.tags] = patch.tags
   const res = await airtableRequest(`${CONVERSATIONS_TABLE}/${id}`, {
     method: 'PATCH',
-    body: JSON.stringify({ fields }),
+    body: JSON.stringify({ fields, returnFieldsByFieldId: true }),
   })
   if (!res.ok) {
     throw new Error(`Airtable update failed: ${res.status} ${await res.text()}`)
@@ -301,8 +319,9 @@ async function findConversationBySession(
   // Escape any double-quotes for the formula literal.
   const escaped = session.replace(/"/g, '\\"')
   const params = new URLSearchParams()
-  params.set('filterByFormula', `{Session} = "${escaped}"`)
+  params.set('filterByFormula', `{${FIELD.session}} = "${escaped}"`)
   params.set('maxRecords', '1')
+  params.set('returnFieldsByFieldId', 'true')
   const res = await airtableRequest(
     `${CONVERSATIONS_TABLE}?${params.toString()}`
   )
@@ -340,7 +359,9 @@ export async function upsertConversation(input: {
   const existing = input.session
     ? await findConversationBySession(input.session)
     : null
-  const previous = existing ? parseData(existing.fields.Data) : null
+  const previous = existing
+    ? parseData(str(existing.fields[FIELD.data]) || undefined)
+    : null
 
   const data: ConversationData = {
     user: input.user,
@@ -378,11 +399,11 @@ export async function upsertConversation(input: {
   }
 
   const fields: ConversationFields = {
-    Session: input.session ?? '',
-    Page: input.page,
-    'Latency ms': input.latencyMs,
-    'Prompt version': input.promptVersion,
-    Data: JSON.stringify(data),
+    [FIELD.session]: input.session ?? '',
+    [FIELD.page]: input.page,
+    [FIELD.latencyMs]: input.latencyMs,
+    [FIELD.promptVersion]: input.promptVersion,
+    [FIELD.data]: JSON.stringify(data),
   }
 
   const res = existing
@@ -417,12 +438,14 @@ export async function recordCitationClick(
   // but if the row isn't there yet we simply drop the click rather than
   // creating a dataless row.
   if (!existing) return
-  const current = parseClicked(existing.fields.Clicked)
+  const current = parseClicked(str(existing.fields[FIELD.clicked]) || undefined)
   if (current.includes(citationId)) return
   const next = [...current, citationId]
   const res = await airtableRequest(`${CONVERSATIONS_TABLE}/${existing.id}`, {
     method: 'PATCH',
-    body: JSON.stringify({ fields: { Clicked: JSON.stringify(next) } }),
+    body: JSON.stringify({
+      fields: { [FIELD.clicked]: JSON.stringify(next) },
+    }),
   })
   if (!res.ok) {
     throw new Error(

--- a/src/lib/data/advisors.ts
+++ b/src/lib/data/advisors.ts
@@ -1,20 +1,30 @@
-import { fetchAirtableRecords } from './airtable'
+import {
+  fetchAirtableRecords,
+  fieldAttachmentUrl,
+  fieldFeatured,
+  fieldString,
+  fieldText,
+  publishedFormula,
+} from './airtable'
 
 const TABLE_ID = 'tblf3KKYnmgcjVGhD'
 const VIEW_ID = 'viwIdRmaCar2Y6gPi'
 
-interface AirtableRecord {
-  fields: {
-    Name?: string
-    Description?: string
-    Logo?: Array<{ url: string }>
-    Focus?: string | string[]
-    Status?: string | string[]
-    Link?: string
-    Featured?: string
-    'Featured tagline'?: string
-  }
-}
+// Permanent Airtable field IDs for the Advisors table. Fetching, filtering
+// and sorting by ID keeps the page working when fields are renamed.
+const FIELD = {
+  name: 'fldDCHQmcF8HLOz5S', // Name
+  description: 'fldKAGrIoU5VBZJ85', // Description
+  logo: 'fldlN4rEUvhZBt8Bk', // Logo
+  focus: 'fldJw9XfXOInZ7mCq', // Focus
+  status: 'flduXnbMW0gaLpSgE', // Status
+  link: 'fldAOckkk19f4aNTm', // Link
+  featured: 'fldEp3grkZngt3fmk', // Featured
+  featuredTagline: 'fldqzI3RhC7hwYJN2', // Featured tagline
+  sort: 'fldbIK2vKzWm61CGr', // Sort
+  publish: 'fldaOmFd67ORPMfTC', // Publish?
+  hide: 'fldBOSo9B5KSaTZRq', // Hide?
+} as const
 
 export interface Advisor {
   id: string
@@ -32,37 +42,27 @@ export async function getAdvisors(): Promise<Advisor[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,
-    filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
-    sort: [{ field: 'Sort', direction: 'asc' }],
+    returnFieldsByFieldId: true,
+    filterByFormula: publishedFormula(FIELD.publish, FIELD.hide),
+    sort: [{ field: FIELD.sort, direction: 'asc' }],
   })
 
   const results: Advisor[] = []
   for (const record of raw) {
-    const fields = record.fields as AirtableRecord['fields']
-    if (!fields.Name) continue
-
-    let logo: string | null = null
-    if (fields.Logo && fields.Logo.length > 0) {
-      logo = fields.Logo[0].url
-    }
+    const f = record.fields
+    const name = fieldString(f[FIELD.name])
+    if (!name) continue
 
     results.push({
       id: record.id,
-      name: fields.Name,
-      description: fields.Description || '',
-      logo,
-      focus: Array.isArray(fields.Focus)
-        ? fields.Focus.join(', ')
-        : fields.Focus || '',
-      status: Array.isArray(fields.Status)
-        ? fields.Status.join(', ')
-        : fields.Status || '',
-      url: fields.Link || '#',
-      featured:
-        fields.Featured === '1' || fields.Featured === '2'
-          ? (fields.Featured as '1' | '2')
-          : null,
-      featuredTagline: fields['Featured tagline'] || null,
+      name,
+      description: fieldString(f[FIELD.description]) || '',
+      logo: fieldAttachmentUrl(f[FIELD.logo]),
+      focus: fieldText(f[FIELD.focus]),
+      status: fieldText(f[FIELD.status]),
+      url: fieldString(f[FIELD.link]) || '#',
+      featured: fieldFeatured(f[FIELD.featured]),
+      featuredTagline: fieldString(f[FIELD.featuredTagline]),
     })
   }
 

--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -22,6 +22,56 @@ interface FetchOptions {
   filterByFormula?: string
   sort?: Array<{ field: string; direction: 'asc' | 'desc' }>
   fields?: string[]
+  /** Key record fields by permanent field ID instead of name (rename-proof). */
+  returnFieldsByFieldId?: boolean
+}
+
+// ---- Field-value helpers ---------------------------------------------
+// Records fetched with returnFieldsByFieldId are keyed by permanent field
+// ID and arrive untyped (Record<string, unknown>). These helpers coerce
+// the values safely and uniformly across the data layer.
+
+/** String value, or null when empty or missing. */
+export function fieldString(value: unknown): string | null {
+  return typeof value === 'string' && value !== '' ? value : null
+}
+
+/** Numeric value, or null when missing. */
+export function fieldNumber(value: unknown): number | null {
+  return typeof value === 'number' ? value : null
+}
+
+/** Multi-select (or single string) as an array of strings. */
+export function fieldStringArray(value: unknown): string[] {
+  if (typeof value === 'string') return value ? [value] : []
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === 'string')
+  }
+  return []
+}
+
+/** Multi-select (or single string) joined with ', '; '' when missing. */
+export function fieldText(value: unknown): string {
+  return fieldStringArray(value).join(', ')
+}
+
+/** First attachment's URL, or null. */
+export function fieldAttachmentUrl(value: unknown): string | null {
+  if (!isAttachmentArray(value)) return null
+  return value[0].url
+}
+
+/** The two featured-card slots used across resource pages. */
+export function fieldFeatured(value: unknown): '1' | '2' | null {
+  return value === '1' || value === '2' ? value : null
+}
+
+/** Standard published-and-not-hidden filter, by permanent field ID. */
+export function publishedFormula(
+  publishFieldId: string,
+  hideFieldId: string
+): string {
+  return `AND({${publishFieldId}} = TRUE(), {${hideFieldId}} = FALSE())`
 }
 
 const CACHE_DIR = path.join(process.cwd(), 'public', 'images', 'airtable-cache')
@@ -327,6 +377,9 @@ async function fetchAirtableRecordsImpl(
     }
     if (options.fields) {
       options.fields.forEach(f => url.searchParams.append('fields[]', f))
+    }
+    if (options.returnFieldsByFieldId) {
+      url.searchParams.set('returnFieldsByFieldId', 'true')
     }
     if (offset) {
       url.searchParams.set('offset', offset)

--- a/src/lib/data/communities.ts
+++ b/src/lib/data/communities.ts
@@ -1,28 +1,39 @@
-import { fetchAirtableRecords } from './airtable'
+import {
+  fetchAirtableRecords,
+  fieldAttachmentUrl,
+  fieldFeatured,
+  fieldNumber,
+  fieldString,
+  fieldStringArray,
+  publishedFormula,
+} from './airtable'
 
 const TABLE_ID = 'tbluI5Dll697WiSm8'
 const VIEW_ID = 'viwFIU3lKQHZlpc0b'
 
-interface AirtableRecord {
-  fields: {
-    Name?: string
-    Description?: string
-    Logo?: Array<{ url: string }>
-    Platform?: string[]
-    'Platform wrangled'?: string
-    Type?: string[]
-    'Activity level'?: string
-    Focus?: string
-    Link?: string
-    'Location (if in-person)'?: string
-    Size?: string
-    Sort?: number
-    Latitude?: number
-    Longitude?: number
-    Featured?: string
-    'Featured tagline'?: string
-  }
-}
+// Permanent Airtable field IDs for the Communities table. Fetching,
+// filtering and sorting by ID keeps the page working when fields are
+// renamed.
+const FIELD = {
+  name: 'fld6w8ff8niuQCtF8', // Name
+  description: 'fld5EkoT2YkkbYaym', // Description
+  logo: 'fldAOv9unizM1MOoh', // Logo
+  platform: 'fldtB4DH4pavlH2HF', // Platform
+  platformWrangled: 'fld4dZD0bxWJn09Uw', // Platform wrangled
+  type: 'fldxye7cJo7hUZUvQ', // Type
+  activityLevel: 'fldhmpd6FsN0wAED2', // Activity level
+  focus: 'fldmV7OYSEPNKlRAk', // Focus
+  link: 'flddg6m5nLsQS48Kw', // Link
+  locationIfInPerson: 'fldxoaSbAsaLQRKGa', // Location (if in-person)
+  size: 'fldwpS0uMsn7KjLw0', // Size
+  sort: 'fldKaLNPjKAt10KGo', // Sort
+  latitude: 'fldfVGghvBxhEPuH1', // Latitude
+  longitude: 'fldlavJcz8Zl6MqsC', // Longitude
+  featured: 'fldggxJr1i9yxhFex', // Featured
+  featuredTagline: 'fldDxqDvO7vgFo2m0', // Featured tagline
+  publish: 'fldV8RYP1CVzOvHpf', // Publish?
+  hide: 'fldQAl9W6QDPCpdew', // Hide?
+} as const
 
 export interface Community {
   id: string
@@ -48,41 +59,35 @@ export async function getCommunities(): Promise<Community[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,
-    filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
-    sort: [{ field: 'Sort', direction: 'asc' }],
+    returnFieldsByFieldId: true,
+    filterByFormula: publishedFormula(FIELD.publish, FIELD.hide),
+    sort: [{ field: FIELD.sort, direction: 'asc' }],
   })
 
   const results: Community[] = []
   for (const record of raw) {
-    const fields = record.fields as AirtableRecord['fields']
-    if (!fields.Name) continue
-
-    let logo: string | null = null
-    if (fields.Logo && fields.Logo.length > 0) {
-      logo = fields.Logo[0].url
-    }
+    const f = record.fields
+    const name = fieldString(f[FIELD.name])
+    if (!name) continue
 
     results.push({
       id: record.id,
-      name: fields.Name,
-      description: fields.Description || '',
-      logo,
-      platform: fields.Platform || [],
-      platformText: fields['Platform wrangled'] || '',
-      type: fields.Type || [],
-      activityLevel: fields['Activity level'] || '',
-      focus: fields.Focus || '',
-      joinLink: fields.Link || '#',
-      location: fields['Location (if in-person)'] || null,
-      size: fields.Size || null,
-      sort: fields.Sort || 9999,
-      latitude: fields.Latitude ?? null,
-      longitude: fields.Longitude ?? null,
-      featured:
-        fields.Featured === '1' || fields.Featured === '2'
-          ? (fields.Featured as '1' | '2')
-          : null,
-      featuredTagline: fields['Featured tagline'] || null,
+      name,
+      description: fieldString(f[FIELD.description]) || '',
+      logo: fieldAttachmentUrl(f[FIELD.logo]),
+      platform: fieldStringArray(f[FIELD.platform]),
+      platformText: fieldString(f[FIELD.platformWrangled]) || '',
+      type: fieldStringArray(f[FIELD.type]),
+      activityLevel: fieldString(f[FIELD.activityLevel]) || '',
+      focus: fieldString(f[FIELD.focus]) || '',
+      joinLink: fieldString(f[FIELD.link]) || '#',
+      location: fieldString(f[FIELD.locationIfInPerson]),
+      size: fieldString(f[FIELD.size]),
+      sort: fieldNumber(f[FIELD.sort]) ?? 9999,
+      latitude: fieldNumber(f[FIELD.latitude]),
+      longitude: fieldNumber(f[FIELD.longitude]),
+      featured: fieldFeatured(f[FIELD.featured]),
+      featuredTagline: fieldString(f[FIELD.featuredTagline]),
     })
   }
 

--- a/src/lib/data/counts.ts
+++ b/src/lib/data/counts.ts
@@ -1,69 +1,70 @@
 import { fetchAirtableRecords } from './airtable'
 
-// Each resource's table ID, view to count from, and a minimal field to fetch.
+// Each resource's table ID, view to count from, and a minimal field (by
+// permanent field ID — rename-proof) to fetch.
 // adjust: manual correction for counts that don't match the live site exactly.
 const resources = [
   {
     path: '/events-and-training',
     tableId: 'tblx0L8qJEaLBxJFS',
     viewId: 'viwHl72bJxCb2SfrL',
-    field: 'Name',
+    field: 'fldqx8bjKAUc3IfVO', // Name
   },
   {
     path: '/map',
     tableId: 'tblvzbGL9q9dOO9Nc',
     viewId: 'viwJgtDFDmaP8PyoI',
-    field: 'Long name',
+    field: 'fldqYJa5li27kVOUW', // Long name
     adjust: -4, // Grid view includes 4 category header rows that aren't displayed on the site
   },
   {
     path: '/communities',
     tableId: 'tbluI5Dll697WiSm8',
     viewId: 'viwFIU3lKQHZlpc0b',
-    field: 'Name',
+    field: 'fld6w8ff8niuQCtF8', // Name
   },
   {
     path: '/self-study',
     tableId: 'tblRNYJ0m1cmJXKKk',
     viewId: 'viwblgaia3x1gsqBo',
-    field: 'Name',
+    field: 'fldQQt1WHmasrayDD', // Name
     adjust: 1, // View excludes one published record that's shown on the site
   },
   {
     path: '/jobs',
     tableId: 'tblyLelYCQjP6w3nV',
     viewId: 'viwBfn9CIUVqQHUy6',
-    field: '!Title',
+    field: 'fldDVJcmd66eF3E7c', // !Title
   },
   {
     path: '/funding',
     tableId: 'tblzMTLDZWZKqTxrq',
     viewId: 'viwxv2w8utSEhUeiJ',
-    field: 'Name',
+    field: 'fldsFpgVduYnNuYkN', // Name
   },
   {
     path: '/media-channels',
     tableId: 'tblCTOMzyH3vILL5I',
     viewId: 'viwT8KTwupcVyGKLZ',
-    field: 'Name',
+    field: 'fldsju0ew5KYrY3Qa', // Name
   },
   {
     path: '/advisors',
     tableId: 'tblf3KKYnmgcjVGhD',
     viewId: 'viwIdRmaCar2Y6gPi',
-    field: 'Name',
+    field: 'fldDCHQmcF8HLOz5S', // Name
   },
   {
     path: '/projects',
     tableId: 'tblHT29QNgMYKB8iW',
     viewId: 'viwVgPN3hgpGa8dRE',
-    field: 'Project Name',
+    field: 'fldtfqsPSKc5ubNs4', // Project Name
   },
   {
     path: '/founders',
     tableId: 'tbl59Ye8oxvPjoVJv',
     viewId: 'viwzMBhPBk1GpQXnn',
-    field: 'Name',
+    field: 'fldylwo2fwYtfMqM8', // Name
   },
 ]
 

--- a/src/lib/data/events.ts
+++ b/src/lib/data/events.ts
@@ -1,21 +1,30 @@
-import { fetchAirtableRecords } from './airtable'
+import {
+  fetchAirtableRecords,
+  fieldNumber,
+  fieldString,
+  fieldText,
+  publishedFormula,
+} from './airtable'
 
 const TABLE_ID = 'tblx0L8qJEaLBxJFS'
 
-interface AirtableRecord {
-  fields: {
-    Name?: string
-    Description?: string
-    URL?: string
-    'Start date'?: string
-    'End date'?: string
-    'Applications/registrations close'?: string
-    Type?: string[]
-    Location?: string[]
-    'Host name'?: string
-    'Length (days)'?: number
-  }
-}
+// Permanent Airtable field IDs for the legacy Events & training table.
+// Fetching, filtering and sorting by ID keeps this working when fields
+// are renamed.
+const FIELD = {
+  name: 'fldqx8bjKAUc3IfVO', // Name
+  description: 'fldKQrII3tnj8K2xT', // Description
+  url: 'fld6fSumOLa0mCl62', // URL
+  startDate: 'fldRdvrU4kw7liuXt', // Start date
+  endDate: 'fld9viXAgNWmLmcwO', // End date
+  applicationsClose: 'fldiDBF0GlZkxepBx', // Applications/registrations close
+  type: 'fldu75bm9xmXRJ9NU', // Type
+  location: 'fldK8ohHmfjK1N7dY', // Location
+  hostName: 'fldv4uOpBaUOO1CR3', // Host name
+  lengthDays: 'fldmzcZShTVzvZ1js', // Length (days)
+  publish: 'fldttLEJht7oFgNDX', // Publish?
+  hide: 'fldxeTQM7GTOmBY7n', // Hide?
+} as const
 
 export interface AISafetyEvent {
   id: string
@@ -48,36 +57,33 @@ function isUpcomingOrOngoing(
 export async function getEvents(): Promise<AISafetyEvent[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
-    filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
-    sort: [{ field: 'Start date', direction: 'asc' }],
+    returnFieldsByFieldId: true,
+    filterByFormula: publishedFormula(FIELD.publish, FIELD.hide),
+    sort: [{ field: FIELD.startDate, direction: 'asc' }],
   })
 
   const results: AISafetyEvent[] = []
   for (const record of raw) {
-    const fields = record.fields as AirtableRecord['fields']
-    if (!fields.Name) continue
+    const f = record.fields
+    const name = fieldString(f[FIELD.name])
+    if (!name) continue
 
-    const startDate = fields['Start date'] || null
-    const endDate = fields['End date'] || null
+    const startDate = fieldString(f[FIELD.startDate])
+    const endDate = fieldString(f[FIELD.endDate])
     if (!isUpcomingOrOngoing(endDate, startDate)) continue
 
     results.push({
       id: record.id,
-      name: fields.Name,
-      description: fields.Description || '',
-      url: fields.URL || '#',
+      name,
+      description: fieldString(f[FIELD.description]) || '',
+      url: fieldString(f[FIELD.url]) || '#',
       startDate,
       endDate,
-      applicationsClose: fields['Applications/registrations close'] || null,
-      type: Array.isArray(fields.Type) ? fields.Type.join(', ') : '',
-      location: Array.isArray(fields.Location)
-        ? fields.Location.join(', ')
-        : '',
-      host: fields['Host name'] || '',
-      lengthDays:
-        typeof fields['Length (days)'] === 'number'
-          ? fields['Length (days)']
-          : null,
+      applicationsClose: fieldString(f[FIELD.applicationsClose]),
+      type: fieldText(f[FIELD.type]),
+      location: fieldText(f[FIELD.location]),
+      host: fieldString(f[FIELD.hostName]) || '',
+      lengthDays: fieldNumber(f[FIELD.lengthDays]),
     })
   }
 

--- a/src/lib/data/founders.ts
+++ b/src/lib/data/founders.ts
@@ -1,20 +1,31 @@
-import { fetchAirtableRecords } from './airtable'
+import {
+  fetchAirtableRecords,
+  fieldAttachmentUrl,
+  fieldFeatured,
+  fieldNumber,
+  fieldString,
+  fieldText,
+  publishedFormula,
+} from './airtable'
 
 const TABLE_ID = 'tbl59Ye8oxvPjoVJv'
 const VIEW_ID = 'viwzMBhPBk1GpQXnn'
 
-interface AirtableRecord {
-  fields: {
-    Name?: string
-    Sort?: number
-    Type?: string | string[]
-    Image?: Array<{ url: string }>
-    Description?: string
-    Website?: string
-    Featured?: string
-    'Featured tagline'?: string
-  }
-}
+// Permanent Airtable field IDs for the Founder toolkit table. Fetching,
+// filtering and sorting by ID keeps the page working when fields are
+// renamed.
+const FIELD = {
+  name: 'fldylwo2fwYtfMqM8', // Name
+  sort: 'fldBoK9MKNijwTzBl', // Sort
+  type: 'fldu8ymguU2ndeGgF', // Type
+  image: 'fld2MY1ilx2i6Gqll', // Image
+  description: 'fld904S9bZ6oECDte', // Description
+  website: 'fldWDaTU33sdnQC5A', // Website
+  featured: 'fldzM3TDpR4RGllFT', // Featured
+  featuredTagline: 'fldhf703nHwICgQyl', // Featured tagline
+  publish: 'fld9Epdrxu9n0FV20', // Publish?
+  hide: 'fldPKsUP3i4UVujDf', // Hide?
+} as const
 
 export interface FounderResource {
   id: string
@@ -32,38 +43,30 @@ export async function getFounderResources(): Promise<FounderResource[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,
-    filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
+    returnFieldsByFieldId: true,
+    filterByFormula: publishedFormula(FIELD.publish, FIELD.hide),
     sort: [
-      { field: 'Sort', direction: 'asc' },
-      { field: 'Name', direction: 'asc' },
+      { field: FIELD.sort, direction: 'asc' },
+      { field: FIELD.name, direction: 'asc' },
     ],
   })
 
   const results: FounderResource[] = []
   for (const record of raw) {
-    const fields = record.fields as AirtableRecord['fields']
-    if (!fields.Name) continue
-
-    let image: string | null = null
-    if (fields.Image && fields.Image.length > 0) {
-      image = fields.Image[0].url
-    }
+    const f = record.fields
+    const name = fieldString(f[FIELD.name])
+    if (!name) continue
 
     results.push({
       id: record.id,
-      name: fields.Name,
-      sort: fields.Sort ?? null,
-      type: Array.isArray(fields.Type)
-        ? fields.Type.join(', ')
-        : fields.Type || '',
-      image,
-      description: fields.Description || '',
-      website: fields.Website || '#',
-      featured:
-        fields.Featured === '1' || fields.Featured === '2'
-          ? (fields.Featured as '1' | '2')
-          : null,
-      featuredTagline: fields['Featured tagline'] || null,
+      name,
+      sort: fieldNumber(f[FIELD.sort]),
+      type: fieldText(f[FIELD.type]),
+      image: fieldAttachmentUrl(f[FIELD.image]),
+      description: fieldString(f[FIELD.description]) || '',
+      website: fieldString(f[FIELD.website]) || '#',
+      featured: fieldFeatured(f[FIELD.featured]),
+      featuredTagline: fieldString(f[FIELD.featuredTagline]),
     })
   }
 

--- a/src/lib/data/funding.ts
+++ b/src/lib/data/funding.ts
@@ -1,21 +1,30 @@
-import { fetchAirtableRecords } from './airtable'
+import {
+  fetchAirtableRecords,
+  fieldAttachmentUrl,
+  fieldFeatured,
+  fieldString,
+  fieldText,
+  publishedFormula,
+} from './airtable'
 
 const TABLE_ID = 'tblzMTLDZWZKqTxrq'
 const VIEW_ID = 'viwxv2w8utSEhUeiJ'
 
-interface AirtableRecord {
-  fields: {
-    Name?: string
-    Description?: string
-    Logo?: Array<{ url: string }>
-    Type?: string | string[]
-    'Recipient type'?: string | string[]
-    'Accepting applications?'?: string | string[]
-    Website?: string
-    Featured?: string
-    'Featured tagline'?: string
-  }
-}
+// Permanent Airtable field IDs for the Funding table. Fetching, filtering
+// and sorting by ID keeps the page working when fields are renamed.
+const FIELD = {
+  name: 'fldsFpgVduYnNuYkN', // Name
+  description: 'fldBm7ZehvD2anFg8', // Description
+  logo: 'fldVVx7c5jJRvKxDB', // Logo
+  type: 'fldu44vSLT2tH4fqh', // Type
+  acceptingApplications: 'fld398tQjtRGz0Pk1', // Accepting applications?
+  website: 'fldpc3AO5j2k3PU3b', // Website
+  featured: 'fldS0WL2vXJ0h2HQs', // Featured
+  featuredTagline: 'fldNevMnRCmCzv4Jt', // Featured tagline
+  sort: 'fldDDTHjJHiUUBz7k', // Sort
+  publish: 'fldoH88AbtQLEViD7', // Publish?
+  hide: 'fldU5a381Lcgjgzp8', // Hide?
+} as const
 
 export interface Funder {
   id: string
@@ -34,40 +43,29 @@ export async function getFunders(): Promise<Funder[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,
-    filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
-    sort: [{ field: 'Sort', direction: 'asc' }],
+    returnFieldsByFieldId: true,
+    filterByFormula: publishedFormula(FIELD.publish, FIELD.hide),
+    sort: [{ field: FIELD.sort, direction: 'asc' }],
   })
 
   const results: Funder[] = []
   for (const record of raw) {
-    const fields = record.fields as AirtableRecord['fields']
-    if (!fields.Name) continue
-
-    let logo: string | null = null
-    if (fields.Logo && fields.Logo.length > 0) {
-      logo = fields.Logo[0].url
-    }
+    const f = record.fields
+    const name = fieldString(f[FIELD.name])
+    if (!name) continue
 
     results.push({
       id: record.id,
-      name: fields.Name,
-      description: fields.Description || '',
-      logo,
-      type: Array.isArray(fields.Type)
-        ? fields.Type.join(', ')
-        : fields.Type || '',
-      recipientType: Array.isArray(fields['Recipient type'])
-        ? fields['Recipient type'].join(', ')
-        : fields['Recipient type'] || '',
-      acceptingApplications: Array.isArray(fields['Accepting applications?'])
-        ? fields['Accepting applications?'].join(', ')
-        : fields['Accepting applications?'] || '',
-      url: fields.Website || '#',
-      featured:
-        fields.Featured === '1' || fields.Featured === '2'
-          ? (fields.Featured as '1' | '2')
-          : null,
-      featuredTagline: fields['Featured tagline'] || null,
+      name,
+      description: fieldString(f[FIELD.description]) || '',
+      logo: fieldAttachmentUrl(f[FIELD.logo]),
+      type: fieldText(f[FIELD.type]),
+      // The Recipient type field no longer exists in Airtable.
+      recipientType: '',
+      acceptingApplications: fieldText(f[FIELD.acceptingApplications]),
+      url: fieldString(f[FIELD.website]) || '#',
+      featured: fieldFeatured(f[FIELD.featured]),
+      featuredTagline: fieldString(f[FIELD.featuredTagline]),
     })
   }
 

--- a/src/lib/data/jobs.ts
+++ b/src/lib/data/jobs.ts
@@ -1,39 +1,31 @@
-import { fetchAirtableRecords } from './airtable'
+import {
+  fetchAirtableRecords,
+  fieldAttachmentUrl,
+  fieldString,
+  fieldText,
+} from './airtable'
 
 const TABLE_ID = 'tblyLelYCQjP6w3nV'
 const VIEW_ID = 'viwBfn9CIUVqQHUy6'
 
-interface AirtableRecord {
-  fields: {
-    '!Title'?: string
-    '!Description'?: string
-    '!Org'?: string
-    "Org's logo"?: string | Array<{ url: string }>
-    'Skill set text'?: string | string[]
-    'Location (formatted)'?: string | string[]
-    '!MinimumExperienceLevel (text)'?: string | string[]
-    'Role type text'?: string | string[]
-    'Work location'?: string | string[]
-    "Org's vacancies page"?: string
-    'Vacancy Button'?: string
-    'Date published'?: string
-  }
-}
+// Permanent Airtable field IDs for the Jobs table. Fetching and selecting
+// by ID keeps the page working when fields are renamed.
+const FIELD = {
+  title: 'fldDVJcmd66eF3E7c', // !Title
+  description: 'fldZY5rS7RSw3G6vw', // !Description
+  org: 'fldG5yHF2GRnwXLcZ', // !Org
+  orgLogo: 'fld0HYRj3o8ZPzIpB', // Org's logo
+  skillSetText: 'fld7B5GTUR1kEj2wH', // Skill set text
+  locationFormatted: 'fldmUJTIPAi5YIv7P', // Location (formatted)
+  minimumExperienceText: 'fldAskPW25nc6R4GZ', // !MinimumExperienceLevel (text)
+  roleTypeText: 'fldCXYRLhvZbwf0Pp', // Role type text
+  workLocation: 'fldffza4UJBfsjL3v', // Work location
+  orgVacanciesPage: 'fldw33cUFdvqcOz64', // Org's vacancies page
+  vacancyButton: 'fldihcmZcHWNWPsxe', // Vacancy Button
+  datePublished: 'fldo9SdkQLyzUI9yp', // Date published
+} as const
 
-const FIELDS = [
-  '!Title',
-  '!Description',
-  '!Org',
-  "Org's logo",
-  'Skill set text',
-  'Location (formatted)',
-  '!MinimumExperienceLevel (text)',
-  'Role type text',
-  'Work location',
-  "Org's vacancies page",
-  'Vacancy Button',
-  'Date published',
-]
+const FIELDS = Object.values(FIELD)
 
 export interface Job {
   id: string
@@ -54,47 +46,36 @@ export async function getJobs(): Promise<Job[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,
+    returnFieldsByFieldId: true,
     fields: FIELDS,
   })
 
   const results: Job[] = []
   for (const record of raw) {
-    const fields = record.fields as AirtableRecord['fields']
-    if (!fields['!Title']) continue
+    const f = record.fields
+    const name = fieldString(f[FIELD.title])
+    if (!name) continue
 
-    let logo: string | null = null
-    const logoField = fields["Org's logo"]
-    if (logoField) {
-      if (typeof logoField === 'string') {
-        logo = logoField
-      } else if (Array.isArray(logoField) && logoField.length > 0) {
-        logo = logoField[0].url
-      }
-    }
+    // Org's logo is usually a URL string, but has also held attachments.
+    const logoRaw = f[FIELD.orgLogo]
+    const logo = fieldString(logoRaw) ?? fieldAttachmentUrl(logoRaw)
 
     results.push({
       id: record.id,
-      name: fields['!Title'],
-      description: fields['!Description'] || '',
-      organization: fields['!Org'] || '',
+      name,
+      description: fieldString(f[FIELD.description]) || '',
+      organization: fieldString(f[FIELD.org]) || '',
       logo,
-      skillSet: Array.isArray(fields['Skill set text'])
-        ? fields['Skill set text'].join(', ')
-        : fields['Skill set text'] || '',
-      location: Array.isArray(fields['Location (formatted)'])
-        ? fields['Location (formatted)'].join(', ')
-        : fields['Location (formatted)'] || '',
-      minimumExperience: Array.isArray(fields['!MinimumExperienceLevel (text)'])
-        ? fields['!MinimumExperienceLevel (text)'].join(', ')
-        : fields['!MinimumExperienceLevel (text)'] || '',
-      roleType: Array.isArray(fields['Role type text'])
-        ? fields['Role type text'].join(', ')
-        : fields['Role type text'] || '',
-      workLocation: Array.isArray(fields['Work location'])
-        ? fields['Work location'].join(', ')
-        : fields['Work location'] || '',
-      url: fields['Vacancy Button'] || fields["Org's vacancies page"] || '#',
-      datePublished: fields['Date published'] || null,
+      skillSet: fieldText(f[FIELD.skillSetText]),
+      location: fieldText(f[FIELD.locationFormatted]),
+      minimumExperience: fieldText(f[FIELD.minimumExperienceText]),
+      roleType: fieldText(f[FIELD.roleTypeText]),
+      workLocation: fieldText(f[FIELD.workLocation]),
+      url:
+        fieldString(f[FIELD.vacancyButton]) ||
+        fieldString(f[FIELD.orgVacanciesPage]) ||
+        '#',
+      datePublished: fieldString(f[FIELD.datePublished]),
     })
   }
 

--- a/src/lib/data/last-updated.ts
+++ b/src/lib/data/last-updated.ts
@@ -2,6 +2,9 @@ import { DONATION_GUIDE_LAST_UPDATED } from '@/lib/donation-guide-date'
 import { formatDate } from '@/lib/format-date'
 import { fetchAirtableWithRetry } from './airtable'
 
+// All field references below use permanent field IDs (rename-proof); the
+// requests set returnFieldsByFieldId so responses are keyed the same way.
+
 type QueryConfig = {
   type: 'query'
   tableId: string
@@ -29,62 +32,62 @@ const configs: Record<string, ResourceConfig> = {
     type: 'query',
     tableId: 'tblx0L8qJEaLBxJFS',
     viewId: 'viwHl72bJxCb2SfrL',
-    sortField: 'Last modified',
+    sortField: 'fldRXglLBZbUeATnf', // Last modified
   },
   map: {
     type: 'record',
     tableId: 'tblvzbGL9q9dOO9Nc',
     recordId: 'recvDWyM9MW9q1GUj',
-    dateField: 'Description',
+    dateField: 'fldUZfd5kQQP0DoOS', // Description
   },
   communities: {
     type: 'query',
     tableId: 'tbluI5Dll697WiSm8',
-    filter: '{Publish?} = TRUE()',
-    sortField: 'Last modified',
+    filter: '{fldV8RYP1CVzOvHpf} = TRUE()', // Publish?
+    sortField: 'fldcsXAugffjhKmEH', // Last modified
   },
   'self-study': {
     type: 'query',
     tableId: 'tblRNYJ0m1cmJXKKk',
     viewId: 'viwblgaia3x1gsqBo',
-    sortField: 'Last modified',
+    sortField: 'fld4gwoM3vldhbyiE', // Last modified
   },
   jobs: {
     type: 'query',
     tableId: 'tblyLelYCQjP6w3nV',
     viewId: 'viwDXZcviPykFzt4g',
-    sortField: 'Date published',
+    sortField: 'fldo9SdkQLyzUI9yp', // Date published
   },
   funding: {
     type: 'query',
     tableId: 'tblzMTLDZWZKqTxrq',
-    filter: '{Publish?} = TRUE()',
-    sortField: 'Last modified',
+    filter: '{fldoH88AbtQLEViD7} = TRUE()', // Publish?
+    sortField: 'fldMZXYm96wdeq5jw', // Last modified
   },
   'media-channels': {
     type: 'query',
     tableId: 'tblCTOMzyH3vILL5I',
-    filter: '{Publish?} = TRUE()',
-    sortField: 'Last modified',
+    filter: '{fldMN0TF3kz41HTQc} = TRUE()', // Publish?
+    sortField: 'fldg46VoI3zwPRzXR', // Last modified
   },
   advisors: {
     type: 'query',
     tableId: 'tblf3KKYnmgcjVGhD',
-    filter: '{Publish?} = TRUE()',
-    sortField: 'Last modified',
+    filter: '{fldaOmFd67ORPMfTC} = TRUE()', // Publish?
+    sortField: 'fld8rTAfTkJBhnO0L', // Last modified
   },
   projects: {
     type: 'query',
     tableId: 'tblHT29QNgMYKB8iW',
-    filter: '{Publish?} = TRUE()',
-    sortField: 'Last modified',
+    filter: '{fldrGDtZxpFLQfjMz} = TRUE()', // Publish?
+    sortField: 'fld3KsLNUU3IGj5Gg', // Last modified
   },
   founders: {
     type: 'query',
     tableId: 'tbl59Ye8oxvPjoVJv',
     viewId: 'viwzMBhPBk1GpQXnn',
-    filter: '{Publish?} = TRUE()',
-    sortField: 'Last modified',
+    filter: '{fld9Epdrxu9n0FV20} = TRUE()', // Publish?
+    sortField: 'fldMM2jKZeORMO5mP', // Last modified
   },
   'donation-guide': {
     type: 'constant',
@@ -117,7 +120,7 @@ export async function fetchLastUpdated(
 
   if (config.type === 'record') {
     const response = await fetchAirtableWithRetry(
-      `https://api.airtable.com/v0/${baseId}/${config.tableId}/${config.recordId}`,
+      `https://api.airtable.com/v0/${baseId}/${config.tableId}/${config.recordId}?returnFieldsByFieldId=true`,
       token,
       { next: { revalidate: 3600 } }
     )
@@ -149,6 +152,7 @@ export async function fetchLastUpdated(
   url.searchParams.set('sort[0][direction]', 'desc')
   url.searchParams.set('maxRecords', '1')
   url.searchParams.set('fields[]', config.sortField)
+  url.searchParams.set('returnFieldsByFieldId', 'true')
 
   const response = await fetchAirtableWithRetry(url.toString(), token, {
     next: { revalidate: 3600 },

--- a/src/lib/data/map.ts
+++ b/src/lib/data/map.ts
@@ -1,4 +1,11 @@
-import { fetchAirtableRecords } from './airtable'
+import {
+  fetchAirtableRecords,
+  fieldAttachmentUrl,
+  fieldNumber,
+  fieldString,
+  fieldStringArray,
+  publishedFormula,
+} from './airtable'
 
 const TABLE_ID = 'tblvzbGL9q9dOO9Nc'
 const VIEW_ID = 'viwJgtDFDmaP8PyoI'
@@ -10,25 +17,27 @@ const MAGIC_ROW_NAMES = [
   'Suggest entry',
 ]
 
-interface AirtableRecord {
-  fields: {
-    'Long name'?: string
-    'Long name for cards'?: string
-    'Short name'?: string
-    Description?: string
-    Category?: string[]
-    'Category (text)'?: string
-    Status?: string
-    'Logo (for cards)'?: Array<{ url: string }>
-    'Logo (for map)'?: Array<{ url: string }>
-    Link?: string
-    'Short URL'?: string
-    'Date added'?: string
-    x?: number
-    y?: number
-    Scale?: string
-  }
-}
+// Permanent Airtable field IDs for the Map table. Fetching, filtering and
+// selecting by ID keeps the page working when fields are renamed.
+const FIELD = {
+  longName: 'fldqYJa5li27kVOUW', // Long name
+  longNameForCards: 'fldPEouzOZbCIZr7p', // Long name for cards
+  shortName: 'fldIL5rLAwlbvdhtg', // Short name
+  description: 'fldUZfd5kQQP0DoOS', // Description
+  categoryText: 'fldddK6whfSl9DWNd', // Category (text)
+  category: 'fldhofDtTtJqWXLuf', // Category
+  status: 'fld2OFKbXPhO2NQRx', // Status
+  logoForCards: 'fldIuProl6IeG0wH2', // Logo (for cards)
+  logoForMap: 'fldua2ISy01Yntwof', // Logo (for map)
+  link: 'fldOilqj9tDwl70Rp', // Link
+  shortUrl: 'fldSLQDvullnrvmut', // Short URL
+  dateAdded: 'fldx8pSG2rP7pRRZf', // Date added
+  x: 'fld2FlBMPjxhjGuFO', // x
+  y: 'fldkAQPZaibRGawVw', // y
+  scale: 'fldw2bKsCY0VdTCN6', // Scale
+  publish: 'fldCCQ2OYlQluuarR', // Publish?
+  hide: 'fldKwedEOWPFuWSe7', // Hide?
+} as const
 
 export interface MapOrg {
   id: string
@@ -56,21 +65,21 @@ export interface MapData {
 }
 
 const FIELD_LIST = [
-  'Long name',
-  'Long name for cards',
-  'Short name',
-  'Description',
-  'Category (text)',
-  'Category',
-  'Status',
-  'Logo (for cards)',
-  'Logo (for map)',
-  'Link',
-  'Short URL',
-  'Date added',
-  'x',
-  'y',
-  'Scale',
+  FIELD.longName,
+  FIELD.longNameForCards,
+  FIELD.shortName,
+  FIELD.description,
+  FIELD.categoryText,
+  FIELD.category,
+  FIELD.status,
+  FIELD.logoForCards,
+  FIELD.logoForMap,
+  FIELD.link,
+  FIELD.shortUrl,
+  FIELD.dateAdded,
+  FIELD.x,
+  FIELD.y,
+  FIELD.scale,
 ]
 
 // Sort order is hardcoded so the Airtable view sort can be changed freely
@@ -135,7 +144,8 @@ export async function getMapData(): Promise<MapData> {
     // keep unpublished orgs out of the data (and therefore out of the chatbot
     // catalog). The page's magic control rows (Last updated, Suggest entry,
     // etc.) are all published, so they pass this filter unaffected.
-    filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
+    filterByFormula: publishedFormula(FIELD.publish, FIELD.hide),
+    returnFieldsByFieldId: true,
     fields: FIELD_LIST,
   })
 
@@ -145,60 +155,50 @@ export async function getMapData(): Promise<MapData> {
   let suggestCorrectionLink = '#'
 
   for (const record of raw) {
-    const fields = record.fields as AirtableRecord['fields']
+    const f = record.fields
 
-    const title = fields['Long name for cards'] || fields['Long name']
-    if (!title || !fields.Description) continue
+    const title =
+      fieldString(f[FIELD.longNameForCards]) || fieldString(f[FIELD.longName])
+    const description = fieldString(f[FIELD.description])
+    if (!title || !description) continue
 
     const isMagic = MAGIC_ROW_NAMES.includes(title)
 
-    if (title === 'Last updated' && fields.Description) {
-      lastUpdated = fields.Description
+    if (title === 'Last updated') {
+      lastUpdated = description
     }
 
-    if (title === 'Suggest entry' && fields.Link) {
-      suggestEntryLink = fields.Link
-    } else if (title === 'Suggest correction' && fields.Link) {
-      suggestCorrectionLink = fields.Link
+    const link = fieldString(f[FIELD.link])
+    if (title === 'Suggest entry' && link) {
+      suggestEntryLink = link
+    } else if (title === 'Suggest correction' && link) {
+      suggestCorrectionLink = link
     }
 
-    let category = ''
-    if (fields['Category (text)']) {
-      category = fields['Category (text)']
-    } else if (Array.isArray(fields.Category)) {
-      category = fields.Category.join(', ')
-    }
-
-    let logo: string | null = null
-    if (fields['Logo (for cards)'] && fields['Logo (for cards)'].length > 0) {
-      logo = fields['Logo (for cards)'][0].url
-    }
-
-    let mapLogo: string | null = null
-    if (fields['Logo (for map)'] && fields['Logo (for map)'].length > 0) {
-      mapLogo = fields['Logo (for map)'][0].url
-    }
+    const category =
+      fieldString(f[FIELD.categoryText]) ||
+      fieldStringArray(f[FIELD.category]).join(', ')
 
     // QA: 'Long name for cards' includes acronyms in brackets (e.g. "CARMA"),
     // which is correct for card titles but not for the map tooltip. The tooltip
     // should use 'Long name' (without brackets), matching the live site's LongLabel.
-    const tooltipTitle = fields['Long name'] || title
+    const tooltipTitle = fieldString(f[FIELD.longName]) || title
 
     allRecords.push({
       id: record.id,
       title,
       tooltipTitle,
-      shortName: fields['Short name'] || null,
-      description: fields.Description,
+      shortName: fieldString(f[FIELD.shortName]),
+      description,
       category,
-      status: fields.Status || 'Active',
-      logo,
-      mapLogo,
-      link: fields.Link || '#',
-      shortUrl: fields['Short URL'] || null,
-      x: fields.x ?? null,
-      y: fields.y ?? null,
-      scale: fields.Scale || null,
+      status: fieldString(f[FIELD.status]) || 'Active',
+      logo: fieldAttachmentUrl(f[FIELD.logoForCards]),
+      mapLogo: fieldAttachmentUrl(f[FIELD.logoForMap]),
+      link: link || '#',
+      shortUrl: fieldString(f[FIELD.shortUrl]),
+      x: fieldNumber(f[FIELD.x]),
+      y: fieldNumber(f[FIELD.y]),
+      scale: fieldString(f[FIELD.scale]),
       isMagic,
     })
   }

--- a/src/lib/data/media-channels.ts
+++ b/src/lib/data/media-channels.ts
@@ -1,19 +1,30 @@
-import { fetchAirtableRecords } from './airtable'
+import {
+  fetchAirtableRecords,
+  fieldAttachmentUrl,
+  fieldFeatured,
+  fieldString,
+  fieldText,
+  publishedFormula,
+} from './airtable'
 
 const TABLE_ID = 'tblCTOMzyH3vILL5I'
 const VIEW_ID = 'viwT8KTwupcVyGKLZ'
 
-interface AirtableRecord {
-  fields: {
-    Name?: string
-    Description?: string
-    Image?: Array<{ url: string }>
-    Type?: string | string[]
-    Link?: string
-    Featured?: string
-    'Featured tagline'?: string
-  }
-}
+// Permanent Airtable field IDs for the Media channels table. Fetching,
+// filtering and sorting by ID keeps the page working when fields are
+// renamed.
+const FIELD = {
+  name: 'fldsju0ew5KYrY3Qa', // Name
+  description: 'fld4grLOZyX7Msjxg', // Description
+  image: 'fldhHGt6N9SSWjUXG', // Image
+  type: 'fldEnZ1ZYO1849kV1', // Type
+  link: 'fldvCayjHmj5GuBoE', // Link
+  featured: 'fldZlWHVADe5glk3g', // Featured
+  featuredTagline: 'fldYalqFyaKuPJZDO', // Featured tagline
+  sort: 'fldhkOSt89LF6aYE5', // Sort
+  publish: 'fldMN0TF3kz41HTQc', // Publish?
+  hide: 'fldxzKJV6SnPk7eD8', // Hide?
+} as const
 
 export interface MediaChannel {
   id: string
@@ -30,34 +41,26 @@ export async function getMediaChannels(): Promise<MediaChannel[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,
-    filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
-    sort: [{ field: 'Sort', direction: 'asc' }],
+    returnFieldsByFieldId: true,
+    filterByFormula: publishedFormula(FIELD.publish, FIELD.hide),
+    sort: [{ field: FIELD.sort, direction: 'asc' }],
   })
 
   const results: MediaChannel[] = []
   for (const record of raw) {
-    const fields = record.fields as AirtableRecord['fields']
-    if (!fields.Name) continue
-
-    let logo: string | null = null
-    if (fields.Image && fields.Image.length > 0) {
-      logo = fields.Image[0].url
-    }
+    const f = record.fields
+    const name = fieldString(f[FIELD.name])
+    if (!name) continue
 
     results.push({
       id: record.id,
-      name: fields.Name,
-      description: fields.Description || '',
-      logo,
-      type: Array.isArray(fields.Type)
-        ? fields.Type.join(', ')
-        : fields.Type || '',
-      url: fields.Link || '#',
-      featured:
-        fields.Featured === '1' || fields.Featured === '2'
-          ? (fields.Featured as '1' | '2')
-          : null,
-      featuredTagline: fields['Featured tagline'] || null,
+      name,
+      description: fieldString(f[FIELD.description]) || '',
+      logo: fieldAttachmentUrl(f[FIELD.image]),
+      type: fieldText(f[FIELD.type]),
+      url: fieldString(f[FIELD.link]) || '#',
+      featured: fieldFeatured(f[FIELD.featured]),
+      featuredTagline: fieldString(f[FIELD.featuredTagline]),
     })
   }
 

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -1,19 +1,28 @@
-import { fetchAirtableRecords } from './airtable'
+import {
+  fetchAirtableRecords,
+  fieldFeatured,
+  fieldString,
+  fieldText,
+  publishedFormula,
+} from './airtable'
 
 const TABLE_ID = 'tblHT29QNgMYKB8iW'
 const VIEW_ID = 'viwVgPN3hgpGa8dRE'
 
-interface AirtableRecord {
-  fields: {
-    'Project Name'?: string
-    'Description (short)'?: string
-    Status?: string | string[]
-    'Contact name'?: string
-    'Contact email'?: string
-    Featured?: string
-    'Featured tagline'?: string
-  }
-}
+// Permanent Airtable field IDs for the Projects table. Fetching, filtering
+// and sorting by ID keeps the page working when fields are renamed.
+const FIELD = {
+  projectName: 'fldtfqsPSKc5ubNs4', // Project Name
+  descriptionShort: 'fldbeRqlUCLsgOcCT', // Description (short)
+  status: 'fld57KJsNvSKFLoHT', // Status
+  contactName: 'fldejiM6qWUfXAeqO', // Contact name
+  contactEmail: 'fldNhMihsnXhsHMnc', // Contact email
+  featured: 'fldMxxOYWQGlWTZ9D', // Featured
+  featuredTagline: 'fld8LvgC3dnT40Vbl', // Featured tagline
+  sort: 'fldNvTVR11SJjYu2l', // Sort
+  publish: 'fldrGDtZxpFLQfjMz', // Publish?
+  hide: 'fldPjPfUW5hK98ysn', // Hide?
+} as const
 
 export interface Project {
   id: string
@@ -31,30 +40,27 @@ export async function getProjects(): Promise<Project[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,
-    filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
-    sort: [{ field: 'Sort', direction: 'asc' }],
+    returnFieldsByFieldId: true,
+    filterByFormula: publishedFormula(FIELD.publish, FIELD.hide),
+    sort: [{ field: FIELD.sort, direction: 'asc' }],
   })
 
   const results: Project[] = []
   for (const record of raw) {
-    const fields = record.fields as AirtableRecord['fields']
-    if (!fields['Project Name']) continue
+    const f = record.fields
+    const name = fieldString(f[FIELD.projectName])
+    if (!name) continue
 
     results.push({
       id: record.id,
-      name: fields['Project Name'],
-      description: fields['Description (short)'] || '',
+      name,
+      description: fieldString(f[FIELD.descriptionShort]) || '',
       logo: null,
-      contact: fields['Contact name'] || '',
-      email: fields['Contact email'] || null,
-      status: Array.isArray(fields.Status)
-        ? fields.Status.join(', ')
-        : fields.Status || '',
-      featured:
-        fields.Featured === '1' || fields.Featured === '2'
-          ? (fields.Featured as '1' | '2')
-          : null,
-      featuredTagline: fields['Featured tagline'] || null,
+      contact: fieldString(f[FIELD.contactName]) || '',
+      email: fieldString(f[FIELD.contactEmail]),
+      status: fieldText(f[FIELD.status]),
+      featured: fieldFeatured(f[FIELD.featured]),
+      featuredTagline: fieldString(f[FIELD.featuredTagline]),
     })
   }
 

--- a/src/lib/data/search-index.ts
+++ b/src/lib/data/search-index.ts
@@ -1,5 +1,5 @@
 import { getAdvisors } from './advisors'
-import { fetchAirtableRecords } from './airtable'
+import { fetchAirtableRecords, fieldString, fieldStringArray } from './airtable'
 import { getCommunities } from './communities'
 import { getCourses } from './self-study'
 import { getFounderResources } from './founders'
@@ -120,53 +120,48 @@ const STATIC_PAGES: SearchEntry[] = [
   ),
 ]
 
+// Permanent Airtable field IDs for the legacy Events & training table.
+// Fetching, selecting and sorting by ID keeps this working when fields
+// are renamed.
+const EVENT_FIELD = {
+  name: 'fldqx8bjKAUc3IfVO', // Name
+  description: 'fldKQrII3tnj8K2xT', // Description
+  hostName: 'fldv4uOpBaUOO1CR3', // Host name
+  type: 'fldu75bm9xmXRJ9NU', // Type
+  location: 'fldK8ohHmfjK1N7dY', // Location
+  startDate: 'fldRdvrU4kw7liuXt', // Start date
+  endDate: 'fld9viXAgNWmLmcwO', // End date
+  applicationsClose: 'fldiDBF0GlZkxepBx', // Applications/registrations close
+  applicationsOpenOrToday: 'fldTPqG0RfUiu71zl', // Applications open or today
+  url: 'fld6fSumOLa0mCl62', // URL
+} as const
+
 async function getEventEntries(): Promise<SearchEntry[]> {
   const raw = await fetchAirtableRecords({
     tableId: 'tblx0L8qJEaLBxJFS',
     viewId: 'viwHl72bJxCb2SfrL',
-    fields: [
-      'Name',
-      'Description',
-      'Host name',
-      'Type',
-      'Location',
-      'Start date',
-      'End date',
-      'Applications/registrations close',
-      'Applications open or today',
-      'URL',
-    ],
-    sort: [{ field: 'Start date', direction: 'asc' }],
+    returnFieldsByFieldId: true,
+    fields: Object.values(EVENT_FIELD),
+    sort: [{ field: EVENT_FIELD.startDate, direction: 'asc' }],
   })
 
   const today = new Date().toISOString().slice(0, 10)
   const entries: SearchEntry[] = []
 
   for (const record of raw) {
-    const f = record.fields as {
-      Name?: string
-      Description?: string
-      'Host name'?: string
-      Type?: string[]
-      Location?: string[]
-      'Start date'?: string
-      'End date'?: string
-      'Applications/registrations close'?: string
-      'Applications open or today'?: string
-      URL?: string
-    }
-    const name = f.Name
-    const startDate = f['Start date']
+    const f = record.fields
+    const name = fieldString(f[EVENT_FIELD.name])
+    const startDate = fieldString(f[EVENT_FIELD.startDate])
     if (!name || !startDate) continue
-    const endDate = f['End date'] || startDate
+    const endDate = fieldString(f[EVENT_FIELD.endDate]) || startDate
     if (endDate < today) continue
 
-    const closesOn = f['Applications/registrations close']
-    const openOrToday = f['Applications open or today']
+    const closesOn = fieldString(f[EVENT_FIELD.applicationsClose])
+    const openOrToday = fieldString(f[EVENT_FIELD.applicationsOpenOrToday])
     const appsOpen =
       !!closesOn && !!openOrToday && openOrToday <= today && closesOn >= today
 
-    const url = f.URL || ''
+    const url = fieldString(f[EVENT_FIELD.url]) || ''
     let logo: string | null = null
     if (url) {
       try {
@@ -182,14 +177,14 @@ async function getEventEntries(): Promise<SearchEntry[]> {
 
     const dateRange =
       endDate !== startDate ? `${startDate} – ${endDate}` : startDate
-    const types = f.Type || []
-    const locations = f.Location || []
+    const types = fieldStringArray(f[EVENT_FIELD.type])
+    const locations = fieldStringArray(f[EVENT_FIELD.location])
 
     entries.push({
       type: 'event',
       title: name,
-      subtitle: f['Host name'] || '',
-      description: f.Description || '',
+      subtitle: fieldString(f[EVENT_FIELD.hostName]) || '',
+      description: fieldString(f[EVENT_FIELD.description]) || '',
       category: [
         dateRange,
         types.join(', '),

--- a/src/lib/data/self-study.ts
+++ b/src/lib/data/self-study.ts
@@ -1,21 +1,32 @@
-import { fetchAirtableRecords } from './airtable'
+import {
+  fetchAirtableRecords,
+  fieldAttachmentUrl,
+  fieldFeatured,
+  fieldString,
+  fieldText,
+  publishedFormula,
+} from './airtable'
 
 const TABLE_ID = 'tblRNYJ0m1cmJXKKk'
 const VIEW_ID = 'viwblgaia3x1gsqBo'
 
-interface AirtableRecord {
-  fields: {
-    Name?: string
-    Description?: string
-    Focus?: string | string[]
-    Format?: string | string[]
-    'Created by'?: string
-    Link?: string
-    Logo?: Array<{ url: string }>
-    Featured?: string
-    'Featured tagline'?: string
-  }
-}
+// Permanent Airtable field IDs for the Self-study table. Fetching,
+// filtering and sorting by ID keeps the page working when fields are
+// renamed.
+const FIELD = {
+  name: 'fldQQt1WHmasrayDD', // Name
+  description: 'fld3BWX1PMV9R3lA5', // Description
+  focus: 'fldkyFFjqE02A5nPP', // Focus
+  format: 'fld5x5ek1pBqG9FNV', // Format
+  createdBy: 'fldQAhN1cBrYe5RSY', // Created by
+  link: 'fldkkeUHGbVSFit1g', // Link
+  logo: 'fldtcSqZB0sKbzVCK', // Logo
+  featured: 'fldETJCJIuQwxEvmu', // Featured
+  featuredTagline: 'fldvZjLjgSlDbtfre', // Featured tagline
+  sort: 'fldThp6KjSXk03P7p', // Sort
+  publish: 'fldWShxP7GkMeh6rg', // Publish?
+  hide: 'fldTF2A1ibOD8w3RO', // Hide?
+} as const
 
 export interface Course {
   id: string
@@ -34,38 +45,28 @@ export async function getCourses(): Promise<Course[]> {
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,
-    filterByFormula: 'AND({Publish?} = TRUE(), {Hide?} = FALSE())',
-    sort: [{ field: 'Sort', direction: 'asc' }],
+    returnFieldsByFieldId: true,
+    filterByFormula: publishedFormula(FIELD.publish, FIELD.hide),
+    sort: [{ field: FIELD.sort, direction: 'asc' }],
   })
 
   const results: Course[] = []
   for (const record of raw) {
-    const fields = record.fields as AirtableRecord['fields']
-    if (!fields.Name) continue
-
-    let image: string | null = null
-    if (fields.Logo && fields.Logo.length > 0) {
-      image = fields.Logo[0].url
-    }
+    const f = record.fields
+    const name = fieldString(f[FIELD.name])
+    if (!name) continue
 
     results.push({
       id: record.id,
-      name: fields.Name,
-      description: fields.Description || '',
-      category: Array.isArray(fields.Focus)
-        ? fields.Focus.join(', ')
-        : fields.Focus || '',
-      courseType: Array.isArray(fields.Format)
-        ? fields.Format.join(', ')
-        : fields.Format || '',
-      organizer: fields['Created by'] || '',
-      url: fields.Link || '#',
-      image,
-      featured:
-        fields.Featured === '1' || fields.Featured === '2'
-          ? (fields.Featured as '1' | '2')
-          : null,
-      featuredTagline: fields['Featured tagline'] || null,
+      name,
+      description: fieldString(f[FIELD.description]) || '',
+      category: fieldText(f[FIELD.focus]),
+      courseType: fieldText(f[FIELD.format]),
+      organizer: fieldString(f[FIELD.createdBy]) || '',
+      url: fieldString(f[FIELD.link]) || '#',
+      image: fieldAttachmentUrl(f[FIELD.logo]),
+      featured: fieldFeatured(f[FIELD.featured]),
+      featuredTagline: fieldString(f[FIELD.featuredTagline]),
     })
   }
 


### PR DESCRIPTION
- Every Airtable read and write across the site now uses permanent field IDs instead of field names. Renaming a field in Airtable can no longer break a page — historically each rename (Communities Link, self-study Focus/Format) needed an emergency code fix.
- `fetchAirtableRecords` gains a `returnFieldsByFieldId` option, and new shared helpers (`fieldString`, `fieldText`, `fieldStringArray`, `fieldNumber`, `fieldAttachmentUrl`, `fieldFeatured`, `publishedFormula`) coerce the ID-keyed values consistently.
- All 13 data files map fields through a `FIELD` constant with the human-readable name in a comment. Filters (`filterByFormula`), sorts, and field selections also reference IDs — the Airtable API accepts field IDs in all three (verified live before converting).
- The admin conversation log reads with `returnFieldsByFieldId` and writes ID-keyed fields, including the session lookup and search formulas.
- The check-rebuild cron's Publish? filters use field IDs; check-catalog only ever used table IDs.

Verification: built `main` and this branch back-to-back against live Airtable — all 17 prerendered pages are byte-identical after normalizing path-derived build tokens (asset hashes, CSS module scopes, bundler module IDs). Typecheck and build pass. The chatbot conversation-log write path is typechecked and uses the same ID-keyed PATCH pattern verified live on the Events table, but is worth a smoke test on the preview deploy before merging.

Note: `src/lib/data/funding.ts` still exposes `recipientType` — the "Recipient type" field no longer exists in Airtable, so it now explicitly maps to an empty string (same rendered result as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)