### PR TITLE
Newsletter signup: pass typed email through to Substack

### DIFF
--- a/src/app/events/NewsletterSignup.module.css
+++ b/src/app/events/NewsletterSignup.module.css
@@ -52,6 +52,7 @@
 .submit {
   flex: none;
   display: flex;
+  padding: 0;
   align-items: center;
   justify-content: center;
   width: 40px;

--- a/src/app/events/NewsletterSignup.tsx
+++ b/src/app/events/NewsletterSignup.tsx
@@ -4,16 +4,22 @@ import { useState } from 'react'
 import Image from 'next/image'
 import styles from './NewsletterSignup.module.css'
 
-const NEWSLETTER_URL = 'https://aisafetyeventsandtraining.substack.com/'
+const SUBSCRIBE_URL = 'https://aisafetyeventsandtraining.substack.com/subscribe'
 
 export default function NewsletterSignup() {
   const [email, setEmail] = useState('')
 
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const trimmed = email.trim()
+    const url = trimmed
+      ? `${SUBSCRIBE_URL}?email=${encodeURIComponent(trimmed)}`
+      : SUBSCRIBE_URL
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }
+
   return (
-    <form
-      className={`width-4-col ${styles.card}`}
-      onSubmit={e => e.preventDefault()}
-    >
+    <form className={`width-4-col ${styles.card}`} onSubmit={handleSubmit}>
       <p className={`paragraph-small ${styles.heading}`}>
         Get a weekly summary of upcoming events
       </p>
@@ -25,13 +31,7 @@ export default function NewsletterSignup() {
           value={email}
           onChange={e => setEmail(e.target.value)}
         />
-        <a
-          href={NEWSLETTER_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.submit}
-          aria-label="Subscribe"
-        >
+        <button type="submit" className={styles.submit} aria-label="Subscribe">
           <Image
             src="/images/icons/arrow-right.svg"
             alt=""
@@ -39,7 +39,7 @@ export default function NewsletterSignup() {
             height={16}
             unoptimized
           />
-        </a>
+        </button>
       </div>
     </form>
   )


### PR DESCRIPTION
- The email field on the /events newsletter card now does something: clicking the arrow (or pressing Enter) opens Substack's subscribe page in a new tab with the visitor's email prefilled, so they only have to click Subscribe there.
- Substack rejects direct programmatic signups, so prefill-and-confirm on Substack's own page is the closest possible integration.
- The arrow is now a real submit button instead of a plain link, which also gives free browser validation of the email format; with the field left empty it opens the subscribe page without prefill.
- The same component will cover /training when that page is built, since both pages share the AI Safety Events & Training newsletter.

Note: This PR was written by [Claude Code](https://claude.com/claude-code).