### PR TITLE
Conversations panel: % of messages from a suggested question

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1087,6 +1087,10 @@ function ChatbotView({
                 value={share(conv.suggestedShare)}
               />
               <Stat
+                label="Messages that were a suggested question"
+                value={share(conv.suggestedMessageShare)}
+              />
+              <Stat
                 label="Clicked a card or link"
                 value={share(conv.clickedShare)}
               />

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1087,7 +1087,7 @@ function ChatbotView({
                 value={share(conv.suggestedShare)}
               />
               <Stat
-                label="of messages clicked a follow-up suggestion (conversation starters excluded)"
+                label="of messages were a follow-up suggestion (conversation starters excluded)"
                 value={share(conv.followUpMessageShare)}
               />
               <Stat

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1147,9 +1147,10 @@ function ChatbotView({
               {themes && <>Last updated {formatTime(themes.generatedAt)}.</>}
             </p>
             <p className={styles.caption}>
-              Every typed question (suggested-chip clicks excluded), grouped
-              into themes by Claude across the whole log — a fixed weekly
-              snapshot, so the date range doesn&apos;t filter it.
+              Every typed question since the chatbot launched (suggested-chip
+              clicks excluded), grouped into themes by Claude. Always covers the
+              whole log — the date range doesn&apos;t filter it — and
+              regenerates weekly, or whenever it&apos;s refreshed.
             </p>
           </Panel>
 

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1083,15 +1083,15 @@ function ChatbotView({
               />
               <Stat label="Median messages sent" value={medianLength} />
               <Stat
-                label="Started from a suggested question"
+                label="of conversations started from a suggested question"
                 value={share(conv.suggestedShare)}
               />
               <Stat
-                label="Messages from a follow-up suggestion (excludes conversation starters)"
+                label="of messages clicked a follow-up suggestion (conversation starters excluded)"
                 value={share(conv.followUpMessageShare)}
               />
               <Stat
-                label="Clicked a card or link"
+                label="of conversations included a card or link click"
                 value={share(conv.clickedShare)}
               />
             </div>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1087,8 +1087,8 @@ function ChatbotView({
                 value={share(conv.suggestedShare)}
               />
               <Stat
-                label="Messages that were a suggested question"
-                value={share(conv.suggestedMessageShare)}
+                label="Messages from a follow-up suggestion (excludes conversation starters)"
+                value={share(conv.followUpMessageShare)}
               />
               <Stat
                 label="Clicked a card or link"

--- a/src/lib/analytics/conversations.ts
+++ b/src/lib/analytics/conversations.ts
@@ -33,14 +33,13 @@ export interface ConversationStats {
   /** Share (0–1) of conversations whose first message is one of the suggested
    *  question chips, or null with no data. */
   suggestedShare: number | null
-  /** Share (0–1) of ALL user messages that were a suggested pill rather than
-   *  typed — the message-level "pills vs chat window" split. Counts both the
-   *  starter chips (a first message matching the site's chip texts) and the
-   *  follow-up pills the bot offers after every reply (a message matching a
-   *  `[[chip:…]]` the previous reply carried). Computed over the stored
-   *  histories, so both sides of the fraction cover the same messages. Null
-   *  with no data. */
-  suggestedMessageShare: number | null
+  /** Share (0–1) of ALL user messages that clicked one of the follow-up
+   *  pills the bot offers after each reply (a message matching a `[[chip:…]]`
+   *  the previous reply carried). Conversation-STARTING chips are deliberately
+   *  excluded — they're `suggestedShare`'s job — so the two tiles never count
+   *  the same click. Computed over the stored histories, so both sides of the
+   *  fraction cover the same messages. Null with no data. */
+  followUpMessageShare: number | null
   /** Share (0–1) of conversations where the visitor clicked a listing card or
    *  link out of a reply, or null with no data. */
   clickedShare: number | null
@@ -57,7 +56,7 @@ const EMPTY_STATS: ConversationStats = {
   totalConversations: 0,
   medianLength: null,
   suggestedShare: null,
-  suggestedMessageShare: null,
+  followUpMessageShare: null,
   clickedShare: null,
   lengthBuckets: [],
   languages: [],
@@ -235,21 +234,21 @@ function median(sorted: number[]): number | null {
     : (sorted[mid - 1] + sorted[mid]) / 2
 }
 
-/** A conversation's user messages, and how many of them were pill clicks:
- *  the first message matching one of the site's starter chips, or any message
- *  matching a `[[chip:…]]` follow-up the previous reply offered (the stored
- *  history keeps the raw markers the visitor-facing chat strips). A visitor
- *  who types an offered suggestion verbatim counts as a click — they took the
- *  suggestion either way. */
-function countPillMessages(row: ConversationRow): {
+/** A conversation's user messages, and how many of them clicked a follow-up
+ *  pill: a message matching a `[[chip:…]]` suggestion the previous reply
+ *  offered (the stored history keeps the raw markers the visitor-facing chat
+ *  strips). Conversation-starting chips are NOT counted here — the
+ *  started-from-a-suggestion stat covers those. A visitor who types an
+ *  offered suggestion verbatim counts as a click — they took the suggestion
+ *  either way. */
+function countFollowUpMessages(row: ConversationRow): {
   messages: number
-  pills: number
+  followUps: number
 } {
   const history = row.data?.history ?? []
   let messages = 0
-  let pills = 0
+  let followUps = 0
   let offered = new Set<string>()
-  let isFirst = true
   for (const turn of history) {
     if (turn.role === 'assistant') {
       offered = new Set(extractChips(turn.content).map(normalize))
@@ -257,18 +256,13 @@ function countPillMessages(row: ConversationRow): {
     }
     if (!turn.content) continue
     messages += 1
-    const key = normalize(turn.content)
-    if ((isFirst && CHIP_TEXTS.has(key)) || offered.has(key)) pills += 1
-    isFirst = false
+    if (offered.has(normalize(turn.content))) followUps += 1
     offered = new Set() // an offer only applies to the very next message
   }
   // Rows with no stored history but a latest message (e.g. an abandoned
   // first turn) still count that one message.
-  if (messages === 0 && row.data?.user) {
-    messages = 1
-    if (CHIP_TEXTS.has(normalize(row.data.user))) pills = 1
-  }
-  return { messages, pills }
+  if (messages === 0 && row.data?.user) messages = 1
+  return { messages, followUps }
 }
 
 /** The typed (non-suggested-chip) first message of every conversation in the
@@ -324,9 +318,9 @@ export async function readConversationStats(
       languages.push(detectLanguage(messages))
     }
     if (row.clickedCitations.length > 0) clicked += 1
-    const pills = countPillMessages(row)
+    const pills = countFollowUpMessages(row)
     totalMessages += pills.messages
-    pillMessages += pills.pills
+    pillMessages += pills.followUps
 
     const first = messages[0]?.trim().replace(/\s+/g, ' ')
     if (!first) continue
@@ -353,7 +347,7 @@ export async function readConversationStats(
     totalConversations: rows.length,
     medianLength: median(lengths.sort((a, b) => a - b)),
     suggestedShare: withQuestion > 0 ? suggested / withQuestion : null,
-    suggestedMessageShare:
+    followUpMessageShare:
       totalMessages > 0 ? pillMessages / totalMessages : null,
     clickedShare: rows.length > 0 ? clicked / rows.length : null,
     // Buckets in display order (1 → 11+), only the non-empty ones.

--- a/src/lib/analytics/conversations.ts
+++ b/src/lib/analytics/conversations.ts
@@ -5,6 +5,7 @@
 
 import { franc } from 'franc-min'
 import { PAGES, DEFAULT_CHIPS } from '@/lib/assistant/pages'
+import { extractChips } from '@/lib/assistant/tokens'
 import {
   isConversationsTableConfigured,
   listConversationsForStats,
@@ -32,11 +33,13 @@ export interface ConversationStats {
   /** Share (0–1) of conversations whose first message is one of the suggested
    *  question chips, or null with no data. */
   suggestedShare: number | null
-  /** Share (0–1) of ALL user messages that were a suggested chip rather than
-   *  typed — the message-level "pills vs chat window" split. Chips can only
-   *  be a conversation's first message, so the numerator is the chip-started
-   *  conversations and the denominator every message sent. Null with no
-   *  data. */
+  /** Share (0–1) of ALL user messages that were a suggested pill rather than
+   *  typed — the message-level "pills vs chat window" split. Counts both the
+   *  starter chips (a first message matching the site's chip texts) and the
+   *  follow-up pills the bot offers after every reply (a message matching a
+   *  `[[chip:…]]` the previous reply carried). Computed over the stored
+   *  histories, so both sides of the fraction cover the same messages. Null
+   *  with no data. */
   suggestedMessageShare: number | null
   /** Share (0–1) of conversations where the visitor clicked a listing card or
    *  link out of a reply, or null with no data. */
@@ -232,6 +235,42 @@ function median(sorted: number[]): number | null {
     : (sorted[mid - 1] + sorted[mid]) / 2
 }
 
+/** A conversation's user messages, and how many of them were pill clicks:
+ *  the first message matching one of the site's starter chips, or any message
+ *  matching a `[[chip:…]]` follow-up the previous reply offered (the stored
+ *  history keeps the raw markers the visitor-facing chat strips). A visitor
+ *  who types an offered suggestion verbatim counts as a click — they took the
+ *  suggestion either way. */
+function countPillMessages(row: ConversationRow): {
+  messages: number
+  pills: number
+} {
+  const history = row.data?.history ?? []
+  let messages = 0
+  let pills = 0
+  let offered = new Set<string>()
+  let isFirst = true
+  for (const turn of history) {
+    if (turn.role === 'assistant') {
+      offered = new Set(extractChips(turn.content).map(normalize))
+      continue
+    }
+    if (!turn.content) continue
+    messages += 1
+    const key = normalize(turn.content)
+    if ((isFirst && CHIP_TEXTS.has(key)) || offered.has(key)) pills += 1
+    isFirst = false
+    offered = new Set() // an offer only applies to the very next message
+  }
+  // Rows with no stored history but a latest message (e.g. an abandoned
+  // first turn) still count that one message.
+  if (messages === 0 && row.data?.user) {
+    messages = 1
+    if (CHIP_TEXTS.has(normalize(row.data.user))) pills = 1
+  }
+  return { messages, pills }
+}
+
 /** The typed (non-suggested-chip) first message of every conversation in the
  *  range — the input for the question-theme summarizer. Chip messages are
  *  site-authored, so they'd pollute the themes with our own wording. */
@@ -274,6 +313,8 @@ export async function readConversationStats(
   let withQuestion = 0
   let suggested = 0
   let clicked = 0
+  let totalMessages = 0
+  let pillMessages = 0
 
   for (const row of rows) {
     const messages = userMessages(row)
@@ -283,6 +324,9 @@ export async function readConversationStats(
       languages.push(detectLanguage(messages))
     }
     if (row.clickedCitations.length > 0) clicked += 1
+    const pills = countPillMessages(row)
+    totalMessages += pills.messages
+    pillMessages += pills.pills
 
     const first = messages[0]?.trim().replace(/\s+/g, ' ')
     if (!first) continue
@@ -304,14 +348,13 @@ export async function readConversationStats(
     bucketCounts.set(b, (bucketCounts.get(b) ?? 0) + 1)
   }
 
-  const totalMessages = lengths.reduce((sum, l) => sum + l, 0)
-
   return {
     available: true,
     totalConversations: rows.length,
     medianLength: median(lengths.sort((a, b) => a - b)),
     suggestedShare: withQuestion > 0 ? suggested / withQuestion : null,
-    suggestedMessageShare: totalMessages > 0 ? suggested / totalMessages : null,
+    suggestedMessageShare:
+      totalMessages > 0 ? pillMessages / totalMessages : null,
     clickedShare: rows.length > 0 ? clicked / rows.length : null,
     // Buckets in display order (1 → 11+), only the non-empty ones.
     lengthBuckets: LENGTH_BUCKETS.map(b => ({

--- a/src/lib/analytics/conversations.ts
+++ b/src/lib/analytics/conversations.ts
@@ -32,6 +32,12 @@ export interface ConversationStats {
   /** Share (0–1) of conversations whose first message is one of the suggested
    *  question chips, or null with no data. */
   suggestedShare: number | null
+  /** Share (0–1) of ALL user messages that were a suggested chip rather than
+   *  typed — the message-level "pills vs chat window" split. Chips can only
+   *  be a conversation's first message, so the numerator is the chip-started
+   *  conversations and the denominator every message sent. Null with no
+   *  data. */
+  suggestedMessageShare: number | null
   /** Share (0–1) of conversations where the visitor clicked a listing card or
    *  link out of a reply, or null with no data. */
   clickedShare: number | null
@@ -48,6 +54,7 @@ const EMPTY_STATS: ConversationStats = {
   totalConversations: 0,
   medianLength: null,
   suggestedShare: null,
+  suggestedMessageShare: null,
   clickedShare: null,
   lengthBuckets: [],
   languages: [],
@@ -297,11 +304,14 @@ export async function readConversationStats(
     bucketCounts.set(b, (bucketCounts.get(b) ?? 0) + 1)
   }
 
+  const totalMessages = lengths.reduce((sum, l) => sum + l, 0)
+
   return {
     available: true,
     totalConversations: rows.length,
     medianLength: median(lengths.sort((a, b) => a - b)),
     suggestedShare: withQuestion > 0 ? suggested / withQuestion : null,
+    suggestedMessageShare: totalMessages > 0 ? suggested / totalMessages : null,
     clickedShare: rows.length > 0 ? clicked / rows.length : null,
     // Buckets in display order (1 → 11+), only the non-empty ones.
     lengthBuckets: LENGTH_BUCKETS.map(b => ({


### PR DESCRIPTION
- Adds a fifth tile to the Chatbot tab's Conversations panel: the share of ALL user messages that clicked a **follow-up suggestion** – the pills the bot offers after each reply, detected via the `[[chip:…]]` markers preserved in each stored reply. Conversation-starting chips are deliberately excluded (the existing "Started from a suggested question" tile covers those), and the label says so
- Together the two tiles answer Carolin's "pills or chat window" at both levels: 24% of conversations start from a pill, and 22% of all messages are follow-up pill clicks (68 of 307 in the live log)
- Also rewords the question-themes caption – "a fixed weekly snapshot" read as one week of data; the summary always covers the whole log and weekly is just the refresh cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)