### PR TITLE
Events: "Applications/registrations not yet open?" checkbox

### DIFF
--- a/src/lib/data/events.ts
+++ b/src/lib/data/events.ts
@@ -17,6 +17,7 @@ const FIELD = {
   endDate: 'fldAAtwTu3POfROpi',
   deadline: 'fldRhQqHVTVvGFM3k',
   deadlineType: 'fldkz9cW2FkG8xHac',
+  notYetOpen: 'fldF96eidqxAMF08c',
   location: 'fldqvyFLWjImT4n1y',
   logo: 'fldYAG5RVeT6FbSHa',
   host: 'fldNKTGHFtf4EptQ7',
@@ -133,10 +134,14 @@ export async function getEvents(): Promise<EventListing[]> {
       f[FIELD.online] === true || location.trim().toLowerCase() === 'online'
 
     // No close date means there is nothing to apply/register for, so the
-    // event counts as open. See the field descriptions on the Events table.
+    // event counts as open — unless applications/registrations haven't
+    // opened yet, which outranks any deadline (orgs sometimes announce the
+    // deadline before opening). See the field descriptions on the Events
+    // table.
     const closesOn = optionalString(f[FIELD.deadline])
+    const notYetOpen = f[FIELD.notYetOpen] === true
     const applicationStatus: 'Open' | 'Closed' =
-      !closesOn || closesOn >= today ? 'Open' : 'Closed'
+      !notYetOpen && (!closesOn || closesOn >= today) ? 'Open' : 'Closed'
 
     const rawDeadlineType = optionalString(f[FIELD.deadlineType])
     const deadlineType =
@@ -148,7 +153,7 @@ export async function getEvents(): Promise<EventListing[]> {
         `[events] "${name}" has unexpected Deadline type "${rawDeadlineType}" (allowed: Apply, Register)`
       )
     }
-    if (deadlineType && !closesOn) {
+    if (deadlineType && !closesOn && !notYetOpen) {
       console.warn(
         `[events] "${name}" has a Deadline type but no deadline date — no deadline will be shown`
       )


### PR DESCRIPTION
- New Airtable checkbox (`fldF96eidqxAMF08c`) for events that are announced but whose applications/registrations haven't opened yet — orgs sometimes announce a deadline before opening, and required-registration events carry Deadline = start date by convention, so the deadline field alone can't express this state.
- A ticked record now counts as **Closed** in the Applications filter, even when the Deadline field is empty (which normally means open) or holds a future date. Unticked records behave exactly as before.
- The "Deadline type but no deadline date" console warning is suppressed for ticked records — that state is expected while applications aren't open.
- Card rendering is unchanged; whether ticked events should show a "not yet open" label on the card is an open design question.
- Verified on localhost against live Airtable: a ticked, deadline-less test record was excluded from "Open" (7) and appeared only under "Closed" (1).

The same checkbox exists on the Training table for the future /training page, and on the legacy Events & training table where Comb and Broom now maintain it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)