### PR TITLE
Track site-search usage in first-party analytics

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import {
@@ -5,9 +6,10 @@ import {
   type Counted,
   type DateRange,
   type ChatbotFunnel,
-  type ChatbotDestination,
+  type ClickDestination,
   type CorrelationRow,
   type OverallListingRow,
+  type SearchPanelData,
 } from '@/lib/analytics/events'
 import {
   readConversationStats,
@@ -68,6 +70,7 @@ const PAGE_NAV: { name: string; label: string; icon: string }[] = [
 const OVERVIEW_TABS: { key: string; label: string }[] = [
   { key: 'pages', label: 'Overview' },
   { key: 'chatbot', label: 'Chatbot' },
+  { key: 'search', label: 'Search' },
   { key: 'correlations', label: 'Correlations' },
 ]
 const OVERVIEW_KEYS = new Set(OVERVIEW_TABS.map(t => t.key))
@@ -213,15 +216,33 @@ const EVENT_LABELS: Record<string, string> = {
   analytics_optin: 'Turned analytics back on',
 }
 
+/** Feed lines for search opens, by how the modal was opened. */
+const SEARCH_OPEN_LABELS: Record<string, string> = {
+  button: 'Opened search',
+  'cmd-k': 'Opened search (⌘K)',
+  slash: 'Opened search (/)',
+}
+
 function pillFor(e: { page?: string; type: string }): string | null {
-  // Chatbot first: chatbot events carry the page they happened on too, but in
-  // the feed they should read as chatbot activity, not page clicks.
+  // Chatbot/search first: their events carry the page they happened on too,
+  // but in the feed they should read as chatbot/search activity, not clicks.
   if (e.type.startsWith('chatbot')) return 'Chatbot'
+  if (e.type.startsWith('search')) return 'Search'
   if (e.page) return e.page
   return null
 }
 
-function labelFor(e: { label?: string; type: string }): string {
+function labelFor(e: {
+  label?: string
+  type: string
+  source?: string
+  query?: string
+}): string {
+  if (e.type === 'search_open')
+    return SEARCH_OPEN_LABELS[e.source ?? ''] ?? 'Opened search'
+  if (e.type === 'search_query')
+    return e.query ? `Searched for “${e.query}”` : 'Searched'
+  // search_click carries the result's title as its label, like listing clicks.
   return e.label ?? EVENT_LABELS[e.type] ?? e.type
 }
 
@@ -443,6 +464,10 @@ export default async function AnalyticsPage({
             />
           )}
 
+          {activeTab === 'search' && (
+            <SearchView search={data.search} unique={unique} />
+          )}
+
           {activeTab === 'correlations' && (
             <Panel title="Shared interests">
               <CorrelationsTable
@@ -452,10 +477,10 @@ export default async function AnalyticsPage({
               <p className={styles.caption}>
                 Visitors (by anonymous browser id) who engaged with both of a
                 pair — visited the page or clicked one of its listings, with
-                chatbot use as its own row. Clicks give this history back to 20
-                June 2026; page views count from 15 July 2026, so overlaps get
-                richer as views accumulate. Pairs shared by only one visitor are
-                hidden.
+                chatbot and search use as rows of their own. Clicks give this
+                history back to 20 June 2026; page views count from 15 July
+                2026, so overlaps get richer as views accumulate. Pairs shared
+                by only one visitor are hidden.
               </p>
             </Panel>
           )}
@@ -1048,7 +1073,7 @@ function ChatbotView({
 }: {
   funnel: ChatbotFunnel
   opensByPage: Counted[]
-  destinations: ChatbotDestination[]
+  destinations: ClickDestination[]
   conv: ConversationStats | null
   themes: ThemeSummary | null
   unique: boolean
@@ -1069,7 +1094,13 @@ function ChatbotView({
   return (
     <>
       <Panel title="Funnel · unique users">
-        <Funnel funnel={funnel} />
+        <Funnel
+          stages={[
+            { label: 'Opened', value: funnel.opened },
+            { label: 'Sent a message', value: funnel.typed },
+            { label: 'Clicked a result', value: funnel.clicked },
+          ]}
+        />
       </Panel>
 
       <div className={styles.grid}>
@@ -1188,6 +1219,108 @@ function ChatbotView({
         <p className={styles.caption}>
           The listing cards and links visitors opened from the chatbot&apos;s
           replies.
+        </p>
+      </Panel>
+    </>
+  )
+}
+
+/** The Search tab: how often site search gets used (and how it's opened),
+ *  what people search for, which searches come back empty, and what gets
+ *  clicked out of the results. */
+function SearchView({
+  search,
+  unique,
+}: {
+  search: SearchPanelData
+  unique: boolean
+}) {
+  const usersHead = unique ? 'Users' : undefined
+  const sum = (rows: Counted[]) => rows.reduce((s, r) => s + r.count, 0)
+  // Rows whose click carried no title read better as a prettified url.
+  const destRows = search.destinations.map(d => ({
+    ...d,
+    name: d.url && d.name === d.url ? prettyUrl(d.url) : d.name,
+  }))
+  const destUrlByName = new Map(destRows.map(d => [d.name, d.url]))
+  return (
+    <>
+      <Panel title="Funnel · unique users">
+        <Funnel
+          stages={[
+            { label: 'Opened search', value: search.funnel.opened },
+            { label: 'Typed a search', value: search.funnel.searched },
+            { label: 'Clicked a result', value: search.funnel.clicked },
+          ]}
+        />
+        <p className={styles.caption}>Recording since 16 July 2026.</p>
+      </Panel>
+
+      <div className={styles.grid}>
+        <Panel title="How it's opened">
+          <CountTable
+            rows={search.openMethods}
+            labelHead="Method"
+            countHead={usersHead ?? 'Opens'}
+            total={sum(search.openMethods)}
+          />
+          <p className={styles.caption}>
+            The magnifying-glass button, or a keyboard shortcut (⌘K also counts
+            Ctrl+K).
+          </p>
+        </Panel>
+        <Panel title="Where it's opened">
+          <CountTable
+            rows={search.opensByPage}
+            labelHead="Page"
+            countHead={usersHead ?? 'Opens'}
+            total={sum(search.opensByPage)}
+          />
+          <p className={styles.caption}>
+            The page visitors were on when they opened search.
+          </p>
+        </Panel>
+      </div>
+
+      <div className={styles.grid}>
+        <Panel title="What people search for">
+          <CountTable
+            rows={search.topQueries}
+            labelHead="Search"
+            countHead={usersHead ?? 'Searches'}
+            total={sum(search.topQueries)}
+          />
+          <p className={styles.caption}>
+            A search is recorded once the visitor pauses typing, so a few
+            half-typed words are normal.
+          </p>
+        </Panel>
+        <Panel title="Searches with no results">
+          <CountTable
+            rows={search.noResultQueries}
+            labelHead="Search"
+            countHead={usersHead ?? 'Searches'}
+            total={sum(search.noResultQueries)}
+          />
+          <p className={styles.caption}>
+            What visitors looked for and didn&apos;t find — worth scanning for
+            things the site should cover.
+          </p>
+        </Panel>
+      </div>
+
+      <Panel title="Clicked from search">
+        <CountTable
+          rows={destRows}
+          labelHead="Result"
+          countHead={usersHead ?? 'Clicks'}
+          logoFor={name => faviconFor(destUrlByName.get(name))}
+          linkFor={name => destUrlByName.get(name)}
+          total={sum(destRows)}
+        />
+        <p className={styles.caption}>
+          The results visitors opened from search, with the page or listing each
+          one leads to.
         </p>
       </Panel>
     </>
@@ -1353,14 +1486,17 @@ function CorrelationsTable({
   )
 }
 
-function Funnel({ funnel }: { funnel: ChatbotFunnel }) {
+/** A row of funnel stages, with each arrow showing the conversion from the
+ *  stage before it. */
+function Funnel({ stages }: { stages: { label: string; value: number }[] }) {
   return (
     <div className={styles.funnel}>
-      <FunnelStage label="Opened" value={funnel.opened} />
-      <FunnelArrow pct={pct(funnel.typed, funnel.opened)} />
-      <FunnelStage label="Sent a message" value={funnel.typed} />
-      <FunnelArrow pct={pct(funnel.clicked, funnel.typed)} />
-      <FunnelStage label="Clicked a result" value={funnel.clicked} />
+      {stages.map((s, i) => (
+        <Fragment key={s.label}>
+          {i > 0 && <FunnelArrow pct={pct(s.value, stages[i - 1].value)} />}
+          <FunnelStage label={s.label} value={s.value} />
+        </Fragment>
+      ))}
     </div>
   )
 }

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -22,6 +22,12 @@ function str(v: unknown, max: number): string | undefined {
   return s.length > max ? s.slice(0, max) : s
 }
 
+/** Coerce an unknown to a capped non-negative integer, or undefined. */
+function count(v: unknown, max: number): number | undefined {
+  if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) return undefined
+  return Math.min(Math.round(v), max)
+}
+
 export async function POST(req: NextRequest) {
   let body: unknown
   try {
@@ -47,6 +53,8 @@ export async function POST(req: NextRequest) {
     label: str(b.label, 300),
     position: str(b.position, 16),
     source: str(b.source, 16),
+    query: str(b.query, 200),
+    results: count(b.results, 100_000),
     url: str(b.url, 600),
     ref: str(req.headers.get('referer'), 600),
     vid: str(b.vid, 64),

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -63,10 +63,11 @@ export default function PrivacyPage() {
             used (and therefore improve it). Matomo, running in cookieless mode,
             gives us anonymous, aggregated statistics like page views and
             referrers. Our own first-party analytics records page visits, clicks
-            on listings and links, and when the chatbot gets opened; it stores a
-            random ID in your browser&apos;s local storage so we can count
-            unique visitors, but that ID is not tied to your name, email, or IP
-            address, and it never follows you to other sites.
+            on listings and links, what you search for on the site, and when the
+            chatbot gets opened; it stores a random ID in your browser&apos;s
+            local storage so we can count unique visitors, but that ID is not
+            tied to your name, email, or IP address, and it never follows you to
+            other sites.
           </p>
           <p className="color-teal-300 padding-bottom-24px">
             If you&apos;d rather not be counted, you can switch analytics off

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import Image from 'next/image'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { trackSearchClick, trackSearchQuery } from '@/lib/analytics'
 import type { SearchEntry, SearchType } from '@/lib/data/search-index'
 import {
   BROWSE_TYPES,
@@ -45,6 +46,10 @@ export default function SearchModal({
   const activeIndexRef = useRef(0)
   const activeTypeRef = useRef<SearchType | null>(null)
   const queryRef = useRef('')
+  const indexReadyRef = useRef(false)
+  // The search already recorded this open of the modal (filter + lowercased
+  // text), so settling on the same search twice doesn't double-count it.
+  const lastTrackedQueryRef = useRef<string | null>(null)
 
   useEffect(() => {
     // createPortal needs document.body, which only exists after mount.
@@ -74,18 +79,49 @@ export default function SearchModal({
     activeIndexRef.current = activeIndex
     activeTypeRef.current = activeType
     queryRef.current = query
+    indexReadyRef.current = index != null
   })
+
+  // Record the current search for the analytics, if it hasn't been already.
+  // Reads refs only, so callers always see the latest state: the settle timer
+  // below calls it when typing pauses, and it's flushed early when a result is
+  // clicked or the modal closes first. Skipped while the index is still
+  // loading — the result count isn't known yet.
+  const recordQuery = useCallback(() => {
+    const text = queryRef.current.trim()
+    if (!text || !indexReadyRef.current) return
+    const key = `${activeTypeRef.current ?? ''}\n${text.toLowerCase()}`
+    if (lastTrackedQueryRef.current === key) return
+    lastTrackedQueryRef.current = key
+    trackSearchQuery(
+      text,
+      resultsArrRef.current.length,
+      activeTypeRef.current ?? undefined
+    )
+  }, [])
+
+  // A search counts once the visitor pauses typing; every keystroke or filter
+  // change restarts the clock, so half-typed words mostly stay out of the data.
+  useEffect(() => {
+    if (!open || !index || !query.trim()) return
+    const timer = setTimeout(recordQuery, 2000)
+    return () => clearTimeout(timer)
+  }, [open, index, query, activeType, recordQuery])
 
   useEffect(() => {
     if (open) {
       inputRef.current?.focus()
+      lastTrackedQueryRef.current = null
       // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset when modal transitions open/closed
       setActiveIndex(0)
     } else {
+      // Closing without clicking anything is the last chance to record what
+      // was searched (the refs still hold it; the reset lands next render).
+      recordQuery()
       setQuery('')
       setActiveType(null)
     }
-  }, [open])
+  }, [open, recordQuery])
 
   useEffect(() => {
     if (open) inputRef.current?.focus()
@@ -349,6 +385,16 @@ export default function SearchModal({
                     href={entry.url}
                     target={isExternal ? '_blank' : undefined}
                     rel={isExternal ? 'noopener noreferrer' : undefined}
+                    onClick={() => {
+                      // The search that led here may not have settled yet.
+                      recordQuery()
+                      trackSearchClick(
+                        queryRef.current.trim(),
+                        entry.title,
+                        entry.url,
+                        String(flatIndex + 1)
+                      )
+                    }}
                     onMouseMove={() => {
                       if (Date.now() - lastKeyNavRef.current < 300) return
                       setActiveIndex(flatIndex)

--- a/src/components/SearchTrigger.tsx
+++ b/src/components/SearchTrigger.tsx
@@ -11,6 +11,7 @@ import {
 import type { ReactNode } from 'react'
 import type { LoadState } from '@/lib/search'
 import type { SearchEntry } from '@/lib/data/search-index'
+import { trackSearchOpen, type SearchOpenMethod } from '@/lib/analytics'
 import SearchModal from './SearchModal'
 
 interface SearchContextValue {
@@ -54,11 +55,15 @@ export function SearchProvider({
     }
   }, [])
 
-  const handleOpen = useCallback(() => {
-    triggerElRef.current = document.activeElement as HTMLElement | null
-    fetchIndex()
-    setOpen(true)
-  }, [fetchIndex])
+  const handleOpen = useCallback(
+    (method: SearchOpenMethod) => {
+      triggerElRef.current = document.activeElement as HTMLElement | null
+      fetchIndex()
+      setOpen(true)
+      trackSearchOpen(method)
+    },
+    [fetchIndex]
+  )
 
   const handleClose = useCallback(() => {
     setOpen(false)
@@ -80,7 +85,7 @@ export function SearchProvider({
         if (open) {
           handleClose()
         } else {
-          handleOpen()
+          handleOpen('cmd-k')
         }
         return
       }
@@ -92,7 +97,7 @@ export function SearchProvider({
           (target?.isContentEditable ?? false)
         if (isTyping) return
         e.preventDefault()
-        handleOpen()
+        handleOpen('slash')
       }
     }
     window.addEventListener('keydown', handler, true)
@@ -100,7 +105,10 @@ export function SearchProvider({
   }, [open, handleOpen, handleClose])
 
   return (
-    <SearchContext.Provider value={{ open: handleOpen, prefetch: fetchIndex }}>
+    <SearchContext.Provider
+      // The context's open() is only reachable from the SearchButtons.
+      value={{ open: () => handleOpen('button'), prefetch: fetchIndex }}
+    >
       {children}
       <SearchModal
         open={open}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -26,8 +26,13 @@ interface TrackPayload {
    *  dashboard tie clicks to the rank that produced them. */
   position?: string
   /** 'map' when the click came from a page's map (Map, Communities); left unset
-   *  for card clicks, which the dashboard treats as the default. */
+   *  for card clicks, which the dashboard treats as the default. Search events
+   *  reuse it for how the modal was opened / the active type filter. */
   source?: string
+  /** Site-search events: the query text as typed. */
+  query?: string
+  /** search_query only: how many results the query returned. */
+  results?: number
 }
 
 const VID_KEY = 'aisafety_vid'
@@ -155,6 +160,64 @@ export function trackListingClick(
 export function trackPageView(path: string): void {
   if (typeof window === 'undefined') return
   sendTrackEvent({ type: 'page_view', page: path })
+}
+
+/** How the search modal was opened: the nav's magnifying-glass button,
+ *  ⌘K/Ctrl+K, or the / key. */
+export type SearchOpenMethod = 'button' | 'cmd-k' | 'slash'
+
+/** Track the site-search modal opening, and how it was opened. */
+export function trackSearchOpen(method: SearchOpenMethod): void {
+  if (typeof window === 'undefined') return
+  sendTrackEvent({
+    type: 'search_open',
+    source: method,
+    page: window.location.pathname,
+  })
+}
+
+/**
+ * Track a settled site-search query — fired once the visitor pauses typing,
+ * or immediately if they click a result / close search before the pause.
+ * `results` is how many results the query returned (0 = the site had nothing
+ * for it); `filter` is the active type filter, when the search was narrowed
+ * to one resource type.
+ */
+export function trackSearchQuery(
+  query: string,
+  results: number,
+  filter?: string
+): void {
+  if (typeof window === 'undefined') return
+  sendTrackEvent({
+    type: 'search_query',
+    query,
+    results,
+    source: filter,
+    page: window.location.pathname,
+  })
+}
+
+/**
+ * Track a click on a site-search result. `query` is what was typed when the
+ * result was clicked (empty when browsing a type filter without typing);
+ * `position` is the result's rank in the list, counted from 1.
+ */
+export function trackSearchClick(
+  query: string,
+  title: string,
+  url: string,
+  position: string
+): void {
+  if (typeof window === 'undefined') return
+  sendTrackEvent({
+    type: 'search_click',
+    query: query || undefined,
+    label: title,
+    url,
+    position,
+    page: window.location.pathname,
+  })
 }
 
 /**

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -41,8 +41,16 @@ export interface AnalyticsEvent {
   position?: string
   /** Where on the page the click came from. Only set to 'map' on the two pages
    *  with a map (Map, Communities) when the click is on the map itself; every
-   *  other click (cards, featured cards) is left unset and treated as a card. */
+   *  other click (cards, featured cards) is left unset and treated as a card.
+   *  Search events reuse it: on search_open it's how the modal was opened
+   *  ('button' | 'cmd-k' | 'slash'); on search_query, the active type filter. */
   source?: string
+  /** Site-search events: the query text as typed — the subject of a
+   *  search_query, and on a search_click the query that produced the result. */
+  query?: string
+  /** search_query only: how many results the query returned. 0 means the
+   *  visitor searched for something the site has nothing for. */
+  results?: number
   /** Destination / relevant URL. */
   url?: string
   /** Referrer path, if available. */
@@ -66,6 +74,10 @@ export const ALLOWED_EVENT_TYPES = new Set<string>([
   // recorded event, the opt-in its first after coming back.
   'analytics_optout',
   'analytics_optin',
+  // Site search: opening the modal, a settled query, and a result click.
+  'search_open',
+  'search_query',
+  'search_click',
 ])
 
 // ─── Redis backend ───────────────────────────────────────────────────────────
@@ -277,7 +289,10 @@ export interface ChatbotFunnel {
   clicked: number
 }
 
-export interface ChatbotDestination extends Counted {
+/** A clicked-out destination (from chatbot replies or search results). `name`
+ *  is the link's visible text when the click carried one, otherwise the raw
+ *  url (the dashboard prettifies it). */
+export interface ClickDestination extends Counted {
   /** Destination url — for the favicon and link in the dashboard table. */
   url?: string
 }
@@ -288,9 +303,28 @@ export interface ChatbotPanelData {
    *  referer; opens where neither is known fall into 'Unknown'. */
   opensByPage: Counted[]
   /** Listings and links visitors clicked inside chatbot replies, busiest
-   *  first. `name` is the link's visible text when the click carried one,
-   *  otherwise the raw url (the dashboard prettifies it). */
-  destinations: ChatbotDestination[]
+   *  first. */
+  destinations: ClickDestination[]
+}
+
+export interface SearchPanelData {
+  /** Unique users at each step of using site search. */
+  funnel: {
+    opened: number
+    searched: number
+    clicked: number
+  }
+  /** How search gets opened: the nav button, ⌘K, or the / key. */
+  openMethods: Counted[]
+  /** The pages visitors were on when they opened search (site page names). */
+  opensByPage: Counted[]
+  /** What people search for, busiest first (lowercased so casings group). */
+  topQueries: Counted[]
+  /** Searches that returned nothing — what visitors looked for and the site
+   *  couldn't answer. A subset of topQueries. */
+  noResultQueries: Counted[]
+  /** The results visitors clicked out of search, busiest first. */
+  destinations: ClickDestination[]
 }
 
 export interface VisitsData {
@@ -351,6 +385,8 @@ export interface DashboardData {
   funnel: ChatbotFunnel
   /** The Chatbot tab's event-derived panels (opens and reply clicks). */
   chatbot: ChatbotPanelData
+  /** The Search tab's event-derived panels (opens, queries, result clicks). */
+  search: SearchPanelData
   /** Browsers that used the privacy page's analytics switch in range: `off` =
    *  turned analytics off, `on` = turned it back on. Unique browsers, always —
    *  toggling twice isn't two people changing their mind. */
@@ -360,8 +396,8 @@ export interface DashboardData {
   /** Cross-interest overlaps between pages (and the chatbot), from anonymous
    *  visitor ids: pairs ranked by how many visitors engaged with both. */
   correlations: CorrelationRow[]
-  /** Recent clicks and chatbot events — page views are excluded so the feed
-   *  stays an activity log rather than a firehose. */
+  /** Recent clicks and chatbot/search events — page views are excluded so the
+   *  feed stays an activity log rather than a firehose. */
   recent: AnalyticsEvent[]
   /** Timestamp of the oldest event in the WHOLE store (not just the selected
    *  range) — lets the dashboard say how far back its data actually goes.
@@ -386,6 +422,14 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   selectedSource: null,
   funnel: { opened: 0, typed: 0, clicked: 0 },
   chatbot: { opensByPage: [], destinations: [] },
+  search: {
+    funnel: { opened: 0, searched: 0, clicked: 0 },
+    openMethods: [],
+    opensByPage: [],
+    topQueries: [],
+    noResultQueries: [],
+    destinations: [],
+  },
   optOuts: { off: 0, on: 0 },
   visits: { byPage: [], totalViews: 0, uniqueVisitors: 0, visitCount: 0 },
   correlations: [],
@@ -624,6 +668,7 @@ function aggregate(
       clicked: usersOf('chatbot_click'),
     },
     chatbot: chatbotPanels(inRange, unique),
+    search: searchPanels(inRange, unique),
     optOuts: {
       off: usersOf('analytics_optout'),
       on: usersOf('analytics_optin'),
@@ -703,14 +748,15 @@ function countVisits(views: AnalyticsEvent[]): number {
 }
 
 /** The interest an event expresses, for the correlations table: the page it
- *  belongs to (viewed, or clicked a listing on), or 'Chatbot' for chatbot
- *  use. Listing clicks reach back to 20 June 2026, so pairs have history even
- *  though page views only started on 15 July 2026. */
+ *  belongs to (viewed, or clicked a listing on), with 'Chatbot' and 'Search'
+ *  as interests of their own. Listing clicks reach back to 20 June 2026, so
+ *  pairs have history even though page views only started on 15 July 2026. */
 function interestOf(e: AnalyticsEvent): string | undefined {
   if (e.type === 'page_view')
     return e.page ? (PAGE_NAME_BY_PATH[e.page] ?? e.page) : undefined
   if (e.type === 'listing_click') return e.page
   if (e.type.startsWith('chatbot')) return 'Chatbot'
+  if (e.type.startsWith('search')) return 'Search'
   return undefined
 }
 
@@ -796,19 +842,13 @@ function tallyBy(
     .sort((a, b) => b.count - a.count)
 }
 
-/** The Chatbot tab's event-derived panels. `unique` mirrors the dashboard's
- *  count mode: unique users per bucket, or every event. */
-function chatbotPanels(
-  inRange: AnalyticsEvent[],
+/** Clicked-out destinations bucketed by url, busiest first; the most recent
+ *  click's label (event lists are newest-first) names the row when one was
+ *  recorded. In unique mode each visitor counts once per destination. */
+function destinationRows(
+  clicks: AnalyticsEvent[],
   unique: boolean
-): ChatbotPanelData {
-  const opens = inRange.filter(e => e.type === 'chatbot_open')
-  const clicks = inRange.filter(e => e.type === 'chatbot_click')
-
-  const opensByPage = tallyBy(opens, e => chatbotPage(e) ?? 'Unknown', unique)
-
-  // Reply clicks bucketed by destination url; the most recent click's label
-  // (clicks are newest-first) names the row when one was recorded.
+): ClickDestination[] {
   const byUrl = new Map<string, { name: string; url?: string; count: number }>()
   const seen = new Set<string>()
   for (const e of clicks) {
@@ -822,9 +862,66 @@ function chatbotPanels(
     g.count += 1
     byUrl.set(url, g)
   }
-  const destinations = [...byUrl.values()].sort((a, b) => b.count - a.count)
+  return [...byUrl.values()].sort((a, b) => b.count - a.count)
+}
 
-  return { opensByPage, destinations }
+/** The Chatbot tab's event-derived panels. `unique` mirrors the dashboard's
+ *  count mode: unique users per bucket, or every event. */
+function chatbotPanels(
+  inRange: AnalyticsEvent[],
+  unique: boolean
+): ChatbotPanelData {
+  const opens = inRange.filter(e => e.type === 'chatbot_open')
+  const clicks = inRange.filter(e => e.type === 'chatbot_click')
+  return {
+    opensByPage: tallyBy(opens, e => chatbotPage(e) ?? 'Unknown', unique),
+    destinations: destinationRows(clicks, unique),
+  }
+}
+
+/** Dashboard labels for how the search modal was opened (search_open.source). */
+const SEARCH_OPEN_LABEL: Record<string, string> = {
+  button: 'Search button',
+  'cmd-k': '⌘K shortcut',
+  slash: '/ shortcut',
+}
+
+/** The Search tab's panels. The funnel always counts unique users; the other
+ *  panels follow the dashboard's count mode via `unique`, like the chatbot's.
+ *  Queries are grouped lowercased so casings don't split a search across rows.
+ *  A search_query without text (not something the site's own beacons send) is
+ *  ignored rather than counted as an empty search. */
+function searchPanels(
+  inRange: AnalyticsEvent[],
+  unique: boolean
+): SearchPanelData {
+  const opens = inRange.filter(e => e.type === 'search_open')
+  const queries = inRange.filter(e => e.type === 'search_query' && e.query)
+  const clicks = inRange.filter(e => e.type === 'search_click')
+  return {
+    funnel: {
+      opened: uniqueUsers(opens),
+      searched: uniqueUsers(queries),
+      clicked: uniqueUsers(clicks),
+    },
+    openMethods: tallyBy(
+      opens,
+      e => SEARCH_OPEN_LABEL[e.source ?? ''] ?? 'Unknown',
+      unique
+    ),
+    opensByPage: tallyBy(
+      opens,
+      e => (e.page ? (PAGE_NAME_BY_PATH[e.page] ?? e.page) : 'Unknown'),
+      unique
+    ),
+    topQueries: tallyBy(queries, e => e.query!.toLowerCase(), unique),
+    noResultQueries: tallyBy(
+      queries.filter(e => e.results === 0),
+      e => e.query!.toLowerCase(),
+      unique
+    ),
+    destinations: destinationRows(clicks, unique),
+  }
 }
 
 /** Distinct users in a set of events: distinct vids, plus each vid-less event


### PR DESCRIPTION
- Records three new first-party event kinds for the site-wide search modal: `search_open` (with how it was opened – the nav button, ⌘K/Ctrl+K, or the / key – and the page), `search_query` (the query text with its result count), and `search_click` (the clicked result, its rank in the list, and the query behind it).
- A search counts once the visitor pauses typing for 2 seconds; clicking a result or closing the modal first records it immediately, and identical searches in one open of the modal aren't double-counted. Zero-result queries are captured explicitly.
- Adds a Search tab to the admin analytics dashboard: an opened → typed → clicked funnel, how and where search gets opened, top searches, searches with no results, and the results people click. Search events also appear in the recent-activity feed and as their own row in the correlations table.
- The public track endpoint accepts the two new fields (`query`, `results`) with the same length/value caps as everything else, and only the three new event kinds are admitted.
- The privacy page's list of what the first-party analytics records now includes what you search for; the existing analytics opt-out switch already covers the new events.
- Verified end to end on localhost: all three open methods, settled and flushed queries (including a zero-result one), and result clicks via mouse and Enter key all land correctly and render on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)