### PR TITLE
Present the field map as the whole field, not just orgs

### DIFF
--- a/src/app/admin/chatbot/TranscriptMessage.tsx
+++ b/src/app/admin/chatbot/TranscriptMessage.tsx
@@ -544,7 +544,14 @@ function CardPill({
           onError={() => setImgFailed(true)}
         />
       ) : null}
-      {card.type && <span className={styles.convCardType}>{card.type}</span>}
+      {card.type && (
+        <span className={styles.convCardType}>
+          {/* The internal listing type for field-map entries is 'org', but
+           *  only about half of them are organizations — label them by their
+           *  page instead so the chip doesn't misdescribe the listing. */}
+          {card.type === 'org' ? 'map' : card.type}
+        </span>
+      )}
       <span className={styles.convCardName}>{primary}</span>
       {showNote && <span className={styles.convCardNote}>{card.note}</span>}
       {wasClicked && <span className={styles.convCardClicked}>✓ clicked</span>}

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -215,9 +215,9 @@ export default function MapClient({
         <h2 className="width-7-col padding-bottom-56px">
           An overview of the key{' '}
           <span className="color-light-teal">
-            organizations, programs, and projects
+            organizations, programs, and other resources
           </span>{' '}
-          operating in the AI safety space.
+          in the AI safety space.
         </h2>
 
         <div className="database-outer-grid">

--- a/src/app/map/layout.tsx
+++ b/src/app/map/layout.tsx
@@ -1,11 +1,11 @@
 export const metadata = {
   title: 'Field map – AISafety.com',
   description:
-    'Map displaying the main organizations, projects, and programs currently operating in the AI safety space.',
+    'Map displaying the main organizations, programs, and other resources in the AI safety space.',
   openGraph: {
     title: 'Field map – AISafety.com',
     description:
-      'Map displaying the main organizations, projects, and programs currently operating in the AI safety space.',
+      'Map displaying the main organizations, programs, and other resources in the AI safety space.',
     images: [{ url: '/images/link-preview.png' }],
   },
 }

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES, greetingFor } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-07-14-01'
+export const PROMPT_VERSION = '2026-07-18-01'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -160,7 +160,7 @@ Filter keys + complete value lists per type. Values are exact catalog labels:
 - **media-channel**:
   - \`type\`: "Article", "Blog", "Book", "Forum", "Newsletter", "Podcast", "Twitter/X list", "YouTube channel"
 
-- **org** (entries on the field map – mostly organizations, but also blogs, podcasts, newsletters, funders and other resources):
+- **org** (entries on the field map – the type name is historical: only about half the map's entries are organizations. The rest are training programs, blogs, newsletters, funds, YouTube channels, podcasts, tools, databases, forums, publications and individual researchers. When you describe the [Field map](/map) to users, present it as an overview of the whole AI safety field – the key organizations, programs, and resources – never as a page of organizations):
   - \`category\`: "Advocacy", "Blog", "Capabilities research", "Career support", "Conceptual research", "Empirical research", "Forecasting", "Funding", "Governance", "Newsletter", "Podcast", "Research support", "Resource", "Strategy", "Training and education", "Video"
   - \`status\`: "Active", "Inactive", "No longer active"
   - \`scale\`: "Large", "Medium", "Small". The map shows the whole AI safety field, not only organizations – entries also include things like blogs, podcasts, newsletters, funders and other resources. \`scale\` is NOT how big or established an entry is – it's the AISafety.com team's best guess at how useful it likely is for someone browsing the map to know this entry exists (a curation/prominence signal). **When picking which to surface, prefer higher scale: Large > Medium > Small**, since those are the most useful for most users to know about. Only show a Medium/Small one if it's a much better topical fit than the available Large ones. If a user asks what the map sizes/scale mean, explain it this way – do NOT describe it as how big the organization is.


### PR DESCRIPTION
- Only about half of the map's 344 listings are organizations – the rest are training programs, blogs, newsletters, funds, YouTube channels, podcasts, tools, databases, forums, publications, and individual researchers. The chatbot and the /map page both described the map as organizations (plus projects/programs).
- Chatbot prompt: the `org` listing-type section now states the real composition and instructs the bot to present /map as an overview of the whole AI safety field, never as a page of organizations. `PROMPT_VERSION` bumped to `2026-07-18-01`.
- Admin conversation log: field-map cards now show a `MAP` chip instead of the internal type name `ORG`, which misdescribed non-org listings. Job/event/other chips are unchanged.
- /map header now reads "An overview of the key organizations, programs, and other resources in the AI safety space." (was "…programs, and projects operating in…"); the page's meta description gets the same fix.

Verified locally: production build passes; the conversation log shows MAP chips on existing map cards; the playground bot describes the map as "not only organizations…"; the /map header renders with the highlight on the right words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)