### PR TITLE
Chatbot cards: always show the org behind jobs and courses

### DIFF
--- a/src/app/admin/chatbot/TranscriptMessage.tsx
+++ b/src/app/admin/chatbot/TranscriptMessage.tsx
@@ -16,6 +16,8 @@ import styles from '../admin.module.css'
 
 export interface ListingInfo {
   name: string
+  /** The org behind the listing (a job's hiring org, a course's creator). */
+  organization?: string
   logo?: string
   /** External listing URL (the live card's destination). */
   url?: string
@@ -546,6 +548,11 @@ function CardPill({
       ) : null}
       {card.type && <span className={styles.convCardType}>{card.type}</span>}
       <span className={styles.convCardName}>{primary}</span>
+      {info?.organization &&
+        info.organization !== primary &&
+        info.organization !== card.note && (
+          <span className="color-teal-300">{info.organization}</span>
+        )}
       {showNote && <span className={styles.convCardNote}>{card.note}</span>}
       {wasClicked && <span className={styles.convCardClicked}>✓ clicked</span>}
     </>

--- a/src/app/api/admin/conversations/route.ts
+++ b/src/app/api/admin/conversations/route.ts
@@ -92,6 +92,7 @@ export async function GET(req: NextRequest) {
 
   type ListingInfo = {
     name: string
+    organization?: string
     logo?: string
     url?: string
     pageUrl?: string
@@ -104,6 +105,7 @@ export async function GET(req: NextRequest) {
     for (const l of catalog.listings) {
       const info = {
         name: l.name,
+        organization: l.organization,
         logo: l.logo,
         url: l.url,
         pageUrl: l.pageUrl,
@@ -128,7 +130,12 @@ export async function GET(req: NextRequest) {
   for (const c of filtered) {
     for (const ref of c.data?.citationRefs ?? []) {
       if (listings[ref.id]) continue
-      const info: ListingInfo = { name: ref.name, logo: ref.logo, url: ref.url }
+      const info: ListingInfo = {
+        name: ref.name,
+        organization: ref.organization,
+        logo: ref.logo,
+        url: ref.url,
+      }
       listings[ref.id] = info
       const rec = REC_RE.exec(ref.id)?.[0]
       if (rec && !listings[rec]) listings[rec] = info

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -146,7 +146,13 @@ export async function POST(req: NextRequest) {
       const citationRefs = [...cardedIds]
         .map(id => citedById.get(id))
         .filter((c): c is (typeof citations)[number] => Boolean(c))
-        .map(c => ({ id: c.id, name: c.name, url: c.url, logo: c.logo }))
+        .map(c => ({
+          id: c.id,
+          name: c.name,
+          organization: c.organization,
+          url: c.url,
+          logo: c.logo,
+        }))
 
       // after() keeps the serverless function alive until the write completes.
       // A bare fire-and-forget promise gets frozen (and usually lost) the

--- a/src/components/assistant/CitationCard.tsx
+++ b/src/components/assistant/CitationCard.tsx
@@ -6,7 +6,8 @@ import styles from './Assistant.module.css'
 
 interface Props {
   citation: CitationRef
-  /** Optional bot-written annotation that appears below the meta line */
+  /** Optional bot-written annotation shown under the name/org (replaces the
+   *  meta line) */
   note?: string
   onClick?: (c: CitationRef) => void
 }
@@ -90,7 +91,6 @@ function TypeIcon({ type }: { type: ListingType }) {
 
 function metaSummary(c: CitationRef): string {
   const parts: string[] = []
-  if (c.organization) parts.push(c.organization)
   if (c.type === 'job') {
     if (c.meta.workLocation) parts.push(c.meta.workLocation)
     if (c.meta.minimumExperience) parts.push(c.meta.minimumExperience)
@@ -149,6 +149,14 @@ export default function CitationCard({ citation, note, onClick }: Props) {
       </span>
       <span className={styles.citationBody}>
         <span className={styles.citationName}>{citation.name}</span>
+        {/* The org behind the listing (jobs, courses) always renders, even
+            when a note replaces the meta line — a job card without its hiring
+            org is unidentifiable. */}
+        {citation.organization &&
+          citation.organization !== citation.name &&
+          citation.organization !== note && (
+            <span className={styles.citationMeta}>{citation.organization}</span>
+          )}
         {note ? (
           <span className={styles.citationNote}>{note}</span>
         ) : summary ? (

--- a/src/lib/admin/airtable.ts
+++ b/src/lib/admin/airtable.ts
@@ -110,6 +110,9 @@ export interface HistoryTurn {
 export interface StoredCitation {
   id: string
   name: string
+  /** The org behind the listing (a job's hiring org, a course's creator).
+   *  Absent on rows logged before it was captured. */
+  organization?: string
   url: string
   logo?: string
 }

--- a/src/lib/assistant/conversation-store.ts
+++ b/src/lib/assistant/conversation-store.ts
@@ -23,7 +23,13 @@ export interface StoredTurn {
    *  fallback link (or nothing) instead of a real card in the visitor's chat. */
   fallbackCards: string[]
   citations: string[]
-  citationRefs: { id: string; name: string; url: string; logo?: string }[]
+  citationRefs: {
+    id: string
+    name: string
+    organization?: string
+    url: string
+    logo?: string
+  }[]
   zeroMatches: boolean
   /** Set when the turn produced no usable reply: 'abandoned' (visitor left
    *  before/without an answer) or 'error' (generation failed). Absent on

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES, greetingFor } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-07-14-01'
+export const PROMPT_VERSION = '2026-07-18-01'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -54,7 +54,7 @@ You have three tools: \`search_listings\`, \`get_listing\`, and \`read_listing_p
 
 The renderer turns each \`[[card:...]]\` into a clickable card. The optional note (after the pipe) is your one-line annotation for why this card matters to the user. Keep notes under ~10 words.
 
-**The inline note must NOT repeat the listing's name** – the card already shows the name prominently. Write only the descriptive part. Bad: \`[[card:org:rec1|Google DeepMind – AI company with a safety team]]\`. Good: \`[[card:org:rec1|AI company with a dedicated safety team]]\`.
+**The inline note must NOT repeat the listing's name or its org** – the card already shows the name prominently, and for jobs and courses the org behind it. Write only the descriptive part. Bad: \`[[card:org:rec1|Google DeepMind – AI company with a safety team]]\`. Good: \`[[card:org:rec1|AI company with a dedicated safety team]]\`.
 
 **Copy the \`id\` field from the search result verbatim** (e.g. \`community:recc7jUkg0w0HfpY0\`, \`job:rec123ABC\`). The \`id\` already includes the type prefix – do NOT add another prefix, and do NOT strip the existing one. Just paste exactly what the tool returned.
 


### PR DESCRIPTION
- Job and course cards in the chatbot now always show the org behind the listing (title, org, then the bot's note). Previously the org name only appeared in the meta line, which the bot's inline note replaces – so nearly every job card rendered without its employer.
- The admin Conversation Log pills show the org too. Resolution is a live catalog lookup, so existing conversations gain it retroactively; the stored citation snapshot now captures the org as well, so cards for jobs that later leave the catalog keep it.
- The prompt's inline-note rule now also covers the org (the card displays it, so notes must not repeat it); PROMPT_VERSION bumped to 2026-07-18-01.
- No new CSS: the visitor card reuses the existing muted meta style, the admin pill uses the color-teal-300 utility.
- Verified on localhost: visitor widget, admin log (an old conversation shows the org retroactively), and the stored snapshot in the conversations table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)