### PR TITLE
Update site-search Field map description

### DIFF
--- a/src/lib/data/search-index.ts
+++ b/src/lib/data/search-index.ts
@@ -61,7 +61,7 @@ const STATIC_PAGES: SearchEntry[] = [
     'Field map',
     '/map',
     '/images/map.svg',
-    'A visual map of organisations in AI safety.'
+    'A visual overview of the key organizations, programs, and other resources in AI safety.'
   ),
   page(
     'Communities',


### PR DESCRIPTION
- The ⌘K search modal's page descriptions are hardcoded; the Field map entry still read "A visual map of organisations in AI safety" – an orgs-only claim (and British spelling), out of step with the header shipped in #462.
- Now reads "A visual overview of the key organizations, programs, and other resources in AI safety."

Verified locally: production build passes and `/api/search-index` serves the new description for the Field map page entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)