### PR TITLE
Analytics: show each search result's resource page in Clicked from search

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -17,6 +17,12 @@ import {
   type TopQuestion,
 } from '@/lib/analytics/conversations'
 import { readQuestionThemes, type ThemeSummary } from '@/lib/analytics/themes'
+import {
+  buildSearchIndex,
+  type SearchEntry,
+  type SearchType,
+} from '@/lib/data/search-index'
+import { TYPE_ICON, TYPE_LABEL, TYPE_PATH } from '@/lib/search'
 import RefreshThemesButton from './RefreshThemesButton'
 import { getFunders } from '@/lib/data/funding'
 import { getCourses } from '@/lib/data/self-study'
@@ -182,6 +188,67 @@ function faviconFor(url?: string): string | undefined {
   }
 }
 
+/** A row's resource-page marker in the clicked-from-search table: the page's
+ *  nav icon, plus its name for the hover tooltip. */
+interface PageBadge {
+  icon: string | null
+  label: string
+}
+
+/** '/jobs' → 'job', '/funding' → 'funder', … — so a click on a resource page
+ *  itself (a 'page' search result) still resolves to that page's badge. */
+const SEARCH_TYPE_BY_PATH = new Map<string, SearchType>(
+  (Object.keys(TYPE_PATH) as SearchType[])
+    .filter(t => TYPE_PATH[t])
+    .map(t => [TYPE_PATH[t]!, t])
+)
+
+/** The resource page each clicked-from-search row belongs to. Newer clicks
+ *  record the result's type at click time; rows without one (clicks from
+ *  before the type was tracked) are matched against the live search index by
+ *  url, then title. A listing that has since left the index (closed job, past
+ *  event) can stay unresolved — its row just shows no page icon. */
+function searchPageBadges(
+  index: SearchEntry[],
+  rows: { name: string; url?: string; resultType?: string }[]
+): Map<string, PageBadge> {
+  // null marks a url/title claimed by entries of two different types —
+  // too ambiguous to resolve a page from.
+  const byUrl = new Map<string, SearchType | null>()
+  const byTitle = new Map<string, SearchType | null>()
+  const claim = (
+    m: Map<string, SearchType | null>,
+    key: string,
+    type: SearchType
+  ) => {
+    const prev = m.get(key)
+    if (prev === undefined) m.set(key, type)
+    else if (prev !== type) m.set(key, null)
+  }
+  for (const e of index) {
+    // Page entries resolve to the resource page their url is; non-resource
+    // pages (Home, About, …) resolve to nothing.
+    const type = e.type === 'page' ? SEARCH_TYPE_BY_PATH.get(e.url) : e.type
+    if (!type) continue
+    claim(byUrl, e.url, type)
+    claim(byTitle, e.title, type)
+  }
+  const out = new Map<string, PageBadge>()
+  for (const r of rows) {
+    const recorded =
+      r.resultType && r.resultType !== 'page' && r.resultType in TYPE_ICON
+        ? (r.resultType as SearchType)
+        : undefined
+    const matched =
+      (r.url ? byUrl.get(r.url) : undefined) || byTitle.get(r.name) || undefined
+    const type = recorded ?? matched
+    if (type && type !== 'page') {
+      out.set(r.name, { icon: TYPE_ICON[type], label: TYPE_LABEL[type] })
+    }
+  }
+  return out
+}
+
 /** en-GB so the date reads day-before-month (e.g. "19 Jun, 20:30"). */
 function formatTime(iso: string): string {
   try {
@@ -303,7 +370,7 @@ export default async function AnalyticsPage({
   const tabReq = tabRaw === 'funnel' ? 'chatbot' : tabRaw
   const onResourceTab = tabReq != null && !OVERVIEW_KEYS.has(tabReq)
 
-  const [data, funders, convStats, themes] = await Promise.all([
+  const [data, funders, convStats, themes, searchIndex] = await Promise.all([
     readDashboard(
       range,
       onResourceTab ? tabReq : undefined,
@@ -315,6 +382,11 @@ export default async function AnalyticsPage({
     // fetch the (ever-growing) conversation log when it's the active tab.
     tabReq === 'chatbot' ? readConversationStats(range) : null,
     tabReq === 'chatbot' ? readQuestionThemes() : null,
+    // Resolves clicked search results to their resource page; only the Search
+    // tab reads it. On error the page icons resolve from recorded types alone.
+    tabReq === 'search'
+      ? buildSearchIndex().catch(() => [] as SearchEntry[])
+      : ([] as SearchEntry[]),
   ])
 
   // Resource-page tabs: every page in PAGE_NAV always gets one (so quiet pages
@@ -465,7 +537,11 @@ export default async function AnalyticsPage({
           )}
 
           {activeTab === 'search' && (
-            <SearchView search={data.search} unique={unique} />
+            <SearchView
+              search={data.search}
+              index={searchIndex}
+              unique={unique}
+            />
           )}
 
           {activeTab === 'correlations' && (
@@ -886,6 +962,7 @@ function CountTable({
   logoFor,
   linkFor,
   rankFor,
+  pageFor,
   total,
 }: {
   rows: Counted[]
@@ -900,6 +977,9 @@ function CountTable({
    *  selectable/copyable. */
   linkFor?: (name: string) => string | undefined
   rankFor?: (name: string) => string | undefined
+  /** When set, adds a Page column: the resource page each row belongs to,
+   *  shown as the page's nav icon with its name as the hover tooltip. */
+  pageFor?: (name: string) => PageBadge | undefined
   /** When set, adds a % column (each row's share of this total) and a Total
    *  footer row. The total is the denominator, so for a sliced "top N" table it
    *  can exceed the sum of the visible rows. */
@@ -908,7 +988,7 @@ function CountTable({
   if (allRows.length === 0) return <p className={styles.dim}>No data yet.</p>
   const rows = allRows.slice(0, MAX_TABLE_ROWS)
   const showPct = total != null && total > 0
-  const colSpan = (rankFor ? 1 : 0) + 2 + (showPct ? 1 : 0)
+  const colSpan = (rankFor ? 1 : 0) + 2 + (pageFor ? 1 : 0) + (showPct ? 1 : 0)
   return (
     <>
       <table className={styles.table}>
@@ -916,6 +996,7 @@ function CountTable({
           <tr>
             {rankFor && <th className={styles.rankCol}>{rankHead}</th>}
             <th>{labelHead}</th>
+            {pageFor && <th>Page</th>}
             <th className={styles.numCol}>{countHead}</th>
             {showPct && <th className={styles.pctCol}>%</th>}
           </tr>
@@ -925,6 +1006,7 @@ function CountTable({
             const rank = rankFor?.(r.name)
             const featured = rank?.startsWith('F')
             const href = linkFor?.(r.name)
+            const badge = pageFor?.(r.name)
             return (
               <tr key={i}>
                 {rankFor && (
@@ -953,6 +1035,20 @@ function CountTable({
                     ))}
                   <span>{r.name}</span>
                 </td>
+                {pageFor && (
+                  <td>
+                    {badge?.icon && (
+                      <span className={styles.pageTabIcon} title={badge.label}>
+                        <Image
+                          src={badge.icon}
+                          alt={badge.label}
+                          width={12}
+                          height={12}
+                        />
+                      </span>
+                    )}
+                  </td>
+                )}
                 <td className={styles.numCol}>{r.count.toLocaleString()}</td>
                 {showPct && (
                   <td className={styles.pctCol}>{pct1(r.count, total)}</td>
@@ -966,6 +1062,7 @@ function CountTable({
             <tr className={styles.totalRow}>
               {rankFor && <td className={styles.rankCol} />}
               <td className={styles.totalLabel}>Total</td>
+              {pageFor && <td />}
               <td className={styles.numCol}>{total.toLocaleString()}</td>
               {showPct && (
                 <td className={styles.pctCol}>{pct1(total, total)}</td>
@@ -1230,9 +1327,11 @@ function ChatbotView({
  *  clicked out of the results. */
 function SearchView({
   search,
+  index,
   unique,
 }: {
   search: SearchPanelData
+  index: SearchEntry[]
   unique: boolean
 }) {
   const usersHead = unique ? 'Users' : undefined
@@ -1243,6 +1342,7 @@ function SearchView({
     name: d.url && d.name === d.url ? prettyUrl(d.url) : d.name,
   }))
   const destUrlByName = new Map(destRows.map(d => [d.name, d.url]))
+  const pageBadges = searchPageBadges(index, destRows)
   return (
     <>
       <Panel title="Funnel · unique users">
@@ -1316,11 +1416,14 @@ function SearchView({
           countHead={usersHead ?? 'Clicks'}
           logoFor={name => faviconFor(destUrlByName.get(name))}
           linkFor={name => destUrlByName.get(name)}
+          pageFor={name => pageBadges.get(name)}
           total={sum(destRows)}
         />
         <p className={styles.caption}>
           The results visitors opened from search, with the page or listing each
-          one leads to.
+          one leads to. The page icon is the resource page the result belongs to
+          (hover it for the name); a row without one no longer matches anything
+          in the search index.
         </p>
       </Panel>
     </>

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -392,7 +392,8 @@ export default function SearchModal({
                         queryRef.current.trim(),
                         entry.title,
                         entry.url,
-                        String(flatIndex + 1)
+                        String(flatIndex + 1),
+                        entry.type
                       )
                     }}
                     onMouseMove={() => {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -27,7 +27,8 @@ interface TrackPayload {
   position?: string
   /** 'map' when the click came from a page's map (Map, Communities); left unset
    *  for card clicks, which the dashboard treats as the default. Search events
-   *  reuse it for how the modal was opened / the active type filter. */
+   *  reuse it: how the modal was opened (search_open), the active type filter
+   *  (search_query), or the clicked result's type (search_click). */
   source?: string
   /** Site-search events: the query text as typed. */
   query?: string
@@ -201,13 +202,17 @@ export function trackSearchQuery(
 /**
  * Track a click on a site-search result. `query` is what was typed when the
  * result was clicked (empty when browsing a type filter without typing);
- * `position` is the result's rank in the list, counted from 1.
+ * `position` is the result's rank in the list, counted from 1; `resultType`
+ * is the result's search type ('job', 'funder', …) — recorded so the
+ * dashboard can show which resource page the result belongs to even after
+ * the listing itself is gone from the index.
  */
 export function trackSearchClick(
   query: string,
   title: string,
   url: string,
-  position: string
+  position: string,
+  resultType: string
 ): void {
   if (typeof window === 'undefined') return
   sendTrackEvent({
@@ -216,6 +221,7 @@ export function trackSearchClick(
     label: title,
     url,
     position,
+    source: resultType,
     page: window.location.pathname,
   })
 }

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -43,7 +43,8 @@ export interface AnalyticsEvent {
    *  with a map (Map, Communities) when the click is on the map itself; every
    *  other click (cards, featured cards) is left unset and treated as a card.
    *  Search events reuse it: on search_open it's how the modal was opened
-   *  ('button' | 'cmd-k' | 'slash'); on search_query, the active type filter. */
+   *  ('button' | 'cmd-k' | 'slash'); on search_query, the active type filter;
+   *  on search_click, the clicked result's type ('job', 'funder', …). */
   source?: string
   /** Site-search events: the query text as typed — the subject of a
    *  search_query, and on a search_click the query that produced the result. */
@@ -295,6 +296,12 @@ export interface ChatbotFunnel {
 export interface ClickDestination extends Counted {
   /** Destination url — for the favicon and link in the dashboard table. */
   url?: string
+  /** Search rows only: the clicked result's search type ('job', 'funder', …),
+   *  from the most recent click that recorded one — so the dashboard can show
+   *  the resource page the result belongs to. Absent on clicks from before
+   *  the type was tracked (the dashboard falls back to matching the url
+   *  against the live search index). */
+  resultType?: string
 }
 
 export interface ChatbotPanelData {
@@ -844,12 +851,17 @@ function tallyBy(
 
 /** Clicked-out destinations bucketed by url, busiest first; the most recent
  *  click's label (event lists are newest-first) names the row when one was
- *  recorded. In unique mode each visitor counts once per destination. */
+ *  recorded. In unique mode each visitor counts once per destination.
+ *  `sourceIsType` is set by the search panels, whose clicks carry the result's
+ *  type in `source` — the first (newest) one seen becomes the row's
+ *  resultType. Chatbot clicks use `source` for something else ('card'/'link'),
+ *  so they leave it off. */
 function destinationRows(
   clicks: AnalyticsEvent[],
-  unique: boolean
+  unique: boolean,
+  sourceIsType = false
 ): ClickDestination[] {
-  const byUrl = new Map<string, { name: string; url?: string; count: number }>()
+  const byUrl = new Map<string, ClickDestination>()
   const seen = new Set<string>()
   for (const e of clicks) {
     const url = e.url ?? e.label ?? '(unknown)'
@@ -859,6 +871,7 @@ function destinationRows(
       seen.add(dedupe)
     }
     const g = byUrl.get(url) ?? { name: e.label ?? url, url: e.url, count: 0 }
+    if (sourceIsType && !g.resultType && e.source) g.resultType = e.source
     g.count += 1
     byUrl.set(url, g)
   }
@@ -920,7 +933,7 @@ function searchPanels(
       e => e.query!.toLowerCase(),
       unique
     ),
-    destinations: destinationRows(clicks, unique),
+    destinations: destinationRows(clicks, unique, true),
   }
 }
 


### PR DESCRIPTION
- Each row in the Search tab's "Clicked from search" table gets a Page column: the resource page's nav icon (same style as the dashboard tabs), with the page name as the hover tooltip.
- Search result clicks now record the result's type at click time, so the page stays known even after the listing leaves the search index (closed jobs, past events).
- Clicks from before the type was tracked are matched against the live search index by url, then title; rows that no longer match anything show no icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)