### PR TITLE
Analytics: drop Home from Shared interests pairs; trim the caption

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -567,12 +567,11 @@ export default async function AnalyticsPage({
                 labelFor={name => labelByPage.get(name) ?? name}
               />
               <p className={styles.caption}>
-                Visitors (by anonymous browser id) who engaged with both of a
-                pair — visited the page or clicked one of its listings, with
-                chatbot and search use as rows of their own. Clicks give this
-                history back to 20 June 2026; page views count from 15 July
-                2026, so overlaps get richer as views accumulate. Pairs shared
-                by only one visitor are hidden.
+                Visitors who engaged with both of a pair — visited the page or
+                clicked one of its listings, with chatbot and search use as
+                rows of their own. Clicks give this history back to 20 June
+                2026; page views count from 15 July 2026, so overlaps get
+                richer as views accumulate.
               </p>
             </Panel>
           )}

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -756,11 +756,15 @@ function countVisits(views: AnalyticsEvent[]): number {
 
 /** The interest an event expresses, for the correlations table: the page it
  *  belongs to (viewed, or clicked a listing on), with 'Chatbot' and 'Search'
- *  as interests of their own. Listing clicks reach back to 20 June 2026, so
- *  pairs have history even though page views only started on 15 July 2026. */
+ *  as interests of their own. Home isn't an interest — nearly everyone passes
+ *  through it, so its pairs say nothing. Listing clicks reach back to 20 June
+ *  2026, so pairs have history even though page views only started on 15 July
+ *  2026. */
 function interestOf(e: AnalyticsEvent): string | undefined {
   if (e.type === 'page_view')
-    return e.page ? (PAGE_NAME_BY_PATH[e.page] ?? e.page) : undefined
+    return e.page && e.page !== '/'
+      ? (PAGE_NAME_BY_PATH[e.page] ?? e.page)
+      : undefined
   if (e.type === 'listing_click') return e.page
   if (e.type.startsWith('chatbot')) return 'Chatbot'
   if (e.type.startsWith('search')) return 'Search'


### PR DESCRIPTION
- Home page views no longer count as an interest in the Correlations tab, so "Home + X" rows disappear from Shared interests – nearly every visitor passes through Home, so those pairs carried no signal. Resource pages, Chatbot, and Search still pair as before.
- Caption trimmed: removed "(by anonymous browser id)" and the closing "Pairs shared by only one visitor are hidden." sentence.

Verified on localhost with a seeded dev analytics store: visitors who all viewed Home plus other pages produced only the non-Home pair, and the caption renders as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)