### PR TITLE
Remove Grant-based fellowship from funding categories

### DIFF
--- a/src/app/funding/FundingClient.tsx
+++ b/src/app/funding/FundingClient.tsx
@@ -19,7 +19,6 @@ const acceptingOptions = ['Yes', 'No']
 const typeOptions = [
   'Fund',
   'Grant program',
-  'Grant-based fellowship',
   'Platform',
 ]
 

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES, greetingFor } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-07-18-01'
+export const PROMPT_VERSION = '2026-07-18-02'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -127,7 +127,7 @@ Filter keys + complete value lists per type. Values are exact catalog labels:
   - Each job result carries a \`datePublished\` meta field. Results come newest-first, so for a vague "show me jobs" take them in order. When you surface an older posting (several months old) as a specific match, lean toward more recent ones where the fit is comparable, and you may note an old one was "posted a while ago" since it's likelier to be filled – don't present a months-old listing as freshly opened.
 
 - **funder**:
-  - \`type\`: "Fund", "Grant program", "Grant-based fellowship", "Platform"
+  - \`type\`: "Fund", "Grant program", "Platform"
   - \`recipientType\`: free text – common values include "Individuals", "Organizations", "Both"
   - \`acceptingApplications\`: "Yes", "No"
 

--- a/src/lib/assistant/tools.ts
+++ b/src/lib/assistant/tools.ts
@@ -20,7 +20,7 @@ ARGUMENTS:
 
   Per type:
     job: skillSet ("Policy"|"Research"|"Software engineering"|"Operations"|"Outreach"|"Strategy"|"Legal"|"Data"|"Information security"|"Management"), minimumExperience ("Entry-level"|"Junior"|"Mid"|"Senior"), roleType ("Full-time"|"Part-time"|"Internship"|"Fellowship"|"Volunteering"|"Funding"), workLocation ("Remote"|"On-site"), location (city or country)
-    funder: type ("Fund"|"Grant program"|"Prize"), recipientType ("Individuals"|"Organizations"), acceptingApplications ("Yes"|"No")
+    funder: type ("Fund"|"Grant program"|"Platform"), recipientType ("Individuals"|"Organizations"), acceptingApplications ("Yes"|"No")
     community: platform ("Slack"|"Discord"|"In-person"), type, activityLevel ("Active"|"Quiet"), location
     course: category, courseType
     advisor: focus, status


### PR DESCRIPTION
- Removes "Grant-based fellowship" from the /funding Type filter, matching the Airtable Funding table where the option was removed
- Updates the chatbot production prompt's funder type list to the current categories (Fund, Grant program, Platform) and bumps PROMPT_VERSION
- Fixes the search_listings tool description, which listed a nonexistent "Prize" funder type and omitted "Platform"

🤖 Generated with [Claude Code](https://claude.com/claude-code)