### PR TITLE
Global nav: highlight the current page + clipboard icon redraw

### DIFF
--- a/public/images/clipboard.svg
+++ b/public/images/clipboard.svg
@@ -1,7 +1,7 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M6.38819 2.2575C6.45578 2.04116 6.61183 1.8491 6.83152 1.71185C7.05121 1.5746 7.32194 1.50003 7.60069 1.5H9.39881C9.67756 1.50003 9.94829 1.5746 10.168 1.71185C10.3877 1.8491 10.5437 2.04116 10.6113 2.2575L11.0001 3.5H6.00006L6.38819 2.2575Z" stroke="#094141" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6.5 8.5H10.5" stroke="#094141" stroke-linecap="round"/>
-<path d="M6.5 6H10.5" stroke="#094141" stroke-linecap="round"/>
-<path d="M6.5 11H10.5" stroke="#094141" stroke-linecap="round"/>
-<path d="M13 3.5C13.2761 3.5 13.5 3.72386 13.5 4V13C13.5 13.2761 13.2761 13.5 13 13.5H4C3.72386 13.5 3.5 13.2761 3.5 13V4C3.5 3.72386 3.72386 3.5 4 3.5H13Z" stroke="#094141" stroke-linejoin="round"/>
+<path d="M10.5 3H12C12.5523 3 13 3.44772 13 4V13.5C13 14.0523 12.5523 14.5 12 14.5H4C3.44772 14.5 3 14.0523 3 13.5V4C3 3.44772 3.44772 3 4 3H5.5" stroke="#094141" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="5.5" y="1.5" width="5" height="3" rx="1" stroke="#094141" stroke-linejoin="round"/>
+<path d="M5.5 7.5H10.5" stroke="#094141" stroke-linecap="round"/>
+<path d="M5.5 10H10.5" stroke="#094141" stroke-linecap="round"/>
+<path d="M5.5 12.5H10.5" stroke="#094141" stroke-linecap="round"/>
 </svg>

--- a/src/components/Navigation.module.css
+++ b/src/components/Navigation.module.css
@@ -156,13 +156,13 @@
   cursor: pointer;
 }
 
-/* Current page ("you are here") — the resting 30%-alpha green border lit up
+/* Current page ("you are here") — the resting 30%-alpha teal border lit up
    to full strength, plus the hover fill made persistent. Same border width,
    so no layout shift; the existing transition animates the ring on route
    change. aria-current is set in the JSX, one link at a time. */
 .nav-item[aria-current='page'],
 .nav-dropdown-item[aria-current='page'] {
-  border-color: var(--bright-green);
+  border-color: var(--bright-teal-300);
   background-color: var(--teal-850);
 }
 
@@ -177,7 +177,7 @@
 /* Ring-only hint on the +N pill when the current page's link is hidden
    inside the overflow dropdown. */
 .nav-item-last[data-active-inside] {
-  border-color: var(--bright-green);
+  border-color: var(--bright-teal-300);
 }
 
 .nav-search-button {

--- a/src/components/Navigation.module.css
+++ b/src/components/Navigation.module.css
@@ -156,6 +156,30 @@
   cursor: pointer;
 }
 
+/* Current page ("you are here") — the resting 30%-alpha green border lit up
+   to full strength, plus the hover fill made persistent. Same border width,
+   so no layout shift; the existing transition animates the ring on route
+   change. aria-current is set in the JSX, one link at a time. */
+.nav-item[aria-current='page'],
+.nav-dropdown-item[aria-current='page'] {
+  border-color: var(--bright-green);
+  background-color: var(--teal-850);
+}
+
+/* The active pill is already filled, so hover lifts it with the site's
+   card-hover color-mix instead. Also keeps hover visible on the active
+   dropdown item, whose fill blends into the teal-850 dropdown panel. */
+.nav-item[aria-current='page']:hover,
+.nav-dropdown-item[aria-current='page']:hover {
+  background-color: color-mix(in srgb, var(--teal-850) 60%, var(--teal-800));
+}
+
+/* Ring-only hint on the +N pill when the current page's link is hidden
+   inside the overflow dropdown. */
+.nav-item-last[data-active-inside] {
+  border-color: var(--bright-green);
+}
+
 .nav-search-button {
   width: 40px;
   height: 40px;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -222,6 +222,7 @@ export default function Navigation({
                 key={item.href}
                 href={item.href}
                 className={styles['nav-item']}
+                aria-current={pathname === item.href ? 'page' : undefined}
                 ref={el => {
                   itemRefs.current[i] = el
                 }}
@@ -246,6 +247,11 @@ export default function Navigation({
             <div
               ref={dropdownRef}
               className={styles['nav-item-last']}
+              data-active-inside={
+                overflowItems.some(item => item.href === pathname)
+                  ? ''
+                  : undefined
+              }
               onClick={() => setIsDropdownOpen(!isDropdownOpen)}
             >
               <p className="paragraph-small-bold">+{overflowItems.length}</p>
@@ -256,6 +262,7 @@ export default function Navigation({
                       key={item.href}
                       href={item.href}
                       className={styles['nav-dropdown-item']}
+                      aria-current={pathname === item.href ? 'page' : undefined}
                       style={{ marginBottom: '8px' }}
                       onClick={() => setIsDropdownOpen(false)}
                     >
@@ -353,6 +360,7 @@ export default function Navigation({
               key={item.href}
               href={item.href}
               className={styles['nav-item']}
+              aria-current={pathname === item.href ? 'page' : undefined}
             >
               <div className={styles['nav-item-icon']}>
                 <Image


### PR DESCRIPTION
- The global nav now marks the page the user is on: the active pill's existing teal border goes to full-strength `--bright-teal-300` with the hover fill made persistent. Set via `aria-current="page"`, so screen readers announce it too.
- Works in all three nav renders: desktop pills, the +N overflow dropdown, and the mobile menu. When the current page's link is hidden inside the +N dropdown, the +N pill gets the teal ring (ring only, no fill) as a "your page is in here" hint.
- Hover still reads on an active pill: it lifts with the same color-mix used for card hovers.
- Non-active pills are untouched — the new CSS only matches links carrying `aria-current`/`data-active-inside`. No layout shift (border width unchanged), and the existing `--hover-transition` animates the ring on route change.
- `clipboard.svg` (Volunteer projects) redrawn slightly — portrait board, top clip, three ruled lines, same 1px stroke style as the sibling icons. The old shape could be confused with a briefcase.
- Ring color note: this PR originally used the green highlight (`--bright-green`); it has been updated to the teal now that #474 reverts the site's highlight color to `--bright-teal-300`.

@melissasamworth Neither the active-state treatment nor the redrawn icon comes from your designs — both need your design sign-off. Easiest place to see them is the Vercel preview: any resource page shows its own pill ringed; /projects or /donation-guide shows the ring on the +N pill; the new clipboard icon is in the +N dropdown next to Volunteer projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)