### PR TITLE
Analytics: opt-outs tile counts only browsers still opted out; date picker beside presets

### DIFF
--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -551,7 +551,6 @@
 .rangeBar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   flex-wrap: wrap;
   gap: 12px;
   margin-bottom: 24px;

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -568,10 +568,10 @@ export default async function AnalyticsPage({
               />
               <p className={styles.caption}>
                 Visitors who engaged with both of a pair — visited the page or
-                clicked one of its listings, with chatbot and search use as
-                rows of their own. Clicks give this history back to 20 June
-                2026; page views count from 15 July 2026, so overlaps get
-                richer as views accumulate.
+                clicked one of its listings, with chatbot and search use as rows
+                of their own. Clicks give this history back to 20 June 2026;
+                page views count from 15 July 2026, so overlaps get richer as
+                views accumulate.
               </p>
             </Panel>
           )}
@@ -601,9 +601,10 @@ export default async function AnalyticsPage({
                 Visitors = distinct browsers; one visitor&apos;s pages more than
                 30 minutes apart count as separate visits. Recording since 15
                 July 2026. Opt-outs = browsers that switched analytics off on
-                the privacy page (recording since 16 July 2026)
+                the privacy page and haven&apos;t switched it back on (recording
+                since 16 July 2026)
                 {data.optOuts.on > 0 &&
-                  ` — ${data.optOuts.on.toLocaleString()} turned it back on`}
+                  ` – ${data.optOuts.on.toLocaleString()} more switched it back on`}
                 .
               </p>
             </Panel>
@@ -1442,7 +1443,8 @@ function SearchView({
         <p className={styles.caption}>
           The results visitors opened from search, with the page or listing each
           one leads to. The Page column is the page the result belongs to; a row
-          without one can&apos;t be matched to a single page in the search index.
+          without one can&apos;t be matched to a single page in the search
+          index.
         </p>
       </Panel>
     </>

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -394,9 +394,10 @@ export interface DashboardData {
   chatbot: ChatbotPanelData
   /** The Search tab's event-derived panels (opens, queries, result clicks). */
   search: SearchPanelData
-  /** Browsers that used the privacy page's analytics switch in range: `off` =
-   *  turned analytics off, `on` = turned it back on. Unique browsers, always —
-   *  toggling twice isn't two people changing their mind. */
+  /** The privacy page's analytics switch, one bucket per browser by its latest
+   *  toggle in range: `off` = switched analytics off and hasn't switched it
+   *  back, `on` = switched it back on. Changing your mind moves a browser
+   *  between buckets rather than counting it in both. */
   optOuts: { off: number; on: number }
   /** First-party page views (recorded from 15 July 2026). */
   visits: VisitsData
@@ -514,7 +515,7 @@ function uniqueClicks(clicks: AnalyticsEvent[]): AnalyticsEvent[] {
     const day = Number.isNaN(t)
       ? ''
       : new Date(t - 5 * 3_600_000).toISOString().slice(0, 10)
-    const key = `${e.vid} ${day} ${e.page ?? ''} ${listingMember(e)}`
+    const key = `${e.vid}\x00${day}\x00${e.page ?? ''}\x00${listingMember(e)}`
     if (seen.has(key)) continue
     seen.add(key)
     out.push(e)
@@ -616,7 +617,7 @@ function aggregate(
   >()
   for (const e of clicks) {
     const name = listingMember(e)
-    const key = `${e.page ?? ''} ${name}`
+    const key = `${e.page ?? ''}\x00${name}`
     // clicks is newest-first, so the first url seen for a listing is the latest.
     const g = perOverall.get(key) ?? {
       name,
@@ -676,10 +677,7 @@ function aggregate(
     },
     chatbot: chatbotPanels(inRange, unique),
     search: searchPanels(inRange, unique),
-    optOuts: {
-      off: usersOf('analytics_optout'),
-      on: usersOf('analytics_optin'),
-    },
+    optOuts: optOutSplit(inRange),
     visits: visitsData(inRange, unique),
     correlations: correlations(inRange),
     // Newest-first already; page views are left out so the feed stays a log
@@ -939,6 +937,33 @@ function searchPanels(
     ),
     destinations: destinationRows(clicks, unique, true),
   }
+}
+
+/** The privacy switch's toggle events bucketed by each browser's latest state:
+ *  `off` = the latest toggle turned analytics off, `on` = the latest toggle
+ *  turned it back on. Decided per vid by timestamp (ISO strings compare
+ *  chronologically), so flip-flopping counts the browser once, under where it
+ *  ended up. Vid-less events can't be paired with a later change of mind, so
+ *  each counts once under the state it reported. */
+function optOutSplit(events: AnalyticsEvent[]): { off: number; on: number } {
+  const latestByVid = new Map<string, AnalyticsEvent>()
+  let off = 0
+  let on = 0
+  for (const e of events) {
+    if (e.type !== 'analytics_optout' && e.type !== 'analytics_optin') continue
+    if (!e.vid) {
+      if (e.type === 'analytics_optout') off++
+      else on++
+      continue
+    }
+    const prev = latestByVid.get(e.vid)
+    if (!prev || e.ts > prev.ts) latestByVid.set(e.vid, e)
+  }
+  for (const e of latestByVid.values()) {
+    if (e.type === 'analytics_optout') off++
+    else on++
+  }
+  return { off, on }
 }
 
 /** Distinct users in a set of events: distinct vids, plus each vid-less event


### PR DESCRIPTION
- The "Analytics opt-outs" tile now counts each browser by its latest privacy-switch toggle: only browsers that switched analytics off and haven't switched it back on appear in the big number.
- Browsers that switched it back on move to the caption note instead: "– N more switched it back on". A browser that flips off–on–off counts once, as opted out.
- Caption wording claims only switch actions ("haven't switched it back on" rather than "left it off"), since the admin exclude-browser toggles set the same flag without firing events.
- The custom from/to date picker now sits directly next to the range preset buttons instead of at the far right of the row.
- Fixes a pre-existing quirk in the events store: four raw NUL bytes used as map-key separators made grep/ripgrep treat the file as binary and silently skip it. They are now \x00 escapes — identical behavior, searchable file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)