### PR TITLE
Highlight color back to teal sitewide

### DIFF
--- a/src/app/about/page.module.css
+++ b/src/app/about/page.module.css
@@ -1,7 +1,7 @@
-/* Questions card — custom border color (#7AFFB2 at 30% opacity) */
+/* Questions card — custom border color (bright-teal-300 at 30% opacity) */
 .questionsCard {
   padding: 40px;
-  border: 1px solid rgba(122, 255, 178, 0.3);
+  border: 1px solid color-mix(in srgb, var(--bright-teal-300) 30%, transparent);
   border-radius: 16px;
   align-self: flex-start;
 }

--- a/src/app/developers/page.module.css
+++ b/src/app/developers/page.module.css
@@ -83,8 +83,8 @@ a.endpointCard {
   flex: none;
   padding: 3px 8px;
   border-radius: 6px;
-  background-color: rgba(122, 255, 178, 0.12);
-  color: var(--bright-green);
+  background-color: color-mix(in srgb, var(--bright-teal-300) 12%, transparent);
+  color: var(--bright-teal-300);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.5px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -216,7 +216,7 @@ label {
   color: var(--bright-teal-500);
 }
 .color-light-teal {
-  color: var(--bright-green);
+  color: var(--bright-teal-300);
 }
 .color-white {
   color: #fff;
@@ -227,7 +227,11 @@ label {
 
 .underline {
   text-decoration: underline;
-  text-decoration-color: rgba(122, 255, 178, 0.3);
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--bright-teal-300) 30%,
+    transparent
+  );
   text-underline-offset: 6px;
   transition: all var(--hover-transition);
 }

--- a/src/components/Navigation.module.css
+++ b/src/components/Navigation.module.css
@@ -89,7 +89,7 @@
   height: 40px;
   padding-left: 4px;
   padding-right: 16px;
-  border: 1px solid rgba(122, 255, 178, 0.3);
+  border: 1px solid color-mix(in srgb, var(--bright-teal-300) 30%, transparent);
   border-radius: 20px;
   flex: none;
   max-width: 100%;
@@ -108,7 +108,7 @@
   gap: 8px;
   height: 40px;
   padding: 0 16px;
-  border: 1px solid rgba(122, 255, 178, 0.3);
+  border: 1px solid color-mix(in srgb, var(--bright-teal-300) 30%, transparent);
   border-radius: 20px;
   transition: all var(--hover-transition);
   position: relative;
@@ -134,7 +134,7 @@
   height: 40px;
   padding-left: 4px;
   padding-right: 16px;
-  border: 1px solid rgba(122, 255, 178, 0.3);
+  border: 1px solid color-mix(in srgb, var(--bright-teal-300) 30%, transparent);
   border-radius: 20px;
   width: 100%;
   max-width: 100%;

--- a/src/components/SearchModal.module.css
+++ b/src/components/SearchModal.module.css
@@ -71,7 +71,7 @@
 
 .filter-chip {
   flex: none;
-  background-color: var(--bright-green);
+  background-color: var(--bright-teal-300);
   color: var(--teal-900);
   border: none;
   border-radius: 999px;
@@ -80,7 +80,11 @@
 }
 
 .filter-chip:hover {
-  background-color: color-mix(in srgb, var(--bright-green) 80%, var(--white));
+  background-color: color-mix(
+    in srgb,
+    var(--bright-teal-300) 80%,
+    var(--white)
+  );
 }
 
 .filter-chip svg {
@@ -224,7 +228,7 @@
 
 .result-icon-initials {
   background-color: var(--teal-750);
-  color: var(--bright-green);
+  color: var(--bright-teal-300);
   border-radius: 50%;
 }
 
@@ -242,7 +246,7 @@
 }
 
 .result-subtitle {
-  color: var(--bright-green);
+  color: var(--bright-teal-300);
 }
 
 .result-description {


### PR DESCRIPTION
- Reverts the site's highlight color from green (#7affb2) to the teal (--bright-teal-300, #a6dad9) the redesigned /events page uses, per Melissa's direction.
- One-line class change covers the highlighted intro text on every resource page (.color-light-teal); nav pill borders, the homepage underline, the about-page questions card, the search modal (filter chip, result accents), and the /developers method badge are updated individually.
- Hardcoded rgba() greens are replaced with color-mix() over the existing design-system variable, per docs/css-guidelines.md.
- Intentionally unchanged: the admin panel's "connected" status dot (semantic status light) and the category pill colors on the redesigned events/training pages (separate accent palette, other branch).
- PR #471's current-page nav ring and the events/training branch (PR #473) carry the same green and are updated separately on their own branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)