### PR TITLE
/map: zoom controls to the bottom-left, assistant bubble in the corner

### DIFF
--- a/src/app/map/page.module.css
+++ b/src/app/map/page.module.css
@@ -14,12 +14,15 @@
   height: 100%;
 }
 
-/* Map zoom controls - bottom-right on both desktop and mobile */
+/* Map zoom controls - bottom-left, stacked above the View cards button
+   (the bottom-right corner belongs to the assistant bubble).
+   z-index must stay below the assistant scrim/panel/pill (96-100) so the
+   open chat covers the controls instead of them poking through. */
 .map-controls {
   position: absolute;
-  bottom: 24px;
-  right: 24px;
-  z-index: 999;
+  bottom: 88px;
+  left: 24px;
+  z-index: 95;
 }
 
 .map-control-group {

--- a/src/components/assistant/Assistant.module.css
+++ b/src/components/assistant/Assistant.module.css
@@ -34,19 +34,6 @@
   transition: transform var(--hover-transition);
 }
 
-/* Shifted — when there's a fixed UI in the bottom-right (e.g. /map zoom
-   controls), the pill (and panel) move LEFT to clear them, not up.
-   Uses double-class specificity to win against the base .pill / .panel
-   right values regardless of cascade order. */
-
-.pill.pillShifted {
-  right: 80px;
-}
-
-.panel.panelShifted {
-  right: 80px;
-}
-
 .pillIconRotated {
   transform: rotate(0deg);
 }
@@ -1055,19 +1042,6 @@
     bottom: 16px;
     width: 48px;
     height: 48px;
-  }
-
-  /* Mobile /map: shift pill left + raise to align with zoom controls
-     bottom edge. Panel sits ABOVE the zoom stack so the controls stay
-     visible (but unusable) below the chat. */
-  .pill.pillShifted {
-    right: 80px;
-    bottom: 24px;
-  }
-
-  .panel.panelShifted {
-    right: 12px;
-    bottom: 160px;
   }
 
   .pillIcon {

--- a/src/components/assistant/Assistant.tsx
+++ b/src/components/assistant/Assistant.tsx
@@ -98,8 +98,6 @@ export default function Assistant() {
   const currentPage = pathname || '/'
   const chips = useMemo(() => chipsFor(currentPage), [currentPage])
   const greeting = useMemo(() => greetingFor(currentPage), [currentPage])
-  // /map has fixed bottom-right zoom controls; shift pill+panel left to clear.
-  const shiftedRight = currentPage === '/map'
 
   const fireLog = useCallback(async (event: object) => {
     // The "exclude this browser" switch (privacy page/admin) covers the
@@ -260,7 +258,7 @@ export default function Assistant() {
     <>
       <button
         type="button"
-        className={`${styles.pill} drop-shadow-dark ${shiftedRight ? styles.pillShifted : ''}`}
+        className={`${styles.pill} drop-shadow-dark`}
         onClick={handleTogglePill}
         aria-label={
           isOpen ? 'Close the assistant' : 'Open the AISafety.com assistant'
@@ -299,7 +297,7 @@ export default function Assistant() {
       />
 
       <aside
-        className={`${styles.panel} ${isOpen ? styles.panelOpen : ''} ${isExpanded ? styles.panelExpanded : ''} ${shiftedRight && !isExpanded ? styles.panelShifted : ''}`}
+        className={`${styles.panel} ${isOpen ? styles.panelOpen : ''} ${isExpanded ? styles.panelExpanded : ''}`}
         role="dialog"
         aria-modal={isExpanded}
         aria-label="AISafety.com directory assistant"


### PR DESCRIPTION
- On /map, the assistant bubble now sits in its standard bottom-right corner and the zoom/recenter controls move to the bottom-left, stacked above the "View cards" button.
- Removes the /map-only shifted positioning for the assistant pill and panel – the bubble now behaves identically sitewide.
- Lowers the zoom controls' z-index below the assistant overlay so the open chat covers them rather than the buttons showing through (previously visible on mobile).
- Verified on desktop and mobile with the chat open and closed; build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)