### PR TITLE
Map hover tracking, by-area analytics panels, and record ids on featured clicks

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -8,6 +8,7 @@ import {
   type ChatbotFunnel,
   type ClickDestination,
   type CorrelationRow,
+  type ListingRow,
   type OverallListingRow,
   type SearchPanelData,
 } from '@/lib/analytics/events'
@@ -31,7 +32,7 @@ import { getCommunities } from '@/lib/data/communities'
 import { getMediaChannels } from '@/lib/data/media-channels'
 import { getFounderResources } from '@/lib/data/founders'
 import { getJobs } from '@/lib/data/jobs'
-import { getMapData } from '@/lib/data/map'
+import { getMapData, type MapOrg } from '@/lib/data/map'
 import { getProjects } from '@/lib/data/projects'
 import DateRangePicker from './DateRangePicker'
 import ExcludeToggle from './ExcludeToggle'
@@ -80,6 +81,11 @@ const OVERVIEW_TABS: { key: string; label: string }[] = [
   { key: 'correlations', label: 'Correlations' },
 ]
 const OVERVIEW_KEYS = new Set(OVERVIEW_TABS.map(t => t.key))
+
+// Pages with a map (mirrors MAP_PAGES in the events store). Only these emit
+// listing_hover events, so only their tabs get the hovered-listings panel —
+// and only Map has areas, so the by-area rollup is Map-only.
+const MAP_PAGES = new Set(['Map', 'Communities'])
 
 // Bryce is in Colombia — fixed UTC-5, no DST — so day boundaries use -05:00.
 const TZ_OFFSET = '-05:00'
@@ -139,7 +145,9 @@ function resolveRange(sp: SearchParams): ResolvedRange {
 /** Real Airtable logos for the selected page's listings, keyed by the exact
  *  label each click was tracked under, so the top-listings table shows proper
  *  logos instead of favicons. Returns an empty map (→ favicons) on any error or
- *  for pages without listing data. */
+ *  for pages without listing data. The Map page isn't handled here — its
+ *  caller builds the logo map itself, from records it already fetched for the
+ *  by-area panel. */
 async function logosForPage(
   page: string | null
 ): Promise<Map<string, string | null>> {
@@ -165,8 +173,6 @@ async function logosForPage(
         return new Map(
           (await getJobs()).map(i => [`${i.name} – ${i.organization}`, i.logo])
         )
-      case 'Map':
-        return new Map((await getMapData()).records.map(i => [i.title, i.logo]))
       default:
         return new Map()
     }
@@ -186,6 +192,54 @@ function faviconFor(url?: string): string | undefined {
   } catch {
     return undefined
   }
+}
+
+/** The Map tab's per-area rollups: the page's clicks and hovers bucketed by
+ *  map area — one list per metric, each sorted by its own count. Newer events
+ *  carry their area stamped at click/hover time (what the visitor actually
+ *  saw); older rows are resolved against the current map records — by record
+ *  id, then exact name, then url — so history from before area tracking still
+ *  lands in the right bucket. Rows that match a record with no category show
+ *  as 'Other'; rows that match nothing (the listing was removed or renamed
+ *  since) show as 'No longer listed'. */
+function areaBreakdown(
+  clicks: ListingRow[],
+  hovers: ListingRow[],
+  records: MapOrg[]
+): { clicks: Counted[]; hovers: Counted[] } {
+  const byId = new Map(records.map(r => [r.id, r]))
+  // A record answers to both of its display names: card clicks are tracked
+  // under the card title, map tooltips under the (long) tooltip name.
+  const byName = new Map<string, MapOrg>()
+  for (const r of records) {
+    byName.set(r.title, r)
+    byName.set(r.tooltipTitle, r)
+  }
+  // '#' is the map's placeholder for a missing link, not a real url.
+  const byUrl = new Map(
+    records.filter(r => r.link && r.link !== '#').map(r => [r.link, r])
+  )
+  const areaOf = (row: ListingRow): string => {
+    if (row.area) return row.area
+    const rec =
+      (row.listingId ? byId.get(row.listingId) : undefined) ??
+      byName.get(row.name) ??
+      (row.url && row.url !== '#' ? byUrl.get(row.url) : undefined)
+    if (!rec) return 'No longer listed'
+    // The map files each listing under its first category — that's its area.
+    return rec.category.split(',')[0].trim() || 'Other'
+  }
+  const tally = (rows: ListingRow[]): Counted[] => {
+    const areas = new Map<string, number>()
+    for (const row of rows) {
+      const name = areaOf(row)
+      areas.set(name, (areas.get(name) ?? 0) + row.count)
+    }
+    return [...areas.entries()]
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+  }
+  return { clicks: tally(clicks), hovers: tally(hovers) }
 }
 
 /** A row's resource-page marker in the clicked-from-search table: the page's
@@ -427,20 +481,45 @@ export default async function AnalyticsPage({
   const tabKeys = new Set<string>([...OVERVIEW_KEYS, ...resourceNames])
   const activeTab = tabReq && tabKeys.has(tabReq) ? tabReq : 'pages'
   const onResourceView = !OVERVIEW_KEYS.has(activeTab)
-  const selectedLabel = data.selectedPage
-    ? (labelByPage.get(data.selectedPage) ?? data.selectedPage)
-    : null
+
+  // The Map tab needs the live map records twice — the by-area panel joins
+  // clicks and hovers back to them, and the logo maps below read from them —
+  // so they're fetched once here and shared. On error the tab degrades (area
+  // rows fall to 'No longer listed', logos to favicons) with a warning rather
+  // than taking the dashboard down.
+  const mapRecords: MapOrg[] =
+    data.selectedPage === 'Map'
+      ? await getMapData()
+          .then(d => d.records)
+          .catch(err => {
+            console.warn(
+              `[analytics] map data unavailable for the Map tab panels: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            )
+            return []
+          })
+      : []
 
   // logoById drives the recent-activity feed (funding listings, by record id).
   // logoByName drives the top-listings table for the selected page, fetched from
   // that page's Airtable data so every page shows real logos — not just funding.
-  // Funding reuses the already-fetched funders. Only needed on a resource view.
+  // Funding reuses the already-fetched funders, Map the already-fetched map
+  // records — keyed by both display names a Map event can be tracked under
+  // (card title and tooltip name). Only needed on a resource view.
   const logoById = new Map(funders.map(f => [f.id, f.logo]))
   const logoByName = !onResourceView
     ? new Map<string, string | null>()
     : data.selectedPage === 'Funding'
       ? new Map<string, string | null>(funders.map(f => [f.name, f.logo]))
-      : await logosForPage(data.selectedPage)
+      : data.selectedPage === 'Map'
+        ? new Map<string, string | null>(
+            mapRecords.flatMap((r): [string, string | null][] => [
+              [r.tooltipTitle, r.logo],
+              [r.title, r.logo],
+            ])
+          )
+        : await logosForPage(data.selectedPage)
 
   // Per-listing slot range + a url for the favicon, keyed by display name, for
   // whichever page is selected. The slot is stamped onto the click when it
@@ -450,6 +529,23 @@ export default async function AnalyticsPage({
     data.topListings.map(r => [r.name, r.position])
   )
   const urlByName = new Map(data.topListings.map(r => [r.name, r.url]))
+
+  // Same url lookup for the hovered-listings table — hover rows carry their
+  // own urls, independent of the click rows above.
+  const hoverUrlByName = new Map(data.topHovered.map(r => [r.name, r.url]))
+  // Every hover is by definition from the map, so hovers aren't split by
+  // source and the table's % denominator is simply the sum of its rows.
+  const hoverTotal = data.topHovered.reduce((sum, r) => sum + r.count, 0)
+  // The Map tab's by-area rollups (empty on every other tab). Built from
+  // areaClicks, not topListings — topListings narrows to the active ?source
+  // filter while hovers never do, and the two area panels should stay
+  // comparable side by side.
+  const areaData =
+    data.selectedPage === 'Map'
+      ? areaBreakdown(data.areaClicks, data.topHovered, mapRecords)
+      : { clicks: [] as Counted[], hovers: [] as Counted[] }
+  const areaClickTotal = areaData.clicks.reduce((sum, r) => sum + r.count, 0)
+  const areaHoverTotal = areaData.hovers.reduce((sum, r) => sum + r.count, 0)
 
   // Chart totals (also the % denominators). The listings total is the selected
   // page's whole click count, not just the rows currently revealed.
@@ -645,13 +741,9 @@ export default async function AnalyticsPage({
                 params={sp}
               />
               <div className={styles.grid}>
-                <Panel
-                  title={
-                    selectedLabel
-                      ? `Top ${selectedLabel} listings`
-                      : 'Top listings'
-                  }
-                >
+                {/* Titles skip the page name — the active tab already says
+                    which page these panels describe. */}
+                <Panel title="Top listings">
                   <CountTable
                     rows={data.topListings}
                     labelHead="Listing"
@@ -682,12 +774,64 @@ export default async function AnalyticsPage({
                   </p>
                 </Panel>
               </div>
+              {data.selectedPage === 'Map' && (
+                <div className={styles.grid}>
+                  <Panel title="Clicks by area">
+                    <CountTable
+                      rows={areaData.clicks}
+                      labelHead="Area"
+                      total={areaClickTotal}
+                    />
+                    <p className={styles.caption}>
+                      An area is the listing&apos;s first category. Clicks
+                      recorded before areas were tracked are matched against
+                      the current map listings – anything that no longer
+                      matches shows as No longer listed.
+                    </p>
+                  </Panel>
+                  <Panel title="Hovers by area">
+                    <CountTable
+                      rows={areaData.hovers}
+                      labelHead="Area"
+                      countHead="Hovers"
+                      total={areaHoverTotal}
+                    />
+                  </Panel>
+                </div>
+              )}
+              {data.selectedPage != null &&
+                MAP_PAGES.has(data.selectedPage) && (
+                  <div className={styles.grid}>
+                    <Panel title="Top hovered listings">
+                      {/* Stays 'Hovers' in unique mode: the count is one per
+                          visitor per DAY summed across days, not distinct
+                          users — same reason the sibling table keeps 'Clicks'.
+                          'Users' is reserved for true per-visitor tallies. */}
+                      <CountTable
+                        rows={data.topHovered}
+                        labelHead="Listing"
+                        countHead="Hovers"
+                        logoFor={name =>
+                          logoByName.get(name) ??
+                          faviconFor(hoverUrlByName.get(name))
+                        }
+                        linkFor={name => hoverUrlByName.get(name)}
+                        total={hoverTotal}
+                      />
+                      <p className={styles.caption}>
+                        A hover is recorded when the cursor rests on a map
+                        listing for half a second – or, on a phone, when a tap
+                        opens its tooltip.
+                      </p>
+                    </Panel>
+                  </div>
+                )}
             </div>
           )}
 
           {activeTab === 'pages' && (
             <div className={styles.grid}>
-              <Panel title="Most clicked listings overall">
+              <Panel title="Most clicked listings">
                 <OverallListingsTable
                   rows={overallListings}
                   total={totalClicks}
@@ -697,7 +841,7 @@ export default async function AnalyticsPage({
                   period. Open a page&apos;s tab for its own breakdown.
                 </p>
               </Panel>
-              <Panel title="Clicks by position overall">
+              <Panel title="Clicks by position">
                 <CountTable
                   rows={data.byPositionOverall}
                   labelHead="Slot"
@@ -1099,6 +1243,9 @@ function CountTable({
   )
 }
 
+/** The Map tab's per-area table: one row per map area with clicks and hovers
+ *  side by side. Two count columns, so CountTable doesn't fit; area counts are
+ *  bounded by the map's category list, so no show-more truncation either. */
 /** The Overview tab's site-wide listings leaderboard. Like CountTable, but each
  *  row carries the page it came from (shown as a pill) and always uses a favicon
  *  — listings here span every page, so there's no single page's logos to load.

--- a/src/app/advisors/page.tsx
+++ b/src/app/advisors/page.tsx
@@ -55,6 +55,7 @@ export default async function AdvisorsPage() {
                   { label: 'Status', value: advisor.status },
                 ]}
                 trackingPage="Advisors"
+                trackingId={advisor.id}
                 trackingPosition={`F${advisor.featured}`}
               />
             ))}

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -53,6 +53,7 @@ export async function POST(req: NextRequest) {
     label: str(b.label, 300),
     position: str(b.position, 16),
     source: str(b.source, 16),
+    area: str(b.area, 64),
     query: str(b.query, 200),
     results: count(b.results, 100_000),
     url: str(b.url, 600),

--- a/src/app/communities/CommunitiesMap.tsx
+++ b/src/app/communities/CommunitiesMap.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image'
 import styles from './page.module.css'
 import { Community } from '@/lib/data/communities'
 import { positionTooltip } from '@/lib/mapTooltip'
-import { trackListingClick } from '@/lib/analytics'
+import { trackListingClick, trackListingHover } from '@/lib/analytics'
 
 interface CommunitiesMapProps {
   communities: Community[]
@@ -54,6 +54,9 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
         else if (typeStr.includes('continent') || typeStr.includes('global'))
           locationType = 'continent'
         return {
+          // Airtable record id — lets analytics join map interactions back
+          // to the exact source record.
+          id: c.id,
           name: c.name,
           description: c.description,
           type: locationType,
@@ -198,6 +201,20 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
       let hoveredPinId: number | null = null
       let tappedPinId: number | null = null
 
+      // Pending hover-analytics dwell. A desktop hover only counts once the
+      // cursor has rested on a pin for 500 ms — the timer restarts when the
+      // cursor enters a new pin and is canceled whenever it leaves the pins
+      // (mouseleave or the empty-features branch below), so drive-by mouse
+      // passes across the map don't record.
+      let hoverTimer: ReturnType<typeof setTimeout> | null = null
+
+      function cancelHoverTimer() {
+        if (hoverTimer !== null) {
+          clearTimeout(hoverTimer)
+          hoverTimer = null
+        }
+      }
+
       const geojsonData = {
         type: 'FeatureCollection' as const,
         features: mapCommunities.map((community, index) => ({
@@ -205,6 +222,10 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
           id: index,
           properties: {
             id: index,
+            // Distinct name on purpose — `id` above is the feature index
+            // that the hover/tap state machine keys on; `recordId` is the
+            // Airtable record id that analytics reports.
+            recordId: community.id,
             name: community.name,
             description: community.description,
             type: community.type,
@@ -325,6 +346,8 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
             resetHover()
             hoveredPinId = null
             tooltip.style.display = 'none'
+            // Cursor slid off the pins — an unfinished dwell doesn't count.
+            cancelHoverTimer()
           }
           return
         }
@@ -339,11 +362,26 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
           hoveredPinId = currentFeatureId
           tooltip.innerHTML = buildTooltipHTML(feature.properties)
           tooltip.style.display = 'block'
+          // Restart the hover dwell — entering a new pin (including moving
+          // straight from one pin onto another) resets the 500 ms clock.
+          cancelHoverTimer()
+          const props = feature.properties
+          hoverTimer = setTimeout(() => {
+            hoverTimer = null
+            trackListingHover(
+              'Communities',
+              props?.name ?? '',
+              props?.link || undefined,
+              props?.recordId || undefined
+            )
+          }, 500)
         }
         updateTooltipPosition(e, tooltip, mapContainer)
       })
 
       map.on('mouseleave', 'community-pins', () => {
+        // Leaving before the dwell elapses means it wasn't a real hover.
+        cancelHoverTimer()
         if (isMobile()) return
         if (hoveredPinId !== null) {
           map.getCanvas().style.cursor = ''
@@ -382,7 +420,7 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
               'Communities',
               feature.properties?.name,
               link,
-              undefined,
+              feature.properties?.recordId || undefined,
               undefined,
               'map'
             )
@@ -407,7 +445,21 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
             'data-link-title',
             feature.properties?.name || ''
           )
+          // Stash the record id too, so the tooltip-tap click below can
+          // report it — that handler has no feature in scope.
+          tooltip.setAttribute(
+            'data-listing-id',
+            feature.properties?.recordId || ''
+          )
           tooltip.style.display = 'block'
+          // A mobile "hover" is the first tap that opens the tooltip —
+          // there's no cursor to dwell, so it counts immediately.
+          trackListingHover(
+            'Communities',
+            feature.properties?.name ?? '',
+            link || undefined,
+            feature.properties?.recordId || undefined
+          )
         }
         updateTooltipPosition(e, tooltip, mapContainer)
       })
@@ -429,7 +481,8 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
                 'Communities',
                 title,
                 lnk,
-                undefined,
+                // Stashed on the tooltip by the first tap.
+                tooltip.getAttribute('data-listing-id') || undefined,
                 undefined,
                 'map'
               )
@@ -479,6 +532,8 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
 
       // Store cleanup function for useEffect teardown
       cleanupRef.current = () => {
+        // A pending hover dwell must not fire after unmount.
+        cancelHoverTimer()
         tooltip.removeEventListener('click', handleTooltipClick)
         document.removeEventListener('click', handleDocumentClick)
         resizeObserver.disconnect()

--- a/src/app/communities/page.tsx
+++ b/src/app/communities/page.tsx
@@ -77,6 +77,7 @@ export default async function CommunitiesPage() {
                     { label: 'Focus', value: community.focus },
                   ]}
                   trackingPage="Communities"
+                  trackingId={community.id}
                   trackingPosition={`F${community.featured}`}
                   trackingSource="cards"
                 />

--- a/src/app/founders/page.tsx
+++ b/src/app/founders/page.tsx
@@ -51,6 +51,7 @@ export default async function FoundersPage() {
                 logo={resource.image ?? undefined}
                 metadata={[{ label: 'Type', value: resource.type }]}
                 trackingPage="Founders"
+                trackingId={resource.id}
                 trackingPosition={`F${resource.featured}`}
               />
             ))}

--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -55,6 +55,7 @@ export default async function FundingPage() {
                   },
                 ]}
                 trackingPage="Funding"
+                trackingId={funder.id}
                 trackingPosition={`F${funder.featured}`}
               />
             ))}

--- a/src/app/map/D3Map.tsx
+++ b/src/app/map/D3Map.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useRef } from 'react'
 import * as d3 from 'd3'
-import { trackListingClick } from '@/lib/analytics'
+import { trackListingClick, trackListingHover } from '@/lib/analytics'
 import { positionTooltip } from '@/lib/mapTooltip'
 import styles from './page.module.css'
 
@@ -109,12 +109,28 @@ export default function D3Map({ orgs }: D3MapProps) {
     // the next tap can switch to a different pin or dismiss on outside tap.
     let tappedOrgId: string | null = null
 
+    // Pending hover-analytics dwell. A desktop hover only counts once the
+    // cursor has rested on a listing for 500 ms — the timer is canceled on
+    // early leave (and on zoom start, via hideTooltip) so drive-by mouse
+    // passes across the map don't record.
+    let hoverTimer: ReturnType<typeof setTimeout> | null = null
+
+    function cancelHoverTimer() {
+      if (hoverTimer !== null) {
+        clearTimeout(hoverTimer)
+        hoverTimer = null
+      }
+    }
+
     function hideTooltip() {
+      cancelHoverTimer()
       if (tooltipRef.current) {
         tooltipRef.current.style.visibility = 'hidden'
         tooltipRef.current.style.opacity = '0'
         tooltipRef.current.removeAttribute('data-link-url')
         tooltipRef.current.removeAttribute('data-link-title')
+        tooltipRef.current.removeAttribute('data-listing-id')
+        tooltipRef.current.removeAttribute('data-area')
       }
       tappedOrgId = null
     }
@@ -255,6 +271,10 @@ export default function D3Map({ orgs }: D3MapProps) {
       // QA: Items with no real link (e.g. "Last updated") should render
       // on the map but not be clickable
       const hasLink = org.link && org.link !== '#'
+      // First category only — orgs can carry several ("Funding, Resource"),
+      // but the dashboard groups map hovers/clicks by a single area. May be
+      // '' for uncategorized items, which analytics receives as undefined.
+      const firstCategory = org.category.split(',')[0].trim()
       const linkEl = itemGroup
         .append(hasLink ? 'a' : 'g')
         .attr('class', 'mapItem')
@@ -273,16 +293,36 @@ export default function D3Map({ orgs }: D3MapProps) {
               const tt = tooltipRef.current
               const container = containerRef.current
               if (!tt || !container) return
-              tt.querySelector('strong')!.textContent = org.tooltipTitle
-              tt.querySelector('span')!.textContent = org.description
-              tt.setAttribute('data-link-url', org.link)
-              tt.setAttribute('data-link-title', org.title)
-              tt.style.visibility = 'visible'
-              tt.style.opacity = '1'
+              // Only a tap on a DIFFERENT pin (re)opens the tooltip — a
+              // repeat tap on the already-open pin just repositions it below.
+              // Same guard as the /communities map, and it's what keeps the
+              // hover count honest: one open gesture, one recorded hover.
+              if (tappedOrgId !== org.id) {
+                tt.querySelector('strong')!.textContent = org.tooltipTitle
+                tt.querySelector('span')!.textContent = org.description
+                tt.setAttribute('data-link-url', org.link)
+                tt.setAttribute('data-link-title', org.title)
+                // Stash id + area too, so the tooltip's second-tap click can
+                // report them — the tooltip click handler has no org in scope.
+                tt.setAttribute('data-listing-id', org.id)
+                tt.setAttribute('data-area', firstCategory)
+                tt.style.visibility = 'visible'
+                tt.style.opacity = '1'
+                tappedOrgId = org.id
+                // A mobile "hover" is the first tap that opens the tooltip —
+                // there's no cursor to dwell, so it counts immediately.
+                // (hasLink is guaranteed: this handler only exists on links.)
+                trackListingHover(
+                  'Map',
+                  org.title,
+                  org.link,
+                  org.id,
+                  firstCategory || undefined
+                )
+              }
               positionTooltip(event.clientX, event.clientY, tt, container, {
                 minLeftMargin: 20,
               })
-              tappedOrgId = org.id
               return
             }
             trackListingClick(
@@ -291,7 +331,8 @@ export default function D3Map({ orgs }: D3MapProps) {
               org.link,
               org.id,
               undefined,
-              'map'
+              'map',
+              firstCategory || undefined
             )
           })
       }
@@ -396,6 +437,21 @@ export default function D3Map({ orgs }: D3MapProps) {
         .on('mouseenter', event => {
           if (isMobile()) return
           if (isZooming) return
+          // Arm the hover dwell — only for real listings (furniture rows
+          // like "Last updated" show a tooltip but never record a hover).
+          if (hasLink) {
+            cancelHoverTimer()
+            hoverTimer = setTimeout(() => {
+              hoverTimer = null
+              trackListingHover(
+                'Map',
+                org.title,
+                org.link,
+                org.id,
+                firstCategory || undefined
+              )
+            }, 500)
+          }
           const tt = tooltipRef.current
           const container = containerRef.current
           if (!tt || !container) return
@@ -416,6 +472,8 @@ export default function D3Map({ orgs }: D3MapProps) {
           positionTooltip(event.clientX, event.clientY, tt, container)
         })
         .on('mouseleave', () => {
+          // Leaving before the dwell elapses means it wasn't a real hover.
+          cancelHoverTimer()
           if (isMobile()) return
           if (tooltipRef.current) {
             tooltipRef.current.style.visibility = 'hidden'
@@ -453,7 +511,16 @@ export default function D3Map({ orgs }: D3MapProps) {
       const title = tt.getAttribute('data-link-title')
       if (link && link !== '#') {
         if (title)
-          trackListingClick('Map', title, link, undefined, undefined, 'map')
+          trackListingClick(
+            'Map',
+            title,
+            link,
+            // Stashed by the first tap — this handler has no org in scope.
+            tt.getAttribute('data-listing-id') || undefined,
+            undefined,
+            'map',
+            tt.getAttribute('data-area') || undefined
+          )
         hideTooltip()
         window.open(link, '_blank')
       }
@@ -476,6 +543,8 @@ export default function D3Map({ orgs }: D3MapProps) {
 
     const container = containerRef.current
     return () => {
+      // A pending hover dwell must not fire after unmount.
+      cancelHoverTimer()
       svgNode.removeEventListener('wheel', preventPageZoom)
       if (tooltipEl) tooltipEl.removeEventListener('click', handleTooltipClick)
       document.removeEventListener('click', handleDocumentClick)

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -245,7 +245,10 @@ export default function MapClient({
                       org.link,
                       org.id,
                       placements.get(org.id),
-                      'cards'
+                      'cards',
+                      // First category = the org's map area; the dashboard
+                      // groups Map-page activity by it.
+                      org.category.split(',')[0].trim() || undefined
                     )
                   }
                 >

--- a/src/app/media-channels/page.tsx
+++ b/src/app/media-channels/page.tsx
@@ -51,6 +51,7 @@ export default async function MediaChannelsPage() {
                 logo={channel.logo ?? undefined}
                 metadata={[{ label: 'Type', value: channel.type }]}
                 trackingPage="Media channels"
+                trackingId={channel.id}
                 trackingPosition={`F${channel.featured}`}
               />
             ))}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -62,6 +62,7 @@ export default async function ProjectsPage() {
                   { label: 'Status', value: project.status },
                 ]}
                 trackingPage="Projects"
+                trackingId={project.id}
                 trackingPosition={`F${project.featured}`}
               />
             ))}

--- a/src/app/self-study/page.tsx
+++ b/src/app/self-study/page.tsx
@@ -55,6 +55,7 @@ export default async function SelfStudyPage() {
                   { label: 'Created by', value: course.organizer },
                 ]}
                 trackingPage="Self-study"
+                trackingId={course.id}
                 trackingPosition={`F${course.featured}`}
               />
             ))}

--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -15,6 +15,9 @@ interface FeaturedCardProps {
   logo?: string
   metadata: MetadataField[]
   trackingPage: string
+  /** Airtable record id of the featured listing, recorded with the click so it
+   *  can be joined back to the source record. */
+  trackingId?: string
   /** Slot this featured card occupies ('F1'/'F2'), recorded with the click. */
   trackingPosition?: string
   /** Click source ('cards' on map pages), so map vs card clicks can be split. */
@@ -29,6 +32,7 @@ export default function FeaturedCard({
   logo,
   metadata,
   trackingPage,
+  trackingId,
   trackingPosition,
   trackingSource,
 }: FeaturedCardProps) {
@@ -97,6 +101,7 @@ export default function FeaturedCard({
       className="flex flex-col-mobile"
       trackingPage={trackingPage}
       trackingName={name}
+      trackingId={trackingId}
       trackingPosition={trackingPosition}
       trackingSource={trackingSource}
     >

--- a/src/components/TrackedLink.tsx
+++ b/src/components/TrackedLink.tsx
@@ -6,6 +6,9 @@ import { trackListingClick } from '@/lib/analytics'
 interface TrackedLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   trackingPage: string
   trackingName: string
+  /** Airtable record id of the listing, when there is one — the stable join
+   *  key back to the source record (names and urls change; the id doesn't). */
+  trackingId?: string
   /** Slot the listing sits in ('F1'/'F2' or a number), recorded with the click
    *  so the analytics dashboard can tie clicks to page position. */
   trackingPosition?: string
@@ -23,6 +26,7 @@ interface TrackedLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 export default function TrackedLink({
   trackingPage,
   trackingName,
+  trackingId,
   trackingPosition,
   trackingSource,
   href,
@@ -38,7 +42,7 @@ export default function TrackedLink({
           trackingPage,
           trackingName,
           href,
-          undefined,
+          trackingId,
           trackingPosition,
           trackingSource
         )

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -30,6 +30,9 @@ interface TrackPayload {
    *  reuse it: how the modal was opened (search_open), the active type filter
    *  (search_query), or the clicked result's type (search_click). */
   source?: string
+  /** The map-area dimension — the listing's FIRST category, stamped on
+   *  Map-page clicks and hovers so the dashboard can slice the map by area. */
+  area?: string
   /** Site-search events: the query text as typed. */
   query?: string
   /** search_query only: how many results the query returned. */
@@ -127,7 +130,8 @@ function sendTrackEvent(payload: TrackPayload): void {
  * Track a click on a listing (funder, job, event, course, etc.).
  * Matomo category is "Listings - <page>" to match the legacy Webflow format.
  * `listingId` is the Airtable record id when available, so clicks can be joined
- * back to the exact source record.
+ * back to the exact source record. `area` is the listing's first category —
+ * stamped on Map-page clicks only, where areas are how the map is grouped.
  */
 export function trackListingClick(
   page: string,
@@ -135,7 +139,8 @@ export function trackListingClick(
   url: string,
   listingId?: string,
   position?: string,
-  source?: string
+  source?: string,
+  area?: string
 ): void {
   if (typeof window === 'undefined') return
   // Opted-out browsers skip Matomo too, so the owner's clicks stay out of both.
@@ -149,6 +154,34 @@ export function trackListingClick(
     listingId,
     position,
     source,
+    area,
+  })
+}
+
+/**
+ * Track a hover on a map listing: on desktop the cursor rested on it for
+ * 500 ms, on mobile the first tap that opened its tooltip. First-party beacon
+ * only — no Matomo event, since hovers are a dashboard-only signal. `source`
+ * is always 'map': hovers can only happen on the map surface, never on cards.
+ * `area` is the listing's first category (stamped on the Map page only).
+ * Opt-out isn't checked here — sendTrackEvent already does that itself.
+ */
+export function trackListingHover(
+  page: string,
+  name: string,
+  url?: string,
+  listingId?: string,
+  area?: string
+): void {
+  if (typeof window === 'undefined') return
+  sendTrackEvent({
+    type: 'listing_hover',
+    page,
+    label: name,
+    url,
+    listingId,
+    area,
+    source: 'map',
   })
 }
 

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -46,6 +46,9 @@ export interface AnalyticsEvent {
    *  ('button' | 'cmd-k' | 'slash'); on search_query, the active type filter;
    *  on search_click, the clicked result's type ('job', 'funder', …). */
   source?: string
+  /** The map-area dimension — the listing's first category, stamped on
+   *  Map-page clicks and hovers so the dashboard can slice the map by area. */
+  area?: string
   /** Site-search events: the query text as typed — the subject of a
    *  search_query, and on a search_click the query that produced the result. */
   query?: string
@@ -68,6 +71,9 @@ export interface AnalyticsEvent {
 export const ALLOWED_EVENT_TYPES = new Set<string>([
   'page_view',
   'listing_click',
+  // A visitor resting on a map listing (Map, Communities): a 500 ms cursor
+  // dwell on desktop, or the tap that opens the tooltip on mobile.
+  'listing_hover',
   'chatbot_open',
   'chatbot_message',
   'chatbot_click',
@@ -264,6 +270,12 @@ export interface ListingRow extends Counted {
   /** A representative destination url (most recent click) — lets the dashboard
    *  show a favicon for pages whose listings have no Airtable logo. */
   url?: string
+  /** Airtable record id, from the most recent event in range that carried one
+   *  — the stable join key back to the source record. */
+  listingId?: string
+  /** The listing's first category (the map-area dimension), from the most
+   *  recent event in range that carried one. Map-page rows only. */
+  area?: string
 }
 
 export interface OverallListingRow extends Counted {
@@ -389,6 +401,18 @@ export interface DashboardData {
   /** The source the per-listing panels are filtered to ('map' | 'cards' |
    *  'untracked'), or null for all sources. Only ever set on map pages. */
   selectedSource: string | null
+  /** For pages with a map (Map, Communities): `selectedPage`'s most-hovered
+   *  map listings — tooltip dwells (500 ms cursor rest on desktop, first tap
+   *  on mobile), grouped like `topListings` and following the same unique/
+   *  total count mode. Never narrowed by `selectedSource` (every hover is by
+   *  definition from the map). Empty for pages without a map. */
+  topHovered: ListingRow[]
+  /** The Map tab's by-area rollup input: the page's clicks per listing with
+   *  the `selectedSource` filter ignored, so the rollup's click column shares
+   *  a basis with `topHovered` (which is never source-narrowed). Same rows as
+   *  `topListings` when no source is selected. Empty for every page but Map —
+   *  only the Map page has areas. */
+  areaClicks: ListingRow[]
   funnel: ChatbotFunnel
   /** The Chatbot tab's event-derived panels (opens and reply clicks). */
   chatbot: ChatbotPanelData
@@ -404,8 +428,8 @@ export interface DashboardData {
   /** Cross-interest overlaps between pages (and the chatbot), from anonymous
    *  visitor ids: pairs ranked by how many visitors engaged with both. */
   correlations: CorrelationRow[]
-  /** Recent clicks and chatbot/search events — page views are excluded so the
-   *  feed stays an activity log rather than a firehose. */
+  /** Recent clicks and chatbot/search events — page views and map hovers are
+   *  excluded so the feed stays an activity log rather than a firehose. */
   recent: AnalyticsEvent[]
   /** Timestamp of the oldest event in the WHOLE store (not just the selected
    *  range) — lets the dashboard say how far back its data actually goes.
@@ -428,6 +452,8 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   byPositionOverall: [],
   bySource: [],
   selectedSource: null,
+  topHovered: [],
+  areaClicks: [],
   funnel: { opened: 0, typed: 0, clicked: 0 },
   chatbot: { opensByPage: [], destinations: [] },
   search: {
@@ -497,8 +523,10 @@ function tallyPositions(positions: string[]): Counted[] {
     .sort((a, b) => positionSortKey(a.name) - positionSortKey(b.name))
 }
 
-/** Collapse repeat clicks so a visitor counts once per listing per day: keep
- *  only the most recent click per (visitor, day, page, listing). The day uses
+/** Collapse repeat events so a visitor counts once per listing per day: keep
+ *  only the most recent event per (visitor, day, page, listing). Used for
+ *  listing clicks, and by topHovered for map hovers — same key, same
+ *  semantics, and the two types are always deduped separately. The day uses
  *  Bryce's timezone (UTC-5), matching the date-range bounds. Clicks with no id
  *  (e.g. private browsing, where we can't tell visitors apart) are each kept.
  *  Expects a newest-first list, so the first time a key is seen is the most
@@ -521,6 +549,50 @@ function uniqueClicks(clicks: AnalyticsEvent[]): AnalyticsEvent[] {
     out.push(e)
   }
   return out
+}
+
+/** Group events into one row per listing, ranked by count: the range of slots
+ *  it was hit at (from positions stamped at event time — hover events carry
+ *  none, so their rows get no slot) plus a representative url/id/area. Expects
+ *  a newest-first list, so the first url/id/area seen for a listing is the
+ *  most recent — older events only fill fields still missing. */
+function listingRows(events: AnalyticsEvent[]): ListingRow[] {
+  const perListing = new Map<
+    string,
+    {
+      count: number
+      positions: string[]
+      url?: string
+      listingId?: string
+      area?: string
+    }
+  >()
+  for (const e of events) {
+    const k = listingMember(e)
+    const g = perListing.get(k) ?? {
+      count: 0,
+      positions: [],
+      url: e.url,
+      listingId: e.listingId,
+      area: e.area,
+    }
+    g.count += 1
+    if (e.position) g.positions.push(e.position)
+    if (!g.url && e.url) g.url = e.url
+    if (!g.listingId && e.listingId) g.listingId = e.listingId
+    if (!g.area && e.area) g.area = e.area
+    perListing.set(k, g)
+  }
+  return [...perListing.entries()]
+    .map(([name, g]) => ({
+      name,
+      count: g.count,
+      position: positionRange(g.positions),
+      url: g.url,
+      listingId: g.listingId,
+      area: g.area,
+    }))
+    .sort((a, b) => b.count - a.count)
 }
 
 /** Aggregate a newest-first event list into the dashboard view, filtered to the
@@ -581,32 +653,12 @@ function aggregate(
   // For the selected page: total clicks per listing, the range of slots each was
   // clicked at (from positions stamped at click time, so it's period-accurate
   // even as the page is reordered), and a representative url for its favicon.
-  const pageClicksAll = clicks.filter(e => e.page === selectedPage)
-  const pageClicks = pageClicksAll.filter(matchesSource)
-  const perListing = new Map<
-    string,
-    { count: number; positions: string[]; url?: string }
-  >()
-  for (const e of pageClicks) {
-    // pageClicks is newest-first, so the first url we see is the most recent.
-    const k = listingMember(e)
-    const g = perListing.get(k) ?? { count: 0, positions: [], url: e.url }
-    g.count += 1
-    if (e.position) g.positions.push(e.position)
-    if (!g.url && e.url) g.url = e.url
-    perListing.set(k, g)
-  }
   // Every listing for the page, ranked by clicks — the dashboard shows the first
   // 50 and lets the user reveal more, so we return the full list rather than a
   // fixed top-N here.
-  const topListings: ListingRow[] = [...perListing.entries()]
-    .map(([name, g]) => ({
-      name,
-      count: g.count,
-      position: positionRange(g.positions),
-      url: g.url,
-    }))
-    .sort((a, b) => b.count - a.count)
+  const pageClicksAll = clicks.filter(e => e.page === selectedPage)
+  const pageClicks = pageClicksAll.filter(matchesSource)
+  const topListings: ListingRow[] = listingRows(pageClicks)
 
   // Site-wide leaderboards, independent of the selected page: the most-clicked
   // listings and the busiest slots across every page. Keyed by page+listing so
@@ -658,6 +710,34 @@ function aggregate(
     ].filter(r => r.count > 0)
   }
 
+  // Most-hovered map listings for the selected page — tooltip dwells
+  // (listing_hover events), grouped exactly like topListings but with no
+  // position (hovers aren't slotted) and no source narrowing (every hover is
+  // by definition from the map, so the ?source filter would be a no-op at
+  // best and confusing at worst). Follows the unique/total count mode via the
+  // same per-visitor-per-day dedupe as clicks. Map pages only — no other page
+  // emits hover events.
+  let topHovered: ListingRow[] = []
+  if (isMapPage) {
+    const hoverHits = inRange.filter(e => e.type === 'listing_hover' && e.page)
+    const hovers = (unique ? uniqueClicks(hoverHits) : hoverHits).filter(
+      e => e.page === selectedPage
+    )
+    topHovered = listingRows(hovers)
+  }
+
+  // The Map tab's by-area rollup compares clicks against hovers per area, and
+  // topHovered is never source-narrowed — so its click side must ignore the
+  // ?source filter too, or the two columns quietly stop sharing a basis the
+  // moment a source is selected. Same rows as topListings when no source is
+  // selected; empty on every other page (only the Map page has areas).
+  const areaClicks: ListingRow[] =
+    selectedPage === 'Map'
+      ? selectedSource
+        ? listingRows(pageClicksAll)
+        : topListings
+      : []
+
   return {
     totalEvents: inRange.length,
     byPage,
@@ -670,6 +750,8 @@ function aggregate(
     byPositionOverall,
     bySource,
     selectedSource,
+    topHovered,
+    areaClicks,
     funnel: {
       opened: usersOf('chatbot_open'),
       typed: usersOf('chatbot_message'),
@@ -680,9 +762,12 @@ function aggregate(
     optOuts: optOutSplit(inRange),
     visits: visitsData(inRange, unique),
     correlations: correlations(inRange),
-    // Newest-first already; page views are left out so the feed stays a log
-    // of actions rather than a firehose of visits.
-    recent: inRange.filter(e => e.type !== 'page_view').slice(0, 50),
+    // Newest-first already; page views and map hovers are left out so the
+    // feed stays a log of deliberate actions rather than a firehose of visits
+    // and passing cursors.
+    recent: inRange
+      .filter(e => e.type !== 'page_view' && e.type !== 'listing_hover')
+      .slice(0, 50),
   }
 }
 


### PR DESCRIPTION
- Records a hover when the cursor rests on a /map or /communities map listing for half a second – or, on a phone, when a tap opens its tooltip. Repeat taps on an already-open pin don't double-count, and a cursor merely passing over a pin records nothing.
- New admin dashboard panels: "Top hovered listings" on the Field map and Communities tabs, plus "Clicks by area" and "Hovers by area" on the Field map tab. Areas are each listing's first category; clicks recorded before areas were tracked are matched against the current map records (by id, then name, then link), with unmatched rows shown as "No longer listed". All new panels respect the date range and the Unique/Total toggle.
- Map-page clicks now stamp the listing's area at click time, so the area panels stay accurate even after listings are renamed or removed.
- Clicks now carry the Airtable record id everywhere it was missing: the /communities map (both tap paths), the /map mobile tooltip, and the featured F1/F2 cards on Funding, Communities, Advisors, Projects, Self-study, Media channels, and Founders.
- Panel titles drop the page name the active tab already shows ("Top Field map listings" → "Top listings", "Most clicked listings overall" → "Most clicked listings", "Clicks by map area" → "Clicks by area").
- Hovers are excluded from the Recent activity feed and from every click table, funnel, and correlation; the ingest endpoint accepts the new event type with the same field length caps and rate limits as before.

Verified on localhost with a real browser: dwell hovers record (short brushes don't), both maps send record ids, featured-card clicks carry ids, and all panels render with live data. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)