### PR TITLE
ESC key resets map zoom on /map and /communities

### DIFF
--- a/src/app/communities/CommunitiesMap.tsx
+++ b/src/app/communities/CommunitiesMap.tsx
@@ -107,6 +107,17 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
     const resizeObserver = new ResizeObserver(() => map.resize())
     resizeObserver.observe(mapContainer)
 
+    const resetMapView = () => {
+      map.flyTo({
+        center: initialCenter,
+        zoom: initialZoom,
+        bearing: 0,
+        pitch: 0,
+        duration: 500,
+        essential: true,
+      })
+    }
+
     // Repurpose Mapbox's compass button as a "reset map view" button.
     // addControl synchronously inserts the compass into the DOM, so this
     // runs reliably without depending on the map 'load' event or pin image
@@ -131,14 +142,7 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
         ev => {
           ev.preventDefault()
           ev.stopPropagation()
-          map.flyTo({
-            center: initialCenter,
-            zoom: initialZoom,
-            bearing: 0,
-            pitch: 0,
-            duration: 500,
-            essential: true,
-          })
+          resetMapView()
         },
         true
       )
@@ -527,8 +531,24 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
         }
       }
 
+      // ESC resets the view, same as the reset button. Skip while typing in
+      // a form field — ESC there shouldn't yank the map.
+      const handleEscKey = function (e: KeyboardEvent) {
+        if (e.key !== 'Escape') return
+        const target = e.target as HTMLElement | null
+        if (
+          target &&
+          (target.tagName === 'INPUT' ||
+            target.tagName === 'TEXTAREA' ||
+            target.isContentEditable)
+        )
+          return
+        resetMapView()
+      }
+
       tooltip.addEventListener('click', handleTooltipClick)
       document.addEventListener('click', handleDocumentClick)
+      document.addEventListener('keydown', handleEscKey)
 
       // Store cleanup function for useEffect teardown
       cleanupRef.current = () => {
@@ -536,6 +556,7 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
         cancelHoverTimer()
         tooltip.removeEventListener('click', handleTooltipClick)
         document.removeEventListener('click', handleDocumentClick)
+        document.removeEventListener('keydown', handleEscKey)
         resizeObserver.disconnect()
       }
     })

--- a/src/app/map/D3Map.tsx
+++ b/src/app/map/D3Map.tsx
@@ -497,11 +497,28 @@ export default function D3Map({ orgs }: D3MapProps) {
         svg.transition().duration(300).call(zoom.scaleBy, 0.75)
       }
     }
-    if (recenter) {
-      recenter.onclick = () => {
-        svg.transition().duration(500).call(zoom.transform, d3.zoomIdentity)
-      }
+    const resetView = () => {
+      svg.transition().duration(500).call(zoom.transform, d3.zoomIdentity)
     }
+    if (recenter) {
+      recenter.onclick = resetView
+    }
+
+    // ESC resets the view, same as the recenter button. Skip while typing in
+    // a form field — ESC there shouldn't yank the map.
+    const handleEscKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      const target = e.target as HTMLElement | null
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      )
+        return
+      resetView()
+    }
+    document.addEventListener('keydown', handleEscKey)
 
     // Mobile: tapping the tooltip opens the stashed link in a new tab.
     const handleTooltipClick = (e: MouseEvent) => {
@@ -548,6 +565,7 @@ export default function D3Map({ orgs }: D3MapProps) {
       svgNode.removeEventListener('wheel', preventPageZoom)
       if (tooltipEl) tooltipEl.removeEventListener('click', handleTooltipClick)
       document.removeEventListener('click', handleDocumentClick)
+      document.removeEventListener('keydown', handleEscKey)
       if (container) {
         d3.select(container).select('svg').remove()
       }


### PR DESCRIPTION
- Pressing Escape now resets the map view on /map and /communities, identical to clicking the reset-view button.
- Ignored while typing in a form field, so ESC in a text input doesn't move the map.
- Verified in a headless browser: both maps return to their exact initial view after zooming in and pressing ESC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)