### PR TITLE
Cmd/Ctrl+Enter opens search results in a new tab

### DIFF
--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -173,7 +173,20 @@ export default function SearchModal({
             `[data-result-index="${activeIndexRef.current}"]`
           )
           if (link) {
-            link.click()
+            if (e.metaKey || e.ctrlKey) {
+              // Cmd/Ctrl+Enter opens the result in a new tab. Borrow
+              // target=_blank on the real anchor for this one click so it
+              // stays an ad-blocker-safe anchor click (see note above).
+              const prevTarget = link.target
+              const prevRel = link.rel
+              link.target = '_blank'
+              link.rel = 'noopener noreferrer'
+              link.click()
+              link.target = prevTarget
+              link.rel = prevRel
+            } else {
+              link.click()
+            }
           } else {
             window.location.href = target.url
           }


### PR DESCRIPTION
- Pressing Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) on the highlighted search result opens it in a new tab, leaving the current page in place.
- Plain Enter is unchanged: internal results open in the same tab, external results in a new tab.
- Implemented by temporarily borrowing `target="_blank"` on the rendered anchor for that one click, keeping the existing ad-blocker-safe anchor-click approach; the attribute is restored immediately after.
- Verified in a headless browser across all four combinations (Cmd/Ctrl+Enter and plain Enter, on internal and external results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)