### PR TITLE
Refresh chatbot data as soon as Airtable changes

### DIFF
--- a/src/app/api/check-rebuild/route.ts
+++ b/src/app/api/check-rebuild/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { revalidateTag } from 'next/cache'
 import { fetchAirtableWithRetry } from '@/lib/data/airtable'
 
 // Force dynamic - this endpoint must run fresh on every cron invocation
@@ -158,6 +159,15 @@ export async function GET(request: Request) {
       changedTables: [],
     })
   }
+
+  // Static pages get fresh data from the rebuild below, but runtime consumers
+  // (assistant catalog, search index) read the shared data cache, which a
+  // rebuild does not clear. Invalidate it here so they refetch on their next
+  // request. Runs before the hook cooldowns on purpose: even when a rebuild
+  // can't be triggered yet, runtime data should not stay stale. 'max' =
+  // stale-while-revalidate; the cron re-fires every minute until the rebuild
+  // lands, so the background refresh converges within a couple of requests.
+  revalidateTag('airtable-records', 'max')
 
   const now = Date.now()
 

--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -416,5 +416,9 @@ async function fetchAirtableRecordsImpl(
 export const fetchAirtableRecords = unstable_cache(
   fetchAirtableRecordsImpl,
   ['airtable-records', 'v2'],
-  { revalidate: 3600 }
+  // The tag lets /api/check-rebuild invalidate these entries the minute an
+  // Airtable change is detected, so runtime consumers (assistant catalog,
+  // search index) don't wait out the hourly revalidate that static pages
+  // bypass via rebuilds.
+  { revalidate: 3600, tags: ['airtable-records'] }
 )


### PR DESCRIPTION
- The chatbot and search index read Airtable through a shared runtime data cache that only refreshed hourly, so the bot could tell users a listing doesn't exist while the site pages (rebuilt within ~2-3 min) already showed it. Seen today with the Torchbearer Community map record.
- Tags the `fetchAirtableRecords` cache (`airtable-records`) and has `/api/check-rebuild` invalidate that tag the minute it detects an Airtable change, using Next 16's `revalidateTag(tag, 'max')` stale-while-revalidate mode.
- The invalidation runs before the deploy-hook cooldown checks, so runtime data stays fresh even if the deploy hook is rate-limited or broken.
- Net effect: the bot now lags an Airtable edit by ~1-6 minutes (1-min cron + its 5-min in-memory catalog snapshot) instead of up to ~65 minutes.
- Verification after deploy: edit a published record's visible field in Airtable, then ask the chatbot about it a few minutes later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)