### PR TITLE
Training: featured tag shows the program type, not 'program'

### DIFF
--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -466,10 +466,9 @@ export default function TrainingClient({
               className="width-6-col"
               href={program.url !== '#' ? program.url : undefined}
               tagline={
-                program.featuredTagline ??
-                (program.type[0]
+                program.type[0]
                   ? `Featured ${program.type[0].toLowerCase()}`
-                  : 'Featured program')
+                  : 'Featured program'
               }
               name={program.name}
               description={program.description}


### PR DESCRIPTION
On `/training`, the featured cards for MATS Summer 2026 and the Anthropic AI Safety Fellows Program showed **"Featured program"** instead of the specific type.

Cause: the tag used `program.featuredTagline ?? "Featured " + type`, and the Airtable **Featured tagline** field is set to a generic "Featured program" for those rows, which overrode the type.

Fix: derive the tag from the program **type** (dropping the `featuredTagline` precedence), matching how `/events` builds its featured tag. Now reads "Featured fellowship", "Featured bootcamp", etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)