### PR TITLE
Training: constrain the filter bar to the listing (9-col) width

### DIFF
--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -496,7 +496,7 @@ export default function TrainingClient({
       <FilterBar
         count={filtered.length}
         noun="program"
-        className={styles.filterBar}
+        className={`width-9-col ${styles.filterBar}`}
         label={`${filtered.length} ${mode} training program${
           filtered.length === 1 ? '' : 's'
         }`}


### PR DESCRIPTION
Constrains the `/training` filter bar to `width-9-col` — the same width as the listing-cards section it filters — instead of spanning the full container.

**Tradeoff (flagging for a design call):** it feels more intuitive to have the filters not cross past the 9-column layout of the filtered list. But with this many filters (7 dropdowns), a constrained bar doesn't look great either — they wrap into multiple rows. So neither option is clearly better; opening this so we can compare and decide (likely one for Melissa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)