### PR TITLE
Track AI chatbot visits in Matomo

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,52 @@
+import type { NextFetchEvent, NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+// AI assistants (ChatGPT, Claude, Perplexity, ...) fetch pages without running
+// JavaScript, so the Matomo snippet in layout.tsx never sees them. They do
+// identify themselves in the User-Agent header, though — this proxy runs on
+// every page request, spots those signatures, and reports the hit server-side
+// via Matomo's HTTP Tracking API. recMode=1 files the hit under Matomo's
+// separate "AI Chatbots" report; it never counts as a human visit or session.
+//
+// Covers the assistants' live fetchers (ChatGPT-User, Claude-User,
+// Perplexity-User, ...) and their crawlers (GPTBot, ClaudeBot, CCBot, ...).
+// Matomo classifies and names the bot from the raw User-Agent we pass along,
+// so new variants from these families need no changes here.
+const AI_BOT_UA =
+  /GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|Claude-User|Claude-SearchBot|Claude-Web|anthropic-ai|PerplexityBot|Perplexity-User|Google-Extended|Google-CloudVertexBot|Meta-ExternalAgent|Meta-ExternalFetcher|Amazonbot|Applebot-Extended|Bytespider|CCBot|cohere-ai|DuckAssistBot|YouBot|MistralAI-User|AI2Bot|Diffbot/i
+
+const MATOMO_ENDPOINT = 'https://aisafety.matomo.cloud/matomo.php'
+const MATOMO_SITE_ID = '1'
+
+export function proxy(request: NextRequest, event: NextFetchEvent) {
+  const ua = request.headers.get('user-agent') ?? ''
+
+  if (request.method === 'GET' && AI_BOT_UA.test(ua)) {
+    const hit = new URL(MATOMO_ENDPOINT)
+    hit.searchParams.set('idsite', MATOMO_SITE_ID)
+    hit.searchParams.set('rec', '1')
+    hit.searchParams.set('recMode', '1')
+    hit.searchParams.set('ua', ua)
+    hit.searchParams.set('url', request.nextUrl.href)
+
+    // Only the real site reports to Matomo — preview deploys and localhost
+    // would otherwise pollute the report with test hits.
+    const host = request.nextUrl.hostname
+    if (host === 'aisafety.com' || host === 'www.aisafety.com') {
+      // waitUntil: the ping happens after the response is sent, so bots (and
+      // humans, if a bot UA ever overlaps) are never slowed down. Failures are
+      // swallowed — analytics must never break a page.
+      event.waitUntil(fetch(hit).catch(() => {}))
+    } else if (process.env.NODE_ENV === 'development') {
+      console.log(`[ai-bot-tracking] would send: ${hit}`)
+    }
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  // Page routes only: skip API routes, Next.js internals/assets, the internal
+  // admin area, and anything with a file extension (favicon, sitemap, images).
+  matcher: ['/((?!api|_next|admin|.*\\..*).*)'],
+}


### PR DESCRIPTION
- AI assistants (ChatGPT, Claude, Perplexity, and others) fetch pages without running JavaScript, so the Matomo snippet in `layout.tsx` never sees them. This adds a `proxy.ts` (Next.js 16's middleware) that recognizes their User-Agent signatures on page requests and reports each hit server-side through Matomo's HTTP Tracking API.
- Hits are sent with `recMode=1`, which Matomo files under its dedicated "AI Chatbots" report – they never count as human visits, sessions, or attribution data, so regular traffic numbers are unaffected.
- Covers both the assistants' live fetchers (ChatGPT-User, Claude-User, Perplexity-User, DuckAssistBot, MistralAI-User) and their crawlers (GPTBot, ClaudeBot, PerplexityBot, CCBot, Bytespider, Amazonbot, Meta-ExternalAgent, and more). Matomo names the bot from the raw User-Agent, so no per-bot handling is needed here.
- Only `aisafety.com` / `www.aisafety.com` report to Matomo. Preview deploys stay silent, and localhost logs the would-be tracking request to the dev console instead – that's also how this was verified.
- The ping is fired after the response is sent (`event.waitUntil`), so pages are never slowed down, and failures are swallowed. API routes, `/admin`, assets, and non-GET requests are excluded via the matcher.
- Note: adding a proxy means every matched page request now runs a (very small) function before Vercel serves the page. That's inherent to this tracking method, since these bots can only be seen server-side.

Verified locally: requests with GPTBot / Claude-User / PerplexityBot user agents on `/`, `/funding`, and `/jobs` each produced a correctly-formed Matomo hit (`idsite=1&rec=1&recMode=1` plus the bot's User-Agent and page URL); a normal Chrome user agent, a bot hitting `/api/*`, and a bot fetching `robots.txt` produced none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)