### PR TITLE
Chatbot and analytics theme grouping: upgrade to Claude Opus 5

### DIFF
--- a/src/lib/analytics/themes.ts
+++ b/src/lib/analytics/themes.ts
@@ -13,6 +13,7 @@ import Anthropic from '@anthropic-ai/sdk'
 import { Redis } from '@upstash/redis'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { DEFAULT_MODEL_ID } from '@/lib/assistant/models'
 import { listTypedQuestions } from './conversations'
 
 export interface QuestionTheme {
@@ -70,7 +71,9 @@ async function storeSummary(summary: ThemeSummary): Promise<void> {
 
 // The latest Opus — Bryce wants the best grouping quality, and a weekly call
 // over a few hundred short questions costs cents even on the top model.
-const MODEL = 'claude-opus-4-8'
+// Anthropic offers no auto-updating "latest Opus" alias, so this tracks the
+// chatbot's default model (kept on the newest Opus): one bump upgrades both.
+const MODEL = DEFAULT_MODEL_ID
 // Far above organic volume (~130 conversations in month one). If the log ever
 // outgrows it, the newest questions win and the truncation is logged.
 const MAX_QUESTIONS = 800
@@ -115,7 +118,10 @@ Reply with ONLY this JSON, no other text:
 
   const response = await client.messages.create({
     model: MODEL,
-    max_tokens: 4000,
+    // Opus 5 thinks before answering out of this same budget, and the JSON
+    // for 800 questions is a few thousand tokens on its own — 4000 risked a
+    // truncated reply that would fail the JSON parse.
+    max_tokens: 16000,
     messages: [{ role: 'user', content: prompt }],
   })
   const text = response.content

--- a/src/lib/assistant/models.ts
+++ b/src/lib/assistant/models.ts
@@ -27,11 +27,16 @@ export const MODELS: AssistantModel[] = [
   {
     id: 'claude-opus-4-8',
     shortLabel: 'Opus 4.8',
-    longLabel: 'Opus 4.8 — most capable',
+    longLabel: 'Opus 4.8',
+  },
+  {
+    id: 'claude-opus-5',
+    shortLabel: 'Opus 5',
+    longLabel: 'Opus 5 — most capable',
   },
 ]
 
-export const DEFAULT_MODEL_ID = 'claude-opus-4-8'
+export const DEFAULT_MODEL_ID = 'claude-opus-5'
 
 export function modelShortLabel(id: string): string {
   return MODELS.find(m => m.id === id)?.shortLabel ?? id

--- a/src/lib/assistant/stream.ts
+++ b/src/lib/assistant/stream.ts
@@ -217,6 +217,13 @@ export async function runAssistantStream(
       {
         model,
         max_tokens: MAX_TOKENS,
+        // Opus 5 turns API-level thinking ON when this field is omitted
+        // (earlier models defaulted to off). The assistant does its reasoning
+        // in visible text ending with the [[/thinking]] marker, and this loop
+        // only reconstructs text/tool_use blocks — API thinking blocks would
+        // be dropped from the echoed assistant turn, breaking tool rounds. So
+        // keep it explicitly off.
+        thinking: { type: 'disabled' },
         system: [
           { type: 'text', text: systemPrompt },
           { type: 'text', text: pagesBlock },


### PR DESCRIPTION
- Makes `claude-opus-5` the chatbot's production model and adds it to the admin playground picker (Opus 4.8 remains selectable)
- Explicitly disables API-level thinking in the chatbot's request: Opus 5 turns it on when the field is omitted, which would break the tool loop (thinking blocks are not echoed back) and conflict with the assistant's own `[[/thinking]]` text-marker architecture
- Points the analytics question-theme job at the chatbot's model constant (`DEFAULT_MODEL_ID`) so future model bumps upgrade both in one place
- Raises the theme job's `max_tokens` from 4000 to 16000 — on Opus 5, thinking spends from the same budget, and the themes JSON alone can run a few thousand tokens

Verified on localhost: build passes; chatbot answers, runs searches, and renders cards cleanly on Opus 5; prompt caching confirmed working (~35K tokens read per round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)