### PR TITLE
Events: recognize the Other type with a teal pill matching /training

### DIFF
--- a/src/lib/event-types.ts
+++ b/src/lib/event-types.ts
@@ -5,6 +5,7 @@ export const EVENT_TYPES = [
   'Meetup',
   'Talk',
   'Workshop',
+  'Other',
 ] as const
 
 export type EventType = (typeof EVENT_TYPES)[number]
@@ -16,6 +17,7 @@ const EVENT_TYPE_COLOR: Record<string, string> = {
   Meetup: 'color-blue',
   Hackathon: 'color-purple',
   Competition: 'color-yellow',
+  Other: 'color-teal-300',
 }
 
 export function eventTypeColor(type: string): string {


### PR DESCRIPTION
- Adds "Other" to the recognized Events type list, matching the new option on the Airtable Events table – without this, an event typed "Other" would lose its type on read (no pill) and the Type filter would never offer it.
- Pill color is `color-teal-300`, the same class /training uses for its "Other" pill, so the two pages match.
- Verified on localhost with mock data: pill renders teal, "Other" shows in the Event type dropdown with a working count, `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)