### PR TITLE
check-rebuild: watch the new Events and Training tables

### DIFF
--- a/src/app/api/check-rebuild/route.ts
+++ b/src/app/api/check-rebuild/route.ts
@@ -50,7 +50,21 @@ const TABLES: Array<{
     tableId: 'tbl59Ye8oxvPjoVJv',
     filter: '{fld9Epdrxu9n0FV20} = TRUE()', // Publish?
   },
-  { name: 'events', tableId: 'tblx0L8qJEaLBxJFS' },
+  {
+    name: 'events',
+    tableId: 'tblXbN9swwldwq8f7',
+    filter: '{flddgpgNm090Uftsq} = TRUE()', // Publish?
+  },
+  {
+    name: 'training',
+    tableId: 'tbli1YSCpIuNY2DvL',
+    filter: '{fldqlN36P6BVFP151} = TRUE()', // Publish?
+  },
+  {
+    name: 'recurring-training',
+    tableId: 'tblEEIbj6dW5oS4cX',
+    filter: '{fldpjcvh7n6w4cIsi} = TRUE()', // Publish?
+  },
 ]
 
 // Module-level cooldowns prevent hammering the Vercel deploy hook. The hook is


### PR DESCRIPTION
- The auto-rebuild watcher (`/api/check-rebuild`) still monitored the legacy combined events table (`tblx0L8qJEaLBxJFS`), so Airtable edits to the tables the redesigned /events and /training pages actually display would not have triggered fast rebuilds after launch – changes would have waited on the hourly cache instead of going live in ~2–3 minutes.
- Replaces the legacy entry with the three new tables: Events (`tblXbN9swwldwq8f7`), Training (`tbli1YSCpIuNY2DvL`), and Recurring training (`tblEEIbj6dW5oS4cX`).
- Each entry filters to published records via the table's permanent `Publish?` field ID, matching the pattern used by the other watched tables, so edits to unpublished records don't cause unnecessary rebuilds.
- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)