### PR TITLE
Point "View data in Airtable" at the new Events/Training share views

### DIFF
--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -21,14 +21,12 @@ import { EVENT_TYPES, eventTypeColor } from '@/lib/event-types'
 import type { EventListing } from '@/lib/data/events'
 import styles from './page.module.css'
 
-// TODO(bryce): swap the share view for an Events-table one before launch —
-// it still points at the events/legacy share.
 const ADD_EVENT_URL =
   'https://airtable.com/appF8XfZUGXtfi40E/pagns0zQqcM713eKk/form'
 const SUGGEST_CORRECTION_URL =
   'https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form'
 const AIRTABLE_VIEW_URL =
-  'https://airtable.com/appF8XfZUGXtfi40E/shrLgl03tMK4q6cyc/tblx0L8qJEaLBxJFS?viewControls=on'
+  'https://airtable.com/appF8XfZUGXtfi40E/shrteEg2cClc3x484/tblXbN9swwldwq8f7?viewControls=on'
 
 const applicationOptions = ['Open', 'Closed']
 // Cards show the full Airtable Cost value ("Pay to attend (assistance

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -31,8 +31,6 @@ import type {
 
 // Each tab links to its own add form and share view; the correction form is
 // the sitewide one.
-// TODO(bryce): swap the share views for Training/Recurring-table ones before
-// launch — they still point at the events/legacy share.
 const ADD_PROGRAM_URLS: Record<Mode, string> = {
   upcoming: 'https://airtable.com/appF8XfZUGXtfi40E/pagSB4ucUn38CvXFD/form',
   recurring: 'https://airtable.com/appF8XfZUGXtfi40E/pagMXYNesOJse9Ga0/form',
@@ -41,9 +39,9 @@ const SUGGEST_CORRECTION_URL =
   'https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form'
 const AIRTABLE_VIEW_URLS: Record<Mode, string> = {
   upcoming:
-    'https://airtable.com/appF8XfZUGXtfi40E/shrLgl03tMK4q6cyc/tblx0L8qJEaLBxJFS?viewControls=on',
+    'https://airtable.com/appF8XfZUGXtfi40E/shrripC3ZUNDHqZkU/tbli1YSCpIuNY2DvL?viewControls=on',
   recurring:
-    'https://airtable.com/appF8XfZUGXtfi40E/shrLgl03tMK4q6cyc/tblx0L8qJEaLBxJFS?viewControls=on',
+    'https://airtable.com/appF8XfZUGXtfi40E/shrjEwxwchrKPvnDO/tblEEIbj6dW5oS4cX?viewControls=on',
 }
 
 const applicationOptions = ['Open', 'Closed']


### PR DESCRIPTION
- Points the three "View data in Airtable" sidebar buttons at public share views of the new tables: /events → Events table, /training Upcoming → Training table, /training Recurring → Training (recurring) table. All three were still linking the legacy Events & training share.
- The new share views mirror the /map setup: only published, non-hidden records; internal fields (Publish?, Hide?, Internal notes, Submitter's email, Newsletter, Featured) are hidden.
- Removes the two pre-launch TODO comments that tracked this swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)