### PR TITLE
Search results: remove /training org subtitle, reformat dates

### DIFF
--- a/src/lib/data/search-index.ts
+++ b/src/lib/data/search-index.ts
@@ -187,7 +187,9 @@ async function getTrainingEntries(): Promise<SearchEntry[]> {
     entries.push({
       type: 'training',
       title: p.name,
-      subtitle: p.host,
+      // Host isn't shown on /training and isn't maintained, so don't
+      // display or match on it.
+      subtitle: '',
       description: p.description,
       category: [
         p.startDateApprox || dateRange(p.startDate, p.endDate),
@@ -207,7 +209,7 @@ async function getTrainingEntries(): Promise<SearchEntry[]> {
     entries.push({
       type: 'training',
       title: p.name,
-      subtitle: p.host,
+      subtitle: '',
       description: p.description,
       category: ['Recurring', p.type.join(', '), p.location || p.mode]
         .filter(Boolean)

--- a/src/lib/data/search-index.ts
+++ b/src/lib/data/search-index.ts
@@ -153,11 +153,11 @@ const SHORT_MONTHS = [
   'DEC',
 ]
 
-// "2026-09-28" -> "2026-SEP-28"
+// "2026-09-28" -> "28-SEP-2026"
 function shortDate(iso: string): string {
   const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso)
   if (!m) throw new Error(`Unexpected date format in search index: "${iso}"`)
-  return `${m[1]}-${SHORT_MONTHS[Number(m[2]) - 1]}-${Number(m[3])}`
+  return `${Number(m[3])}-${SHORT_MONTHS[Number(m[2]) - 1]}-${m[1]}`
 }
 
 function dateRange(start: string | null, end: string | null): string {

--- a/src/lib/data/search-index.ts
+++ b/src/lib/data/search-index.ts
@@ -138,9 +138,33 @@ function faviconFor(url: string): string | null {
   return `https://www.google.com/s2/favicons?domain=${new URL(url).hostname}&sz=64`
 }
 
+const SHORT_MONTHS = [
+  'JAN',
+  'FEB',
+  'MAR',
+  'APR',
+  'MAY',
+  'JUN',
+  'JUL',
+  'AUG',
+  'SEP',
+  'OCT',
+  'NOV',
+  'DEC',
+]
+
+// "2026-09-28" -> "2026-SEP-28"
+function shortDate(iso: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso)
+  if (!m) throw new Error(`Unexpected date format in search index: "${iso}"`)
+  return `${m[1]}-${SHORT_MONTHS[Number(m[2]) - 1]}-${Number(m[3])}`
+}
+
 function dateRange(start: string | null, end: string | null): string {
   if (!start) return ''
-  return end && end !== start ? `${start} – ${end}` : start
+  return end && end !== start
+    ? `${shortDate(start)} – ${shortDate(end)}`
+    : shortDate(start)
 }
 
 async function getEventEntries(): Promise<SearchEntry[]> {
@@ -149,7 +173,7 @@ async function getEventEntries(): Promise<SearchEntry[]> {
     const url = realUrl(e.url)
     const deadline =
       e.applicationStatus === 'Open' && e.deadlineType && e.applicationsClose
-        ? `${e.deadlineType} by ${e.applicationsClose}`
+        ? `${e.deadlineType} by ${shortDate(e.applicationsClose)}`
         : ''
     return {
       type: 'event' as const,
@@ -182,7 +206,7 @@ async function getTrainingEntries(): Promise<SearchEntry[]> {
     const applications = p.notYetOpen
       ? 'Applications not yet open'
       : p.applicationStatus === 'Open' && p.applicationsClose
-        ? `Apply by ${p.applicationsClose}`
+        ? `Apply by ${shortDate(p.applicationsClose)}`
         : ''
     entries.push({
       type: 'training',


### PR DESCRIPTION
- Search results for training programs no longer show the Host org (the teal subtitle line, e.g. "MATS Research") – the field isn't displayed anywhere on the /training page and won't be maintained. It also no longer influences search matching, so stale org names can't surface irrelevant matches. Jobs results still show their organization as before.
- All dates in search results now display as `28-SEP-2026` instead of `2026-09-28` – covers event/training date ranges and "Apply by"/"Register by" deadlines.
- Verified on localhost: searching "mats" shows training results without the org line and with the new date format; the full index has no remaining ISO-formatted dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)