### PR TITLE
Events + Training: abbreviate September as "Sep", not "Sept"

### DIFF
--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -51,7 +51,8 @@ function parseISO(date: string): Date {
   return new Date(date + 'T00:00:00Z')
 }
 function shortMonth(d: Date): string {
-  return new Intl.DateTimeFormat('en-GB', {
+  // en-US, not en-GB: en-GB abbreviates September as "Sept".
+  return new Intl.DateTimeFormat('en-US', {
     month: 'short',
     timeZone: 'UTC',
   }).format(d)

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -61,7 +61,8 @@ function parseISO(date: string): Date {
 
 function formatShortDate(date: string): string {
   const d = parseISO(date)
-  const month = new Intl.DateTimeFormat('en-GB', {
+  // en-US, not en-GB: en-GB abbreviates September as "Sept".
+  const month = new Intl.DateTimeFormat('en-US', {
     month: 'short',
     timeZone: 'UTC',
   }).format(d)


### PR DESCRIPTION
- Card dates on /events and /training showed "7 Sept 2026" because the short-month formatter used the en-GB locale, which abbreviates September as "Sept". Switched those formatters to en-US, which uses "Sep". September is the only month the two locales abbreviate differently.
- The day-month-year order is assembled manually, so it stays "7 Sep 2026".
- Full-month labels ("September 2026" section headers) and search-result dates (already "SEP") are unaffected.
- Verified on localhost: all abbreviated dates on both pages now render "Sep", with no "Sept" remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)