### PR TITLE
/events: show hybrid events as "Online & <location>" like /training

### DIFF
--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -112,8 +112,15 @@ function titleMetaFor(event: EventListing) {
   const date = formatEventDate(event.startDate, event.endDate)
   const time = formatEventTime(event.startTime, event.endTime)
   const rows: { icon: string; value: string }[] = []
+  // Hybrid events can be attended either way, so the card spells out both
+  // facets ("Online & Oxford, UK") the way /training listings do. The raw
+  // location stays city-only in Airtable so the city filter isn't polluted.
   if (event.location)
-    rows.push({ icon: '/images/icons/pin.svg', value: event.location })
+    rows.push({
+      icon: '/images/icons/pin.svg',
+      value:
+        event.mode === 'Hybrid' ? `Online & ${event.location}` : event.location,
+    })
   if (date) rows.push({ icon: '/images/icons/calendar.svg', value: date })
   if (time) rows.push({ icon: '/images/icons/timer.svg', value: time })
   return rows


### PR DESCRIPTION
- Hybrid events on /events now display their location as "Online & <city>" (e.g. "Online & Oxford, UK"), matching how /training listings spell out both attendance facets.
- The prefix is added in code from the Mode field. The Airtable Location field stays city-only, so the "Find events near you" city search isn't polluted with "Online & …" entries.
- Applies in both the Online and In person views (hybrid events appear under both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)