### PR TITLE
/events: multi-location city search with keyboard navigation

### DIFF
--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -173,19 +173,22 @@ function emptyStateMessage(
 
 function CitySearch({
   cities,
-  selectedCity,
-  onSelect,
+  selectedCities,
+  onAdd,
+  onRemove,
   onClear,
 }: {
   cities: string[]
-  selectedCity: string
-  onSelect: (city: string) => void
+  selectedCities: string[]
+  onAdd: (city: string) => void
+  onRemove: (city: string) => void
   onClear: () => void
 }) {
-  const [query, setQuery] = useState(selectedCity)
+  const [query, setQuery] = useState('')
   const [open, setOpen] = useState(false)
   const [highlighted, setHighlighted] = useState(-1)
   const ref = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (!open) return
@@ -204,13 +207,16 @@ function CitySearch({
   }, [open])
 
   const normalized = query.trim().toLowerCase()
-  const matches = cities.filter(c => c.toLowerCase().includes(normalized))
+  const matches = cities.filter(
+    c => c.toLowerCase().includes(normalized) && !selectedCities.includes(c)
+  )
 
   function selectCity(city: string) {
-    setQuery(city)
-    onSelect(city)
+    setQuery('')
+    onAdd(city)
     setOpen(false)
     setHighlighted(-1)
+    inputRef.current?.focus()
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -228,32 +234,74 @@ function CitySearch({
         e.preventDefault()
         selectCity(matches[highlighted])
       }
+    } else if (e.key === 'Backspace') {
+      if (query === '' && selectedCities.length > 0) {
+        onRemove(selectedCities[selectedCities.length - 1])
+      }
     }
   }
 
   return (
     <div className={styles.nearMeSearch} ref={ref}>
       <span className={styles.nearMeIcon} aria-hidden="true" />
-      <input
-        type="text"
-        className={`text-field ${styles.nearMeInput}`}
-        placeholder="Type your city or country"
-        maxLength={256}
-        value={query}
-        onFocus={() => setOpen(true)}
-        onChange={e => {
-          setQuery(e.target.value)
-          setOpen(true)
-          setHighlighted(-1)
-          if (e.target.value.trim() === '') onClear()
-        }}
-        onKeyDown={handleKeyDown}
-      />
-      {query.length > 0 && (
+      <div
+        className={styles.nearMeField}
+        onClick={() => inputRef.current?.focus()}
+      >
+        {selectedCities.map(city => (
+          <span key={city} className={`paragraph-xs ${styles.cityChip}`}>
+            {city}
+            <button
+              type="button"
+              className={styles.cityChipRemove}
+              aria-label={`Remove ${city}`}
+              onClick={e => {
+                e.stopPropagation()
+                onRemove(city)
+              }}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 20 20"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M6 6L14 14M14 6L6 14"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          className={`text-field ${styles.nearMeInput}`}
+          placeholder={
+            selectedCities.length > 0
+              ? 'Add another location'
+              : 'Type your city or country'
+          }
+          maxLength={256}
+          value={query}
+          onFocus={() => setOpen(true)}
+          onChange={e => {
+            setQuery(e.target.value)
+            setOpen(true)
+            setHighlighted(-1)
+          }}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+      {(query.length > 0 || selectedCities.length > 0) && (
         <button
           type="button"
           className={styles.nearMeClear}
-          aria-label="Clear city"
+          aria-label="Clear locations"
           onClick={() => {
             setQuery('')
             onClear()
@@ -276,7 +324,7 @@ function CitySearch({
           </svg>
         </button>
       )}
-      {open && (
+      {open && (matches.length > 0 || normalized !== '') && (
         <div className={`${styles.cityList} drop-shadow-dark`}>
           {matches.length > 0 ? (
             matches.map((city, i) => (
@@ -340,7 +388,7 @@ export default function EventsClient({ events }: EventsClientProps) {
   const [selectedStatus, setSelectedStatus] = useState<string[]>(['Open'])
   const [selectedTypes, setSelectedTypes] = useState<string[]>([])
   const [selectedCost, setSelectedCost] = useState<string[]>([])
-  const [selectedCity, setSelectedCity] = useState('')
+  const [selectedCities, setSelectedCities] = useState<string[]>([])
 
   const toggleAnchorRef = useRef<HTMLDivElement>(null)
 
@@ -349,14 +397,14 @@ export default function EventsClient({ events }: EventsClientProps) {
   // Landing on online drops the city filter, mirroring switchMode.
   const applyViewParam = useCallback((view: string | null) => {
     const next: Mode = view === 'in-person' ? 'in-person' : 'online'
-    if (next === 'online') setSelectedCity('')
+    if (next === 'online') setSelectedCities([])
     setMode(next)
   }, [])
 
   // Switching sets replaces the whole grid, so jump back to the top of the
   // listings (just below the global nav) for the new set.
   function switchMode(next: Mode) {
-    if (next === 'online') setSelectedCity('')
+    if (next === 'online') setSelectedCities([])
     setMode(next)
     syncViewParam(next)
     scrollToAnchor(toggleAnchorRef.current)
@@ -417,8 +465,8 @@ export default function EventsClient({ events }: EventsClientProps) {
           return false
         if (
           mode === 'in-person' &&
-          selectedCity &&
-          event.location !== selectedCity
+          selectedCities.length > 0 &&
+          !selectedCities.includes(event.location)
         )
           return false
         return true
@@ -448,7 +496,7 @@ export default function EventsClient({ events }: EventsClientProps) {
       selectedTypes,
       selectedCost,
       mode,
-      selectedCity,
+      selectedCities,
     ])
 
   const monthGroups = useMemo(() => {
@@ -578,9 +626,16 @@ export default function EventsClient({ events }: EventsClientProps) {
             </p>
             <CitySearch
               cities={cities}
-              selectedCity={selectedCity}
-              onSelect={setSelectedCity}
-              onClear={() => setSelectedCity('')}
+              selectedCities={selectedCities}
+              onAdd={city =>
+                setSelectedCities(prev =>
+                  prev.includes(city) ? prev : [...prev, city]
+                )
+              }
+              onRemove={city =>
+                setSelectedCities(prev => prev.filter(c => c !== city))
+              }
+              onClear={() => setSelectedCities([])}
             />
           </div>
         )}

--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -184,6 +184,7 @@ function CitySearch({
 }) {
   const [query, setQuery] = useState(selectedCity)
   const [open, setOpen] = useState(false)
+  const [highlighted, setHighlighted] = useState(-1)
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -205,6 +206,31 @@ function CitySearch({
   const normalized = query.trim().toLowerCase()
   const matches = cities.filter(c => c.toLowerCase().includes(normalized))
 
+  function selectCity(city: string) {
+    setQuery(city)
+    onSelect(city)
+    setOpen(false)
+    setHighlighted(-1)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault()
+      if (!open) {
+        setOpen(true)
+        return
+      }
+      if (matches.length === 0) return
+      const delta = e.key === 'ArrowDown' ? 1 : -1
+      setHighlighted(h => (h + delta + matches.length) % matches.length)
+    } else if (e.key === 'Enter') {
+      if (open && highlighted >= 0 && highlighted < matches.length) {
+        e.preventDefault()
+        selectCity(matches[highlighted])
+      }
+    }
+  }
+
   return (
     <div className={styles.nearMeSearch} ref={ref}>
       <span className={styles.nearMeIcon} aria-hidden="true" />
@@ -218,8 +244,10 @@ function CitySearch({
         onChange={e => {
           setQuery(e.target.value)
           setOpen(true)
+          setHighlighted(-1)
           if (e.target.value.trim() === '') onClear()
         }}
+        onKeyDown={handleKeyDown}
       />
       {query.length > 0 && (
         <button
@@ -251,16 +279,20 @@ function CitySearch({
       {open && (
         <div className={`${styles.cityList} drop-shadow-dark`}>
           {matches.length > 0 ? (
-            matches.map(city => (
+            matches.map((city, i) => (
               <button
                 key={city}
                 type="button"
-                className={`paragraph-small ${styles.cityOption}`}
-                onClick={() => {
-                  setQuery(city)
-                  onSelect(city)
-                  setOpen(false)
-                }}
+                ref={
+                  i === highlighted
+                    ? el => el?.scrollIntoView({ block: 'nearest' })
+                    : undefined
+                }
+                className={`paragraph-small ${styles.cityOption} ${
+                  i === highlighted ? styles.cityOptionHighlighted : ''
+                }`}
+                onMouseEnter={() => setHighlighted(i)}
+                onClick={() => selectCity(city)}
               >
                 <span className={styles.cityOptionIcon} aria-hidden="true" />
                 {city}

--- a/src/app/events/page.module.css
+++ b/src/app/events/page.module.css
@@ -79,7 +79,8 @@
   text-align: left;
 }
 
-.cityOption:hover {
+.cityOption:hover,
+.cityOptionHighlighted {
   background-color: color-mix(in srgb, var(--bright-teal-500) 10%, transparent);
 }
 

--- a/src/app/events/page.module.css
+++ b/src/app/events/page.module.css
@@ -11,7 +11,7 @@
 .nearMeIcon {
   position: absolute;
   left: 16px;
-  top: 50%;
+  top: 24px;
   transform: translateY(-50%);
   z-index: 1;
   width: 16px;
@@ -21,22 +21,63 @@
   mask: url('/images/icons/pin.svg') no-repeat center / contain;
 }
 
-.nearMeInput {
-  height: 48px;
-  padding-left: 40px;
-  padding-right: 44px;
-  border: none;
-  border-radius: 999px;
+/* The pill-shaped field: holds the selected-city chips plus the text input,
+   wrapping onto extra rows as chips accumulate. */
+.nearMeField {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-height: 48px;
+  padding: 6px 44px 6px 40px;
+  border-radius: 24px;
   background-color: color-mix(in srgb, var(--bright-teal-500) 10%, transparent);
+  cursor: text;
+}
+
+.nearMeInput {
+  flex: 1;
+  min-width: 160px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
   color: var(--white);
   font-size: 15px;
   font-weight: 300;
 }
 
+.cityChip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px 5px 14px;
+  border-radius: 999px;
+  background-color: var(--teal-bright-800);
+  color: var(--white);
+  white-space: nowrap;
+}
+
+.cityChipRemove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  color: var(--teal-400);
+  cursor: pointer;
+}
+
+.cityChipRemove:hover {
+  color: var(--white);
+}
+
 .nearMeClear {
   position: absolute;
   right: 14px;
-  top: 50%;
+  top: 24px;
   transform: translateY(-50%);
   z-index: 1;
   display: flex;

--- a/src/components/StickyBar.module.css
+++ b/src/components/StickyBar.module.css
@@ -6,7 +6,7 @@
      edge UNDER the nav's (which stacks far above), so rendering can never
      show a hairline seam between the two mid-animation. */
   top: max(0px, calc(var(--nav-offset, 0px) - 2px));
-  z-index: 5; /* under the filter popovers (10) and the nav */
+  z-index: 20; /* above the filter popovers (10), under the nav */
   /* Full-bleed: stretch the stuck backdrop to the viewport edges like the
      nav's, while the content stays aligned to the container. */
   margin-left: calc(50% - 50vw);


### PR DESCRIPTION
- Arrow keys now move through the "Find events near you" suggestions, with Enter selecting the highlighted city; the highlight matches the hover style and scrolls into view in long lists.
- Multiple locations can be selected: each becomes a removable chip inside the search field, the input clears for typing another, and events from all selected cities show together. Already-selected cities are excluded from the suggestions, Backspace in an empty input removes the last chip, and the field's clear button removes everything.
- Open filter popovers on /events and /training now scroll behind the sticky bar instead of drawing over it (StickyBar now stacks above the popovers, still below the global nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)