### PR TITLE
/events: reduce padding on "Find events near you" box

### DIFF
--- a/src/app/events/page.module.css
+++ b/src/app/events/page.module.css
@@ -1,6 +1,6 @@
 /* "Find events near you" box — border comes from the global .border-only. */
 .nearMe {
-  padding: 48px;
+  padding: 24px;
   border-radius: 16px;
 }
 


### PR DESCRIPTION
- Halves the padding on the "Find events near you" search box on /events (48px → 24px) so it takes up less vertical space
- Shows on the "In person" view only

🤖 Generated with [Claude Code](https://claude.com/claude-code)