### PR TITLE
Chatbot: render cards whose note contains brackets instead of leaking raw code

### DIFF
--- a/src/app/admin/chatbot/TranscriptMessage.tsx
+++ b/src/app/admin/chatbot/TranscriptMessage.tsx
@@ -8,6 +8,7 @@
 import { createContext, Fragment, ReactNode, useContext, useState } from 'react'
 import {
   SuggestInline,
+  flattenNoteLinks,
   parseSuggestToken,
 } from '@/components/assistant/MessageContent'
 import { cardTypePage } from '@/components/assistant/cardFallback'
@@ -75,17 +76,18 @@ const SUGGEST_TOKEN_RE = /^\[\[\s*suggest\s*:([^\]\n]*)\]\]$/i
 // rec id, no rec at all) were NOT cards in the visitor's chat — the live
 // malformed-directive sweep stripped them — so they must not become pills
 // here either; they fall through to the paragraph path and render as
-// struck-through "stripped" tokens instead.
+// struck-through "stripped" tokens instead. Like the live renderer, the
+// |note runs to the closing `]]`, so brackets inside it don't break the card.
 const CARD_LINE_RE =
-  /^\s*\[\[\s*card\s*:\s*((?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+)(?:\s*\|([^\]\n]*))?\s*\]\]\s*$/i
+  /^\s*\[\[\s*card\s*:\s*((?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+)(?:\s*\|(.*?))?\s*\]\]\s*$/i
 // Anchored well-formedness tests for inline card/id tokens, mirroring the
 // live renderer's CARD_TOKEN_RE / ID_TOKEN_RE.
 const STRICT_CARD_TOKEN_RE =
-  /^\[\[\s*card\s*:\s*(?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+(?:\s*\|[^\]\n]*)?\s*\]\]$/i
+  /^\[\[\s*card\s*:\s*(?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+(?:\s*\|.*?)?\s*\]\]$/i
 const STRICT_ID_TOKEN_RE =
   /^\[\[\s*id\s*:\s*(?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+\s*\]\]$/i
 const INLINE_RE =
-  /(\[\[[^\]\n]*\]\])|(\[[^\]\n]+\]\(\/?[^)\n]+\))|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(\baisafety\.info(?:\/[^\s<>),]*)?)/gi
+  /(\[\[[^\n]*?\]\])|(\[[^\]\n]+\]\(\/?[^)\n]+\))|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(\baisafety\.info(?:\/[^\s<>),]*)?)/gi
 
 /** Did the visitor get a real card for this token, or a degraded fallback?
  *  Turns logged since fallback tracking (Data.fallbackCards) say exactly
@@ -117,13 +119,14 @@ function inlineCardLabel(
   listings: Record<string, ListingInfo>
 ): string {
   const m =
-    /^\[\[\s*(?:card|id)\s*:\s*([^\]|\n]+?)(?:\s*\|([^\]\n]*))?\s*\]\]$/i.exec(
+    /^\[\[\s*(?:card|id)\s*:\s*([^\]|\n]+?)(?:\s*\|(.*?))?\s*\]\]$/i.exec(
       token
     )
   if (!m) return ''
   const info = resolveListing(listings, m[1])
   if (info) return info.name
-  if (m[2]?.trim()) return m[2].trim()
+  const noteLabel = flattenNoteLinks(m[2] ?? '').trim()
+  if (noteLabel) return noteLabel
   const type = cardType(m[1])
   const rec = /rec[A-Za-z0-9]+/.exec(m[1])?.[0] ?? m[1].trim()
   return type ? `${type} ${rec}` : rec
@@ -425,7 +428,7 @@ function parseBlocks(text: string): Block[] {
       current.cards.push({
         type: cardType(cardMatch[1]),
         id: cardMatch[1].replace(/\s+/g, ''),
-        note: cardMatch[2]?.trim() ?? '',
+        note: flattenNoteLinks(cardMatch[2] ?? '').trim(),
       })
     } else if (ulMatch) {
       if (current?.kind !== 'ul') {

--- a/src/app/api/admin/conversations/route.ts
+++ b/src/app/api/admin/conversations/route.ts
@@ -11,7 +11,7 @@ export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 /** Pulls the listing ids out of every [[card:ID|note]] token in a reply. */
-const CARD_ID_RE = /\[\[\s*card\s*:\s*([^\]|\n]+?)(?:\s*\|[^\]\n]*)?\s*\]\]/gi
+const CARD_ID_RE = /\[\[\s*card\s*:\s*([^\]|\n]+?)(?:\s*\|[^\n]*?)?\s*\]\]/gi
 function collectCardIds(text: string, into: Set<string>): void {
   CARD_ID_RE.lastIndex = 0
   let m: RegExpExecArray | null

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -138,7 +138,7 @@ export async function POST(req: NextRequest) {
       // limit. The viewer only needs refs for [[card:...]] ids anyway.
       const citedById = new Map(citations.map(c => [c.id, c]))
       const cardedIds = new Set<string>()
-      const cardRe = /\[\[\s*card\s*:\s*([^\]|\n]+?)(?:\s*\|[^\]\n]*)?\s*\]\]/gi
+      const cardRe = /\[\[\s*card\s*:\s*([^\]|\n]+?)(?:\s*\|[^\n]*?)?\s*\]\]/gi
       let cardMatch: RegExpExecArray | null
       while ((cardMatch = cardRe.exec(assistantText)) !== null) {
         cardedIds.add(cardMatch[1].replace(/\s+/g, ''))

--- a/src/components/assistant/MessageContent.tsx
+++ b/src/components/assistant/MessageContent.tsx
@@ -43,20 +43,22 @@ interface Props {
 //   - doubled prefixes (re-prefixing mistake): `[[card:type:type:recXXX]]`
 //   - whitespace inside brackets / around colons / around the pipe
 //   - capitalization on the keyword itself: `[[Card:...]]`
+//   - brackets inside the |note (e.g. a Markdown link the model wasn't
+//     supposed to write there) — the note runs to the closing `]]`
 // resolveCitation handles the actual lookup with suffix matching on the
 // underlying rec id when the full id doesn't resolve directly.
 const INLINE_REGEX =
-  /(\[\[\s*id\s*:\s*(?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+\s*\]\])|(\[\[\s*suggest\s*:[^\]\n]*\]\])|(\[\[\s*chip\s*:[^\]\n]*\]\])|(\[\[\s*card\s*:\s*(?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+(?:\s*\|[^\]\n]*)?\s*\]\])|(\[[^\]\n]+\]\([^)\n]+\))|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(\baisafety\.info(?:\/[^\s<>),]*)?)/gi
+  /(\[\[\s*id\s*:\s*(?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+\s*\]\])|(\[\[\s*suggest\s*:[^\]\n]*\]\])|(\[\[\s*chip\s*:[^\]\n]*\]\])|(\[\[\s*card\s*:\s*(?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+(?:\s*\|[^\n]*?)?\s*\]\])|(\[[^\]\n]+\]\([^)\n]+\))|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(\baisafety\.info(?:\/[^\s<>),]*)?)/gi
 
 const CARD_LINE =
-  /^\s*\[\[\s*card\s*:\s*((?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+)(?:\s*\|([^\]\n]*))?\s*\]\]\s*$/i
+  /^\s*\[\[\s*card\s*:\s*((?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+)(?:\s*\|(.*?))?\s*\]\]\s*$/i
 
 // Per-token regexes used to extract pieces from a matched token. Anchored
 // so they only match if the whole token is well-formed.
 const ID_TOKEN_RE =
   /^\[\[\s*id\s*:\s*((?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+)\s*\]\]$/i
 const CARD_TOKEN_RE =
-  /^\[\[\s*card\s*:\s*((?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+)(?:\s*\|([^\]\n]*))?\s*\]\]$/i
+  /^\[\[\s*card\s*:\s*((?:[a-z][a-z-]*\s*:\s*)*rec[A-Za-z0-9]+)(?:\s*\|(.*?))?\s*\]\]$/i
 const SUGGEST_TOKEN_RE = /^\[\[\s*suggest\s*:([^\]\n]*)\]\]$/i
 const CHIP_TOKEN_RE = /^\[\[\s*chip\s*:([^\]\n]*)\]\]$/i
 
@@ -103,7 +105,7 @@ function maskStreamingTail(text: string): string {
 // recAlignment Jams|...]]` with a space in the rec id) and silently strip
 // them, rather than leaking the raw text to the user.
 const MALFORMED_DIRECTIVE_SWEEP =
-  /\[\[\s*(?:card|id|chip|suggest)\b[^\]\n]*?\]\]/gi
+  /\[\[\s*(?:card|id|chip|suggest)\b[^\n]*?\]\]/gi
 
 function stripMalformedDirectives(text: string): string {
   return text.replace(MALFORMED_DIRECTIVE_SWEEP, m => {
@@ -124,10 +126,18 @@ interface CardSpec {
   note?: string
 }
 
+/** Card notes render as plain text, so a Markdown link the model smuggled
+ *  into one (e.g. "find it on [Communities](/communities)") would show raw.
+ *  Keep the link's label, drop its destination. */
+export function flattenNoteLinks(note: string): string {
+  return note.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+}
+
 function parseCardLine(line: string): CardSpec | null {
   const m = CARD_LINE.exec(line)
   if (!m) return null
-  return { id: normaliseListingId(m[1]), note: m[2]?.trim() || undefined }
+  const note = m[2] ? flattenNoteLinks(m[2]).trim() : ''
+  return { id: normaliseListingId(m[1]), note: note || undefined }
 }
 
 function renderInline(

--- a/src/lib/assistant/citations.ts
+++ b/src/lib/assistant/citations.ts
@@ -3,9 +3,10 @@ import type { Catalog, CitationRef, Listing } from './types'
 const CITATION_REGEX = /\[\[id:([a-z][a-z-]*:rec[A-Za-z0-9]+)\]\]/g
 
 // Mirrors the tolerant [[card:...]] grammar the renderer and the log snapshot
-// use (route.ts): bare rec id, doubled prefix, and whitespace are all allowed.
+// use (route.ts): bare rec id, doubled prefix, whitespace, and brackets
+// inside the |note are all allowed.
 const CARD_ID_REGEX =
-  /\[\[\s*card\s*:\s*([^\]|\n]+?)(?:\s*\|[^\]\n]*)?\s*\]\]/gi
+  /\[\[\s*card\s*:\s*([^\]|\n]+?)(?:\s*\|[^\n]*?)?\s*\]\]/gi
 
 function toRef(l: Listing): CitationRef {
   return {


### PR DESCRIPTION
- A live conversation on 28 July surfaced raw `[[card:...]]` code in the chat widget: the model wrote a Markdown link inside a card's inline note, and the `]` characters broke the card pattern, so the token fell through to the link renderer and displayed as one long raw-text link.
- The note pattern now runs to the closing `]]` in all five copies of the card grammar: the live renderer and its malformed-directive sweep (`MessageContent.tsx`), the admin transcript viewer (`TranscriptMessage.tsx`), the server-side card audit (`citations.ts`), the log snapshot (`api/assistant/route.ts`), and the admin conversations API (`api/admin/conversations/route.ts`).
- Links written inside a note are flattened to their plain-text label (new `flattenNoteLinks` helper), since notes render as plain text.
- Genuinely malformed tokens (e.g. a space inside the rec id) are still stripped by the sweep, as before.
- Verified by replaying the exact logged reply in the widget on localhost: the card renders correctly with no raw code, and neighboring cards, links, and chips are unaffected.
- A companion prompt rule (card notes are plain text – no links or brackets) went straight to main as v2026-07-29-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)