### PR TITLE
Click context, filter, contribute and newsletter tracking

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -579,6 +579,10 @@ export default async function AnalyticsPage({
     (sum, r) => sum + r.count,
     0
   )
+  const newsletterTotalByPage = data.newsletterByPage.reduce(
+    (sum, r) => sum + r.count,
+    0
+  )
   // The site's own sidebar icons, so the rows read like the buttons they count.
   const contributeIcon = (label: string) =>
     label.startsWith('Add ')
@@ -898,7 +902,8 @@ export default async function AnalyticsPage({
                 </div>
               )}
               {(data.contributeButtons.length > 0 ||
-                data.airtableViews > 0) && (
+                data.airtableViews > 0 ||
+                data.newsletterSignups > 0) && (
                 <div className={styles.grid}>
                   <Panel title="Contribute buttons">
                     <CountTable
@@ -924,6 +929,20 @@ export default async function AnalyticsPage({
                       Recording since 29 July 2026.
                     </p>
                   </Panel>
+                  {data.newsletterSignups > 0 && (
+                    <Panel title="Newsletter signups">
+                      <div className={styles.funnel}>
+                        <Stat
+                          label="Signup-box submits"
+                          value={data.newsletterSignups.toLocaleString()}
+                        />
+                      </div>
+                      <p className={styles.caption}>
+                        Submits of the weekly-summary email box – may not all be
+                        successful signups. Recording since 29 July 2026.
+                      </p>
+                    </Panel>
+                  )}
                 </div>
               )}
             </div>
@@ -954,37 +973,41 @@ export default async function AnalyticsPage({
                 </p>
               </Panel>
               <Panel title="Filter use by page">
-                <table className={styles.table}>
-                  <thead>
-                    <tr>
-                      <th>Page</th>
-                      <th className={styles.numCol}>Uses</th>
-                      <th className={styles.numCol}>Filtered</th>
-                      <th className={styles.pctCol}>% of visitors</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {data.filtersByPage.map(r => {
-                      const share = filterShareByPage.get(r.name)
-                      return (
-                        <tr key={r.name}>
-                          <td>{labelByPage.get(r.name) ?? r.name}</td>
-                          <td className={styles.numCol}>
-                            {r.count.toLocaleString()}
-                          </td>
-                          <td className={styles.numCol}>
-                            {(share?.filtered ?? 0).toLocaleString()}
-                          </td>
-                          <td className={styles.pctCol}>
-                            {share && share.visitors > 0
-                              ? pct1(share.filtered, share.visitors)
-                              : '—'}
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
+                {data.filtersByPage.length === 0 ? (
+                  <p className={styles.dim}>No data yet.</p>
+                ) : (
+                  <table className={styles.table}>
+                    <thead>
+                      <tr>
+                        <th>Page</th>
+                        <th className={styles.numCol}>Uses</th>
+                        <th className={styles.numCol}>Filtered</th>
+                        <th className={styles.pctCol}>% of visitors</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.filtersByPage.map(r => {
+                        const share = filterShareByPage.get(r.name)
+                        return (
+                          <tr key={r.name}>
+                            <td>{labelByPage.get(r.name) ?? r.name}</td>
+                            <td className={styles.numCol}>
+                              {r.count.toLocaleString()}
+                            </td>
+                            <td className={styles.numCol}>
+                              {(share?.filtered ?? 0).toLocaleString()}
+                            </td>
+                            <td className={styles.pctCol}>
+                              {share && share.visitors > 0
+                                ? pct1(share.filtered, share.visitors)
+                                : '—'}
+                            </td>
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                )}
                 <p className={styles.caption}>
                   A use = a visitor turning a filter value on. Filtered =
                   distinct visitors who used at least one filter; % is their
@@ -1020,6 +1043,22 @@ export default async function AnalyticsPage({
                 <p className={styles.caption}>
                   Clicks on the &quot;View data in Airtable&quot; cards.
                   Recording since 29 July 2026.
+                </p>
+              </Panel>
+              <Panel title="Newsletter signups by page">
+                <CountTable
+                  rows={data.newsletterByPage.map(r => ({
+                    ...r,
+                    name: labelByPage.get(r.name) ?? r.name,
+                  }))}
+                  labelHead="Page"
+                  countHead="Submits"
+                  total={newsletterTotalByPage}
+                />
+                <p className={styles.caption}>
+                  Submits of the weekly-summary email box on /events and
+                  /training – may not all be successful signups. Recording since
+                  29 July 2026.
                 </p>
               </Panel>
             </div>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -382,6 +382,8 @@ function labelFor(e: {
     return SEARCH_OPEN_LABELS[e.source ?? ''] ?? 'Opened search'
   if (e.type === 'search_query')
     return e.query ? `Searched for “${e.query}”` : 'Searched'
+  if (e.type === 'filter_apply')
+    return `Filtered by ${e.source ?? '?'}: ${e.label ?? '?'}`
   // search_click carries the result's title as its label, like listing clicks.
   return e.label ?? EVENT_LABELS[e.type] ?? e.type
 }
@@ -561,6 +563,15 @@ export default async function AnalyticsPage({
     ? data.bySource.find(r => sourceSlug(r.name) === data.selectedSource)?.count
     : pageTotal
   const positionTotal = data.byPosition.reduce((sum, r) => sum + r.count, 0)
+  const filterTotal = data.filterGroups.reduce((sum, r) => sum + r.count, 0)
+  const filterShareByPage = new Map(
+    data.filterShareByPage.map(r => [r.name, r])
+  )
+  // The filter-usage caption's denominator: the page's distinct visitors, only
+  // meaningful in unique mode (total mode's byPage rows count views).
+  const filterPageVisitors = unique
+    ? data.visits.byPage.find(p => p.name === data.selectedPage)?.count
+    : undefined
 
   // Site-wide leaderboards for the Overview tab. The listings total is every
   // page's clicks (same denominator as "Clicks by page"); the position total is
@@ -836,6 +847,37 @@ export default async function AnalyticsPage({
                     </Panel>
                   </div>
                 )}
+              {data.filterGroups.length > 0 && (
+                <div className={styles.grid}>
+                  <Panel title="Filter usage">
+                    <CountTable
+                      rows={data.filterGroups}
+                      labelHead="Filter"
+                      countHead="Uses"
+                      total={filterTotal}
+                    />
+                    <p className={styles.caption}>
+                      A use = a visitor turning a filter value on; switching a
+                      value off isn&apos;t counted.{' '}
+                      {data.filterUsers.toLocaleString()} visitor
+                      {data.filterUsers === 1 ? '' : 's'} filtered this page
+                      this period
+                      {filterPageVisitors
+                        ? ` – ${pct1(data.filterUsers, filterPageVisitors)} of its visitors`
+                        : ''}
+                      . Recording since 29 July 2026.
+                    </p>
+                  </Panel>
+                  <Panel title="Filter values">
+                    <CountTable
+                      rows={data.filterValues}
+                      labelHead="Filter: value"
+                      countHead="Uses"
+                      total={filterTotal}
+                    />
+                  </Panel>
+                </div>
+              )}
             </div>
           )}
 
@@ -861,6 +903,46 @@ export default async function AnalyticsPage({
                   Every click across all pages counted at the slot it happened
                   in (F1/F2 = featured cards) — how much attention each slot
                   draws site-wide.
+                </p>
+              </Panel>
+              <Panel title="Filter use by page">
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th>Page</th>
+                      <th className={styles.numCol}>Uses</th>
+                      <th className={styles.numCol}>Filtered</th>
+                      <th className={styles.pctCol}>% of visitors</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.filtersByPage.map(r => {
+                      const share = filterShareByPage.get(r.name)
+                      return (
+                        <tr key={r.name}>
+                          <td>{labelByPage.get(r.name) ?? r.name}</td>
+                          <td className={styles.numCol}>
+                            {r.count.toLocaleString()}
+                          </td>
+                          <td className={styles.numCol}>
+                            {(share?.filtered ?? 0).toLocaleString()}
+                          </td>
+                          <td className={styles.pctCol}>
+                            {share && share.visitors > 0
+                              ? pct1(share.filtered, share.visitors)
+                              : '—'}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+                <p className={styles.caption}>
+                  A use = a visitor turning a filter value on. Filtered =
+                  distinct visitors who used at least one filter; % is their
+                  share of the page&apos;s visitors (always per-visitor,
+                  whichever count mode is on). Open a page&apos;s tab for its
+                  filter breakdown. Recording since 29 July 2026.
                 </p>
               </Panel>
             </div>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import {
   readDashboard,
+  sourceSlug,
   type Counted,
   type DateRange,
   type ChatbotFunnel,
@@ -557,8 +558,7 @@ export default async function AnalyticsPage({
   // share of that source's clicks, not the page's whole. bySource carries the
   // per-source totals, so read the active one from there.
   const listingTotal = data.selectedSource
-    ? data.bySource.find(r => r.name.toLowerCase() === data.selectedSource)
-        ?.count
+    ? data.bySource.find(r => sourceSlug(r.name) === data.selectedSource)?.count
     : pageTotal
   const positionTotal = data.byPosition.reduce((sum, r) => sum + r.count, 0)
 
@@ -744,6 +744,11 @@ export default async function AnalyticsPage({
                 rows={data.bySource}
                 active={data.selectedSource}
                 params={sp}
+                label={
+                  MAP_PAGES.has(data.selectedPage ?? '')
+                    ? 'Clicks by source'
+                    : 'Clicks by view'
+                }
               />
               <div className={styles.grid}>
                 {/* Titles skip the page name — the active tab already says
@@ -956,10 +961,14 @@ function SourceSplit({
   rows,
   active,
   params,
+  label,
 }: {
   rows: Counted[]
   active: string | null
   params: SearchParams
+  /** Heading for the pill row — 'Clicks by source' on map pages (map vs
+   *  cards), 'Clicks by view' on pages with a view toggle. */
+  label: string
 }) {
   if (rows.length === 0) return null
   const total = rows.reduce((sum, r) => sum + r.count, 0)
@@ -974,7 +983,7 @@ function SourceSplit({
   return (
     <div className={styles.sourceSplitWrap}>
       <div className={styles.sourceSplit}>
-        <span className={styles.sourceSplitLabel}>Clicks by source</span>
+        <span className={styles.sourceSplitLabel}>{label}</span>
         {rows.length > 1 && (
           <Link
             href={totalHref}
@@ -990,7 +999,7 @@ function SourceSplit({
           </Link>
         )}
         {rows.map(r => {
-          const key = r.name.toLowerCase()
+          const key = sourceSlug(r.name)
           const q = new URLSearchParams(base)
           q.set('source', key)
           return (
@@ -1017,8 +1026,8 @@ function SourceSplit({
       </div>
       {hasUntracked && (
         <p className={styles.caption}>
-          Untracked = clicks logged before map/card source tracking started;
-          they age out as the date range moves forward.
+          Untracked = clicks logged before this split was recorded; they age out
+          as the date range moves forward.
         </p>
       )}
     </div>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -567,6 +567,25 @@ export default async function AnalyticsPage({
   const filterShareByPage = new Map(
     data.filterShareByPage.map(r => [r.name, r])
   )
+  const contributeTotal = data.contributeButtons.reduce(
+    (sum, r) => sum + r.count,
+    0
+  )
+  const contributeTotalByPage = data.contributeByPage.reduce(
+    (sum, r) => sum + r.count,
+    0
+  )
+  const airtableTotalByPage = data.airtableByPage.reduce(
+    (sum, r) => sum + r.count,
+    0
+  )
+  // The site's own sidebar icons, so the rows read like the buttons they count.
+  const contributeIcon = (label: string) =>
+    label.startsWith('Add ')
+      ? '/images/plus-small.svg'
+      : label === 'Suggest a correction'
+        ? '/images/pencil-small.svg'
+        : '/images/star-small.svg'
   // The filter-usage caption's denominator: the page's distinct visitors, only
   // meaningful in unique mode (total mode's byPage rows count views).
   const filterPageVisitors = unique
@@ -878,6 +897,35 @@ export default async function AnalyticsPage({
                   </Panel>
                 </div>
               )}
+              {(data.contributeButtons.length > 0 ||
+                data.airtableViews > 0) && (
+                <div className={styles.grid}>
+                  <Panel title="Contribute buttons">
+                    <CountTable
+                      rows={data.contributeButtons}
+                      labelHead="Button"
+                      logoFor={contributeIcon}
+                      total={contributeTotal}
+                    />
+                    <p className={styles.caption}>
+                      Clicks on this page&apos;s add and correction forms.
+                      Recording since 29 July 2026.
+                    </p>
+                  </Panel>
+                  <Panel title="View data in Airtable">
+                    <div className={styles.funnel}>
+                      <Stat
+                        label="Card clicks"
+                        value={data.airtableViews.toLocaleString()}
+                      />
+                    </div>
+                    <p className={styles.caption}>
+                      Visitors opening this page&apos;s raw data in Airtable.
+                      Recording since 29 July 2026.
+                    </p>
+                  </Panel>
+                </div>
+              )}
             </div>
           )}
 
@@ -943,6 +991,35 @@ export default async function AnalyticsPage({
                   share of the page&apos;s visitors (always per-visitor,
                   whichever count mode is on). Open a page&apos;s tab for its
                   filter breakdown. Recording since 29 July 2026.
+                </p>
+              </Panel>
+              <Panel title="Contribute clicks by page">
+                <CountTable
+                  rows={data.contributeByPage.map(r => ({
+                    ...r,
+                    name: labelByPage.get(r.name) ?? r.name,
+                  }))}
+                  labelHead="Page"
+                  total={contributeTotalByPage}
+                />
+                <p className={styles.caption}>
+                  Clicks on the &quot;Add a …&quot; and &quot;Suggest a
+                  correction&quot; forms. Open a page&apos;s tab for its
+                  per-button split. Recording since 29 July 2026.
+                </p>
+              </Panel>
+              <Panel title="Airtable views by page">
+                <CountTable
+                  rows={data.airtableByPage.map(r => ({
+                    ...r,
+                    name: labelByPage.get(r.name) ?? r.name,
+                  }))}
+                  labelHead="Page"
+                  total={airtableTotalByPage}
+                />
+                <p className={styles.caption}>
+                  Clicks on the &quot;View data in Airtable&quot; cards.
+                  Recording since 29 July 2026.
                 </p>
               </Panel>
             </div>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -902,8 +902,7 @@ export default async function AnalyticsPage({
                 </div>
               )}
               {(data.contributeButtons.length > 0 ||
-                data.airtableViews > 0 ||
-                data.newsletterSignups > 0) && (
+                data.airtableViews > 0) && (
                 <div className={styles.grid}>
                   <Panel title="Contribute buttons">
                     <CountTable
@@ -929,20 +928,6 @@ export default async function AnalyticsPage({
                       Recording since 29 July 2026.
                     </p>
                   </Panel>
-                  {data.newsletterSignups > 0 && (
-                    <Panel title="Newsletter signups">
-                      <div className={styles.funnel}>
-                        <Stat
-                          label="Signup-box submits"
-                          value={data.newsletterSignups.toLocaleString()}
-                        />
-                      </div>
-                      <p className={styles.caption}>
-                        Submits of the weekly-summary email box – may not all be
-                        successful signups. Recording since 29 July 2026.
-                      </p>
-                    </Panel>
-                  )}
                 </div>
               )}
             </div>

--- a/src/app/advisors/AdvisorsClient.tsx
+++ b/src/app/advisors/AdvisorsClient.tsx
@@ -191,6 +191,7 @@ export default function AdvisorsClient({ advisors }: AdvisorsClientProps) {
           />
         </FilterSidebar>
         <ContributeButtons
+          trackingPage="Advisors"
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagTw6PRaIHUHh8ty/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="advisor"

--- a/src/app/advisors/AdvisorsClient.tsx
+++ b/src/app/advisors/AdvisorsClient.tsx
@@ -174,6 +174,7 @@ export default function AdvisorsClient({ advisors }: AdvisorsClientProps) {
       <div className="hide-mobile width-3-col">
         <FilterSidebar>
           <FilterGroup
+            trackingPage="Advisors"
             title="Focus"
             options={focusOptions}
             selected={selectedFocus}
@@ -181,6 +182,7 @@ export default function AdvisorsClient({ advisors }: AdvisorsClientProps) {
             onToggle={v => toggleFilter(v, selectedFocus, setSelectedFocus)}
           />
           <FilterGroup
+            trackingPage="Advisors"
             title="Status"
             options={statusOptions}
             selected={selectedStatus}

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -52,7 +52,9 @@ export async function POST(req: NextRequest) {
     listingId: str(b.listingId, 64),
     label: str(b.label, 300),
     position: str(b.position, 16),
-    source: str(b.source, 16),
+    // 32, not 16: filter_apply events carry the filter group's title here
+    // (longest today: 'Accepting applications', 22 chars).
+    source: str(b.source, 32),
     area: str(b.area, 64),
     query: str(b.query, 200),
     results: count(b.results, 100_000),

--- a/src/app/communities/CommunitiesClient.tsx
+++ b/src/app/communities/CommunitiesClient.tsx
@@ -263,6 +263,7 @@ export default function CommunitiesClient({
       <aside className="hide-mobile width-3-col">
         <FilterSidebar>
           <FilterGroup
+            trackingPage="Communities"
             title="Type"
             options={typeOptions}
             selected={typeFilters}
@@ -270,6 +271,7 @@ export default function CommunitiesClient({
             onToggle={v => toggleFilter(v, typeFilters, setTypeFilters)}
           />
           <FilterGroup
+            trackingPage="Communities"
             title="Platform"
             options={platformOptions}
             selected={platformFilters}
@@ -277,6 +279,7 @@ export default function CommunitiesClient({
             onToggle={v => toggleFilter(v, platformFilters, setPlatformFilters)}
           />
           <FilterGroup
+            trackingPage="Communities"
             title="Activity level"
             options={activityOptions}
             selected={activityFilters}
@@ -284,6 +287,7 @@ export default function CommunitiesClient({
             onToggle={v => toggleFilter(v, activityFilters, setActivityFilters)}
           />
           <FilterGroup
+            trackingPage="Communities"
             title="Focus"
             options={focusOptions}
             selected={focusFilters}

--- a/src/app/communities/CommunitiesClient.tsx
+++ b/src/app/communities/CommunitiesClient.tsx
@@ -296,6 +296,7 @@ export default function CommunitiesClient({
           />
         </FilterSidebar>
         <ContributeButtons
+          trackingPage="Communities"
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagKhplUqu07DwVqC/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="community"

--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -589,6 +589,7 @@ export default function EventsClient({ events }: EventsClientProps) {
               trackingPage="Events"
               trackingId={event.id}
               trackingPosition={`F${event.featured}`}
+              trackingSource={mode}
               index={i}
               count={featuredEvents.length}
             />
@@ -676,6 +677,7 @@ export default function EventsClient({ events }: EventsClientProps) {
                     trackingPage="Events"
                     listingId={event.id}
                     placement={placements.get(event.id)}
+                    trackingSource={mode}
                   />
                 ))}
               </div>

--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -701,6 +701,7 @@ export default function EventsClient({ events }: EventsClientProps) {
         </div>
 
         <ContributeButtons
+          trackingPage="Events"
           sidebar
           suggestEntryUrl={ADD_EVENT_URL}
           suggestCorrectionUrl={SUGGEST_CORRECTION_URL}

--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -18,6 +18,7 @@ import FilterDropdown from '@/components/FilterDropdown'
 import ModeToggle from '@/components/ModeToggle'
 import StickyBar, { scrollToAnchor } from '@/components/StickyBar'
 import { EVENT_TYPES, eventTypeColor } from '@/lib/event-types'
+import { placementsById } from '@/lib/placements'
 import type { EventListing } from '@/lib/data/events'
 import styles from './page.module.css'
 
@@ -420,6 +421,11 @@ export default function EventsClient({ events }: EventsClientProps) {
     [events, mode]
   )
 
+  // Each event's slot in the full (unfiltered) order of the active mode, so a
+  // click is tagged with the rank the visitor saw — not its position within an
+  // active filter.
+  const placements = useMemo(() => placementsById(modeEvents), [modeEvents])
+
   const cities = useMemo(() => {
     const set = new Set<string>()
     for (const e of modeEvents) {
@@ -581,6 +587,8 @@ export default function EventsClient({ events }: EventsClientProps) {
               titleMeta={titleMetaFor(event)}
               meta={bottomMetaFor(event)}
               trackingPage="Events"
+              trackingId={event.id}
+              trackingPosition={`F${event.featured}`}
               index={i}
               count={featuredEvents.length}
             />
@@ -666,6 +674,8 @@ export default function EventsClient({ events }: EventsClientProps) {
                     titleMeta={titleMetaFor(event)}
                     meta={bottomMetaFor(event)}
                     trackingPage="Events"
+                    listingId={event.id}
+                    placement={placements.get(event.id)}
                   />
                 ))}
               </div>

--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -18,6 +18,7 @@ import FilterDropdown from '@/components/FilterDropdown'
 import ModeToggle from '@/components/ModeToggle'
 import StickyBar, { scrollToAnchor } from '@/components/StickyBar'
 import { EVENT_TYPES, eventTypeColor } from '@/lib/event-types'
+import { trackFilterApply } from '@/lib/analytics'
 import { placementsById } from '@/lib/placements'
 import type { EventListing } from '@/lib/data/events'
 import styles from './page.module.css'
@@ -606,6 +607,7 @@ export default function EventsClient({ events }: EventsClientProps) {
           } ${mode === 'in-person' ? 'in person' : 'online'}`}
         >
           <FilterDropdown
+            trackingPage="Events"
             title="Applications"
             options={applicationOptions}
             selected={selectedStatus}
@@ -613,6 +615,7 @@ export default function EventsClient({ events }: EventsClientProps) {
             onToggle={v => toggleFilter(v, selectedStatus, setSelectedStatus)}
           />
           <FilterDropdown
+            trackingPage="Events"
             title="Event type"
             options={[...EVENT_TYPES]}
             selected={selectedTypes}
@@ -620,6 +623,7 @@ export default function EventsClient({ events }: EventsClientProps) {
             onToggle={v => toggleFilter(v, selectedTypes, setSelectedTypes)}
           />
           <FilterDropdown
+            trackingPage="Events"
             title="Cost"
             options={costOptions}
             selected={selectedCost}
@@ -636,11 +640,12 @@ export default function EventsClient({ events }: EventsClientProps) {
             <CitySearch
               cities={cities}
               selectedCities={selectedCities}
-              onAdd={city =>
+              onAdd={city => {
+                trackFilterApply('Events', 'City', city)
                 setSelectedCities(prev =>
                   prev.includes(city) ? prev : [...prev, city]
                 )
-              }
+              }}
               onRemove={city =>
                 setSelectedCities(prev => prev.filter(c => c !== city))
               }

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -16,6 +16,7 @@ export default async function EventsPage() {
         title="Events"
         lastUpdatedIso={lastUpdated.lastUpdated}
         newsletter
+        newsletterTrackingPage="Events"
         description={
           <>
             Find{' '}

--- a/src/app/founders/FoundersClient.tsx
+++ b/src/app/founders/FoundersClient.tsx
@@ -159,6 +159,7 @@ export default function FoundersClient({ resources }: FoundersClientProps) {
           />
         </FilterSidebar>
         <ContributeButtons
+          trackingPage="Founders"
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pag1OO5TrQkO96W7R/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="resource"

--- a/src/app/founders/FoundersClient.tsx
+++ b/src/app/founders/FoundersClient.tsx
@@ -150,6 +150,7 @@ export default function FoundersClient({ resources }: FoundersClientProps) {
       <div className="hide-mobile width-3-col">
         <FilterSidebar>
           <FilterGroup
+            trackingPage="Founders"
             title="Type"
             options={typeOptions}
             selected={selectedTypes}

--- a/src/app/funding/FundingClient.tsx
+++ b/src/app/funding/FundingClient.tsx
@@ -182,6 +182,7 @@ export default function FundingClient({ funders }: FundingClientProps) {
       <div className="hide-mobile width-3-col">
         <FilterSidebar>
           <FilterGroup
+            trackingPage="Funding"
             title="Accepting applications"
             options={acceptingOptions}
             selected={selectedAccepting}
@@ -191,6 +192,7 @@ export default function FundingClient({ funders }: FundingClientProps) {
             }
           />
           <FilterGroup
+            trackingPage="Funding"
             title="Type"
             options={typeOptions}
             selected={selectedTypes}

--- a/src/app/funding/FundingClient.tsx
+++ b/src/app/funding/FundingClient.tsx
@@ -201,6 +201,7 @@ export default function FundingClient({ funders }: FundingClientProps) {
           />
         </FilterSidebar>
         <ContributeButtons
+          trackingPage="Funding"
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagBI1UdaBbFplw20/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="funder"

--- a/src/app/jobs/JobsClient.tsx
+++ b/src/app/jobs/JobsClient.tsx
@@ -312,6 +312,7 @@ export default function JobsClient({ jobs }: JobsClientProps) {
       <div className="hide-mobile width-3-col">
         <FilterSidebar>
           <FilterGroup
+            trackingPage="Jobs"
             title="Skill set"
             options={skillSetOptions}
             selected={selectedSkills}
@@ -319,6 +320,7 @@ export default function JobsClient({ jobs }: JobsClientProps) {
             onToggle={v => toggleFilter(v, selectedSkills, setSelectedSkills)}
           />
           <FilterGroup
+            trackingPage="Jobs"
             title="Minimum experience"
             options={experienceOptions}
             selected={selectedExperience}
@@ -328,6 +330,7 @@ export default function JobsClient({ jobs }: JobsClientProps) {
             }
           />
           <FilterGroup
+            trackingPage="Jobs"
             title="Role type"
             options={roleTypeOptions}
             selected={selectedRoles}
@@ -335,6 +338,7 @@ export default function JobsClient({ jobs }: JobsClientProps) {
             onToggle={v => toggleFilter(v, selectedRoles, setSelectedRoles)}
           />
           <FilterGroup
+            trackingPage="Jobs"
             title="Work location"
             options={workLocationOptions}
             selected={selectedWorkLocation}

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -289,6 +289,7 @@ export default function MapClient({
           <div className="hide-mobile width-3-col">
             <FilterSidebar>
               <FilterGroup
+                trackingPage="Map"
                 title="Category"
                 options={categories}
                 selected={selectedCategories}
@@ -296,6 +297,7 @@ export default function MapClient({
                 onToggle={toggleCategory}
               />
               <FilterGroup
+                trackingPage="Map"
                 title="Status"
                 options={['Active', 'No longer active']}
                 selected={[

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -316,6 +316,7 @@ export default function MapClient({
               />
             </FilterSidebar>
             <ContributeButtons
+              trackingPage="Map"
               suggestEntryUrl={suggestEntryLink}
               suggestCorrectionUrl={suggestCorrectionLink}
               noun="listing"

--- a/src/app/media-channels/MediaChannelsClient.tsx
+++ b/src/app/media-channels/MediaChannelsClient.tsx
@@ -165,6 +165,7 @@ export default function MediaChannelsClient({
           />
         </FilterSidebar>
         <ContributeButtons
+          trackingPage="Media channels"
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagSZ7vJj9MHyYmtS/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="media source"

--- a/src/app/media-channels/MediaChannelsClient.tsx
+++ b/src/app/media-channels/MediaChannelsClient.tsx
@@ -156,6 +156,7 @@ export default function MediaChannelsClient({
       <div className="hide-mobile width-3-col">
         <FilterSidebar>
           <FilterGroup
+            trackingPage="Media channels"
             title="Type"
             options={typeOptions}
             selected={selectedTypes}

--- a/src/app/projects/ProjectsClient.tsx
+++ b/src/app/projects/ProjectsClient.tsx
@@ -119,6 +119,7 @@ export default function ProjectsClient({ projects }: ProjectsClientProps) {
           />
         </FilterSidebar>
         <ContributeButtons
+          trackingPage="Projects"
           suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pagudvyKXZISztcOI/form"
           suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
           noun="project"

--- a/src/app/projects/ProjectsClient.tsx
+++ b/src/app/projects/ProjectsClient.tsx
@@ -110,6 +110,7 @@ export default function ProjectsClient({ projects }: ProjectsClientProps) {
       <div className="hide-mobile width-3-col">
         <FilterSidebar>
           <FilterGroup
+            trackingPage="Projects"
             title="Status"
             options={statusOptions}
             selected={selectedStatus}

--- a/src/app/self-study/SelfStudyClient.tsx
+++ b/src/app/self-study/SelfStudyClient.tsx
@@ -169,6 +169,7 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
 
         <div className="hide-mobile width-3-col">
           <ContributeButtons
+            trackingPage="Self-study"
             suggestEntryUrl="https://airtable.com/appF8XfZUGXtfi40E/pag6L4BzdkxocBzqr/form"
             suggestCorrectionUrl="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
             noun="course"

--- a/src/app/self-study/SelfStudyClient.tsx
+++ b/src/app/self-study/SelfStudyClient.tsx
@@ -109,6 +109,7 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
           cards and the Contribute/Airtable column both start at the same top. */}
       <FilterBar count={filteredCourses.length} noun="course">
         <FilterDropdown
+          trackingPage="Self-study"
           title="Focus"
           icon="/images/category.svg"
           options={categoryOptions}
@@ -119,6 +120,7 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
           }
         />
         <FilterDropdown
+          trackingPage="Self-study"
           title="Format"
           icon="/images/type.svg"
           options={typeOptions}

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -613,6 +613,7 @@ export default function TrainingClient({
         </div>
 
         <ContributeButtons
+          trackingPage="Training"
           sidebar
           suggestEntryUrl={ADD_PROGRAM_URLS[mode]}
           suggestCorrectionUrl={SUGGEST_CORRECTION_URL}

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -445,6 +445,7 @@ export default function TrainingClient({
       trackingPage="Training"
       listingId={program.id}
       placement={placements.get(program.id)}
+      trackingSource={mode}
     />
   )
 
@@ -504,6 +505,7 @@ export default function TrainingClient({
               trackingPage="Training"
               trackingId={program.id}
               trackingPosition={`F${program.featured}`}
+              trackingSource={mode}
               index={i}
               count={featuredPrograms.length}
             />

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -522,6 +522,7 @@ export default function TrainingClient({
       >
         {mode === 'upcoming' && (
           <FilterDropdown
+            trackingPage="Training"
             title="Applications"
             options={applicationOptions}
             selected={selectedStatus}
@@ -530,6 +531,7 @@ export default function TrainingClient({
           />
         )}
         <FilterDropdown
+          trackingPage="Training"
           title="Type"
           options={[...TRAINING_TYPES]}
           selected={selectedTypes}
@@ -537,6 +539,7 @@ export default function TrainingClient({
           onToggle={v => toggleFilter(v, selectedTypes, setSelectedTypes)}
         />
         <FilterDropdown
+          trackingPage="Training"
           title="Focus"
           options={focusOptions}
           selected={selectedFocus}
@@ -544,6 +547,7 @@ export default function TrainingClient({
           onToggle={v => toggleFilter(v, selectedFocus, setSelectedFocus)}
         />
         <FilterDropdown
+          trackingPage="Training"
           title="Entry bar"
           options={[...ENTRY_BARS]}
           selected={selectedEntryBar}
@@ -551,6 +555,7 @@ export default function TrainingClient({
           onToggle={v => toggleFilter(v, selectedEntryBar, setSelectedEntryBar)}
         />
         <FilterDropdown
+          trackingPage="Training"
           title="Stipend"
           options={[...STIPEND_OPTIONS]}
           selected={selectedStipend}
@@ -558,6 +563,7 @@ export default function TrainingClient({
           onToggle={v => toggleFilter(v, selectedStipend, setSelectedStipend)}
         />
         <FilterDropdown
+          trackingPage="Training"
           title="Length"
           options={[...LENGTH_BUCKETS]}
           selected={selectedLength}
@@ -565,6 +571,7 @@ export default function TrainingClient({
           onToggle={v => toggleFilter(v, selectedLength, setSelectedLength)}
         />
         <FilterDropdown
+          trackingPage="Training"
           title="Location"
           options={locationOptions}
           selected={selectedLocation}

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -23,6 +23,7 @@ import {
   TRAINING_TYPES,
   trainingTypeColor,
 } from '@/lib/training-types'
+import { placementsById } from '@/lib/placements'
 import type {
   ProgramBase,
   RecurringProgram,
@@ -258,6 +259,11 @@ export default function TrainingClient({
 
   const modePrograms: ProgramBase[] = mode === 'upcoming' ? programs : recurring
 
+  // Each program's slot in the full (unfiltered) order of the active set, so a
+  // click is tagged with the rank the visitor saw — not its position within an
+  // active filter.
+  const placements = useMemo(() => placementsById(modePrograms), [modePrograms])
+
   const featuredPrograms = useMemo(
     () =>
       (['1', '2'] as const)
@@ -437,6 +443,8 @@ export default function TrainingClient({
         mode === 'upcoming' ? (program as TrainingProgram) : undefined
       )}
       trackingPage="Training"
+      listingId={program.id}
+      placement={placements.get(program.id)}
     />
   )
 
@@ -494,6 +502,8 @@ export default function TrainingClient({
                 mode === 'upcoming' ? (program as TrainingProgram) : undefined
               )}
               trackingPage="Training"
+              trackingId={program.id}
+              trackingPosition={`F${program.featured}`}
               index={i}
               count={featuredPrograms.length}
             />

--- a/src/app/training/page.tsx
+++ b/src/app/training/page.tsx
@@ -17,6 +17,7 @@ export default async function TrainingPage() {
         title="Training programs"
         lastUpdatedIso={lastUpdated.lastUpdated}
         newsletter
+        newsletterTrackingPage="Training"
         description={
           <>
             Find{' '}

--- a/src/components/ContributeButtons.tsx
+++ b/src/components/ContributeButtons.tsx
@@ -1,4 +1,7 @@
+'use client'
+
 import Image from 'next/image'
+import { trackAirtableView, trackContributeClick } from '@/lib/analytics'
 import styles from './ContributeButtons.module.css'
 
 interface ExtraLink {
@@ -21,6 +24,9 @@ interface ContributeButtonsProps {
   /** Render as the listing pages' right column (desktop only, offset to
       align with the listing grid beside it). */
   sidebar?: boolean
+  /** Analytics page name (e.g. 'Events'). When set, every button click
+   *  records a contribute_click event under this page. */
+  trackingPage?: string
 }
 
 // "a" vs "an" for the "Add a …" label.
@@ -32,16 +38,19 @@ function ActionRow({
   href,
   icon,
   label,
+  onClick,
 }: {
   href: string
   icon: string
   label: string
+  onClick?: () => void
 }) {
   return (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
+      onClick={onClick}
       className={`flex items-center gap-8px color-teal-bright-300 hover-white ${styles.row}`}
     >
       <span className={`bg-teal-bright-850 ${styles.badge}`}>
@@ -60,7 +69,12 @@ export default function ContributeButtons({
   airtableNote,
   extraLinks,
   sidebar,
+  trackingPage,
 }: ContributeButtonsProps) {
+  const track = (action: string, label: string, url: string) => {
+    if (trackingPage) trackContributeClick(trackingPage, action, label, url)
+  }
+  const addLabel = `Add ${article(noun)} ${noun}`
   const cards = (
     <div className="flex flex-col gap-16px">
       {/* Contribute card */}
@@ -73,12 +87,16 @@ export default function ContributeButtons({
           <ActionRow
             href={suggestEntryUrl}
             icon="/images/plus-small.svg"
-            label={`Add ${article(noun)} ${noun}`}
+            label={addLabel}
+            onClick={() => track('add', addLabel, suggestEntryUrl)}
           />
           <ActionRow
             href={suggestCorrectionUrl}
             icon="/images/pencil-small.svg"
             label="Suggest a correction"
+            onClick={() =>
+              track('correction', 'Suggest a correction', suggestCorrectionUrl)
+            }
           />
           {extraLinks?.map(link => (
             <ActionRow
@@ -86,6 +104,7 @@ export default function ContributeButtons({
               href={link.url}
               icon={link.icon || '/images/star-small.svg'}
               label={link.label}
+              onClick={() => track('extra', link.label, link.url)}
             />
           ))}
         </div>
@@ -96,6 +115,9 @@ export default function ContributeButtons({
         href={airtableUrl}
         target="_blank"
         rel="noopener noreferrer"
+        onClick={() => {
+          if (trackingPage) trackAirtableView(trackingPage, airtableUrl)
+        }}
         className={`border-only border-hover color-teal-300 hover-white ${styles.airtableCard}`}
       >
         <Image

--- a/src/components/FilterDropdown.tsx
+++ b/src/components/FilterDropdown.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
+import { trackFilterApply } from '@/lib/analytics'
 import styles from './FilterDropdown.module.css'
 
 interface FilterDropdownProps {
@@ -12,6 +13,9 @@ interface FilterDropdownProps {
   onToggle: (value: string) => void
   /** Optional 16×16 svg icon (path in /images) shown before the label. */
   icon?: string
+  /** Analytics page name (e.g. 'Training'). When set, turning a value on
+   *  records a filter_apply event under this page and the dropdown's title. */
+  trackingPage?: string
 }
 
 // A single pill-shaped filter that opens a checkbox popover. Used in the
@@ -23,6 +27,7 @@ export default function FilterDropdown({
   counts,
   onToggle,
   icon,
+  trackingPage,
 }: FilterDropdownProps) {
   const [open, setOpen] = useState(false)
   const [pos, setPos] = useState({ top: 0, left: 0 })
@@ -119,7 +124,11 @@ export default function FilterDropdown({
                 <input
                   type="checkbox"
                   checked={selected.includes(option)}
-                  onChange={() => onToggle(option)}
+                  onChange={() => {
+                    if (trackingPage && !selected.includes(option))
+                      trackFilterApply(trackingPage, title, option)
+                    onToggle(option)
+                  }}
                   className="checkbox"
                 />
                 <span className="paragraph-small color-white">

--- a/src/components/FilterGroup.tsx
+++ b/src/components/FilterGroup.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { trackFilterApply } from '@/lib/analytics'
+
 interface FilterGroupProps {
   title: string
   options: string[]
@@ -9,6 +11,9 @@ interface FilterGroupProps {
   // Optional map from option value to the label shown to the user. Filtering
   // and counts still run on the raw option values; only the display changes.
   labels?: Record<string, string>
+  /** Analytics page name (e.g. 'Jobs'). When set, turning a value on records
+   *  a filter_apply event under this page and the group's title. */
+  trackingPage?: string
 }
 
 export default function FilterGroup({
@@ -18,6 +23,7 @@ export default function FilterGroup({
   counts,
   onToggle,
   labels,
+  trackingPage,
 }: FilterGroupProps) {
   return (
     <div className="padding-bottom-40px">
@@ -30,7 +36,11 @@ export default function FilterGroup({
             <input
               type="checkbox"
               checked={selected.includes(option)}
-              onChange={() => onToggle(option)}
+              onChange={() => {
+                if (trackingPage && !selected.includes(option))
+                  trackFilterApply(trackingPage, title, option)
+                onToggle(option)
+              }}
               className="checkbox"
             />
             <span className="paragraph-small color-teal-300">

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -32,6 +32,9 @@ interface ListingCardProps {
   listingId?: string
   /** The card's slot on the page ('F1', 'F2', '1', '2'…) at click time. */
   placement?: string
+  /** Click source recorded with the event — the active view's slug on pages
+   *  with a view toggle (e.g. 'online' / 'in-person' on Events). */
+  trackingSource?: string
 }
 
 function MetaRows({ rows }: { rows: ListingCardMeta[] }) {
@@ -61,6 +64,7 @@ export default function ListingCard({
   trackingPage,
   listingId,
   placement,
+  trackingSource,
 }: ListingCardProps) {
   return (
     <a
@@ -69,7 +73,14 @@ export default function ListingCard({
       rel="noopener noreferrer"
       className="card"
       onClick={() =>
-        trackListingClick(trackingPage, name, href, listingId, placement)
+        trackListingClick(
+          trackingPage,
+          name,
+          href,
+          listingId,
+          placement,
+          trackingSource
+        )
       }
     >
       {pills && pills.length > 0 && (

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import Image from 'next/image'
+import { trackNewsletterSignup } from '@/lib/analytics'
 import styles from './NewsletterSignup.module.css'
 
 const SUBSCRIBE_URL = 'https://aisafetyeventsandtraining.substack.com/subscribe'
@@ -10,13 +11,19 @@ const SUBSCRIBE_URL = 'https://aisafetyeventsandtraining.substack.com/subscribe'
 // custom newsletter platform lands.
 export default function NewsletterSignup({
   heading = 'Get a weekly summary of all new events and training programs',
+  trackingPage,
 }: {
   heading?: string
+  /** Analytics page name (e.g. 'Events'). When set, a submit records a
+   *  newsletter_signup event under this page. */
+  trackingPage?: string
 }) {
   const [email, setEmail] = useState('')
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    // On the form, not the button, so Enter submits count the same as clicks.
+    if (trackingPage) trackNewsletterSignup(trackingPage)
     const trimmed = email.trim()
     const url = trimmed
       ? `${SUBSCRIBE_URL}?email=${encodeURIComponent(trimmed)}`

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -13,6 +13,8 @@ interface PageHeaderProps {
   topPadding?: string
   /** Show the newsletter signup beside the header (stacked below on mobile). */
   newsletter?: boolean
+  /** Analytics page name for the signup box's submits (e.g. 'Events'). */
+  newsletterTrackingPage?: string
   /** Extra content under the description, e.g. a cross-link to a sister page. */
   children?: ReactNode
 }
@@ -25,6 +27,7 @@ export default function PageHeader({
   id,
   topPadding = 'padding-top-56px',
   newsletter,
+  newsletterTrackingPage,
   children,
 }: PageHeaderProps) {
   const header = (
@@ -55,7 +58,7 @@ export default function PageHeader({
     <div className={`${styles.heroRow} padding-bottom-56px`}>
       <div className={styles.heroHeader}>{header}</div>
       <div className={styles.newsletterSlot}>
-        <NewsletterSignup />
+        <NewsletterSignup trackingPage={newsletterTrackingPage} />
       </div>
     </div>
   )

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -186,6 +186,28 @@ export function trackListingHover(
 }
 
 /**
+ * Track a visitor turning a filter value on (a sidebar checkbox or a dropdown
+ * option) on a resource page. Deselections aren't recorded — the activation is
+ * the expression of interest. `source` carries the filter group's title (e.g.
+ * 'Type'), `label` the value picked (e.g. 'Fellowship').
+ */
+export function trackFilterApply(
+  page: string,
+  group: string,
+  value: string
+): void {
+  if (typeof window === 'undefined') return
+  if (isTrackingOptedOut()) return
+  window._paq?.push(['trackEvent', `Filters - ${page}`, group, value])
+  sendTrackEvent({
+    type: 'filter_apply',
+    page,
+    source: group,
+    label: value,
+  })
+}
+
+/**
  * Track a page visit. Fired on every route change, initial load included (see
  * MatomoRouteTracker). Matomo records its own page views via its snippet —
  * this is the first-party copy that ad blockers can't strip, and it carries

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -208,6 +208,43 @@ export function trackFilterApply(
 }
 
 /**
+ * Track a click on a page's contribute buttons: the "Add a …" / "Suggest a
+ * correction" rows or an extra action row. `action` slugs the button
+ * ('add' | 'correction' | 'extra'), `label` is its visible text. The "View
+ * data in Airtable" card is not a contribution — see trackAirtableView.
+ */
+export function trackContributeClick(
+  page: string,
+  action: string,
+  label: string,
+  url: string
+): void {
+  if (typeof window === 'undefined') return
+  if (isTrackingOptedOut()) return
+  window._paq?.push(['trackEvent', `Contribute - ${page}`, label, url])
+  sendTrackEvent({
+    type: 'contribute_click',
+    page,
+    source: action,
+    label,
+    url,
+  })
+}
+
+/** Track a click on a page's "View data in Airtable" card. */
+export function trackAirtableView(page: string, url: string): void {
+  if (typeof window === 'undefined') return
+  if (isTrackingOptedOut()) return
+  window._paq?.push(['trackEvent', `Airtable - ${page}`, 'View data', url])
+  sendTrackEvent({
+    type: 'airtable_view',
+    page,
+    label: 'View data in Airtable',
+    url,
+  })
+}
+
+/**
  * Track a page visit. Fired on every route change, initial load included (see
  * MatomoRouteTracker). Matomo records its own page views via its snippet —
  * this is the first-party copy that ad blockers can't strip, and it carries

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -231,6 +231,23 @@ export function trackContributeClick(
   })
 }
 
+/**
+ * Track a submit of the newsletter signup box (arrow click or Enter — both
+ * fire the form's submit). Counts the attempt: the submit opens Substack's
+ * subscribe page, so completion happens off-site. The email itself is never
+ * recorded.
+ */
+export function trackNewsletterSignup(page: string): void {
+  if (typeof window === 'undefined') return
+  if (isTrackingOptedOut()) return
+  window._paq?.push(['trackEvent', `Newsletter - ${page}`, 'Signup'])
+  sendTrackEvent({
+    type: 'newsletter_signup',
+    page,
+    label: 'Newsletter signup',
+  })
+}
+
 /** Track a click on a page's "View data in Airtable" card. */
 export function trackAirtableView(page: string, url: string): void {
   if (typeof window === 'undefined') return

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -77,6 +77,13 @@ export const ALLOWED_EVENT_TYPES = new Set<string>([
   // A visitor turning a filter value on (sidebar checkbox or dropdown option).
   // `source` is the filter group's title, `label` the value picked.
   'filter_apply',
+  // A click on a page's contribute buttons: the "Add a …" / "Suggest a
+  // correction" rows or an extra action row. `source` slugs the button
+  // ('add' | 'correction' | 'extra'), `label` is its visible text.
+  'contribute_click',
+  // A click on a page's "View data in Airtable" card — data curiosity, not a
+  // contribution, so it's its own kind.
+  'airtable_view',
   'chatbot_open',
   'chatbot_message',
   'chatbot_click',
@@ -424,6 +431,15 @@ export interface DashboardData {
    *  whichever count mode is active (a share of visitors only makes sense
    *  that way). `visitors` is 0 when the range predates page-view tracking. */
   filterShareByPage: { name: string; filtered: number; visitors: number }[]
+  /** Contribute-button clicks (Add / Suggest a correction / extra rows) per
+   *  resource page — the Overview's rollup. */
+  contributeByPage: Counted[]
+  /** The selected page's contribute clicks per button label. */
+  contributeButtons: Counted[]
+  /** "View data in Airtable" card clicks per resource page. */
+  airtableByPage: Counted[]
+  /** The selected page's "View data in Airtable" card clicks. */
+  airtableViews: number
   /** For pages with a map (Map, Communities): `selectedPage`'s most-hovered
    *  map listings — tooltip dwells (500 ms cursor rest on desktop, first tap
    *  on mobile), grouped like `topListings` and following the same unique/
@@ -480,6 +496,10 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   filterValues: [],
   filterUsers: 0,
   filterShareByPage: [],
+  contributeByPage: [],
+  contributeButtons: [],
+  airtableByPage: [],
+  airtableViews: 0,
   topHovered: [],
   areaClicks: [],
   funnel: { opened: 0, typed: 0, clicked: 0 },
@@ -820,6 +840,27 @@ function aggregate(
     }))
     .sort((a, b) => b.filtered - a.filtered)
 
+  // Contribute-button and Airtable-card clicks. uniqueClicks dedupes on
+  // page+label, which is exactly the button identity here.
+  const contributeHits = inRange.filter(
+    e => e.type === 'contribute_click' && e.page
+  )
+  const contributeClicks = unique
+    ? uniqueClicks(contributeHits)
+    : contributeHits
+  const contributeByPage = tally(contributeClicks.map(e => e.page as string))
+  const contributeButtons = tally(
+    contributeClicks
+      .filter(e => e.page === selectedPage)
+      .map(e => listingMember(e))
+  )
+  const airtableHits = inRange.filter(e => e.type === 'airtable_view' && e.page)
+  const airtableClicks = unique ? uniqueClicks(airtableHits) : airtableHits
+  const airtableByPage = tally(airtableClicks.map(e => e.page as string))
+  const airtableViews = airtableClicks.filter(
+    e => e.page === selectedPage
+  ).length
+
   // Most-hovered map listings for the selected page — tooltip dwells
   // (listing_hover events), grouped exactly like topListings but with no
   // position (hovers aren't slotted) and no source narrowing (every hover is
@@ -865,6 +906,10 @@ function aggregate(
     filterValues,
     filterUsers,
     filterShareByPage,
+    contributeByPage,
+    contributeButtons,
+    airtableByPage,
+    airtableViews,
     topHovered,
     areaClicks,
     funnel: {

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -84,6 +84,10 @@ export const ALLOWED_EVENT_TYPES = new Set<string>([
   // A click on a page's "View data in Airtable" card — data curiosity, not a
   // contribution, so it's its own kind.
   'airtable_view',
+  // A submit of the newsletter signup box (Events/Training). Counts the
+  // attempt — the submit opens Substack's subscribe page, so completion
+  // happens off-site. Never carries the email address.
+  'newsletter_signup',
   'chatbot_open',
   'chatbot_message',
   'chatbot_click',
@@ -440,6 +444,11 @@ export interface DashboardData {
   airtableByPage: Counted[]
   /** The selected page's "View data in Airtable" card clicks. */
   airtableViews: number
+  /** Newsletter signup-box submits per page (the box lives on Events and
+   *  Training). Submits, not confirmed Substack subscriptions. */
+  newsletterByPage: Counted[]
+  /** The selected page's newsletter signup-box submits. */
+  newsletterSignups: number
   /** For pages with a map (Map, Communities): `selectedPage`'s most-hovered
    *  map listings — tooltip dwells (500 ms cursor rest on desktop, first tap
    *  on mobile), grouped like `topListings` and following the same unique/
@@ -500,6 +509,8 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   contributeButtons: [],
   airtableByPage: [],
   airtableViews: 0,
+  newsletterByPage: [],
+  newsletterSignups: 0,
   topHovered: [],
   areaClicks: [],
   funnel: { opened: 0, typed: 0, clicked: 0 },
@@ -860,6 +871,16 @@ function aggregate(
   const airtableViews = airtableClicks.filter(
     e => e.page === selectedPage
   ).length
+  const newsletterHits = inRange.filter(
+    e => e.type === 'newsletter_signup' && e.page
+  )
+  const newsletterSubmits = unique
+    ? uniqueClicks(newsletterHits)
+    : newsletterHits
+  const newsletterByPage = tally(newsletterSubmits.map(e => e.page as string))
+  const newsletterSignups = newsletterSubmits.filter(
+    e => e.page === selectedPage
+  ).length
 
   // Most-hovered map listings for the selected page — tooltip dwells
   // (listing_hover events), grouped exactly like topListings but with no
@@ -910,6 +931,8 @@ function aggregate(
     contributeButtons,
     airtableByPage,
     airtableViews,
+    newsletterByPage,
+    newsletterSignups,
     topHovered,
     areaClicks,
     funnel: {

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -394,12 +394,15 @@ export interface DashboardData {
   /** Every click across every page bucketed by the slot it happened in, ordered
    *  F1, F2, 1, 2, 3… — the site-wide version of `byPosition`. */
   byPositionOverall: Counted[]
-  /** For pages with a map (Map, Communities): the selected page's clicks split
-   *  into 'Map' vs 'Cards'. Empty for pages without a map. Always the full split,
-   *  even when one source is selected, so the user can switch between them. */
+  /** For pages in PAGE_SPLITS: the selected page's clicks split across the
+   *  page's surfaces or views (Map vs Cards on map pages, Online vs In person
+   *  on Events, Upcoming vs Recurring on Training). Empty for other pages.
+   *  Always the full split, even when one source is selected, so the user can
+   *  switch between them. */
   bySource: Counted[]
-  /** The source the per-listing panels are filtered to ('map' | 'cards' |
-   *  'untracked'), or null for all sources. Only ever set on map pages. */
+  /** The source the per-listing panels are filtered to (a slug of one of the
+   *  page's split labels, or 'untracked'), or null for all sources. Only ever
+   *  set on pages in PAGE_SPLITS. */
   selectedSource: string | null
   /** For pages with a map (Map, Communities): `selectedPage`'s most-hovered
    *  map listings — tooltip dwells (500 ms cursor rest on desktop, first tap
@@ -472,11 +475,27 @@ const EMPTY: Omit<DashboardData, 'source'> = {
 }
 
 /** Source filters offered on map pages. 'untracked' = neither map nor cards. */
-const SOURCE_FILTERS = new Set(['map', 'cards', 'untracked'])
-
 /** Resource pages that have a map above their card list, so a click can come
- *  from either surface. These are the only pages that get a source breakdown. */
+ *  from either surface. Gates the hover panels (only maps emit hovers). */
 const MAP_PAGES = new Set(['Map', 'Communities'])
+
+/** Pages whose clicks are split across two surfaces or views, and the display
+ *  labels of the split. A click's `source` carries the slug of the label it
+ *  happened under (map pages tag the surface, Events/Training tag the active
+ *  view toggle); untagged clicks — logged before the split was tracked — fall
+ *  into an 'Untracked' bucket rather than being miscounted. */
+const PAGE_SPLITS: Record<string, string[]> = {
+  Map: ['Map', 'Cards'],
+  Communities: ['Map', 'Cards'],
+  Events: ['Online', 'In person'],
+  Training: ['Upcoming', 'Recurring'],
+}
+
+/** 'In person' → 'in-person': how a split label appears in a click's `source`
+ *  and in the dashboard's ?source query param. */
+export function sourceSlug(label: string): string {
+  return label.toLowerCase().replace(/ /g, '-')
+}
 
 /** What a listing click is counted under. Prefer the human label; fall back to
  *  id/url so nothing is silently dropped. */
@@ -636,18 +655,21 @@ function aggregate(
       ? 'Funding'
       : (pageNames[0] ?? null)
 
-  // On a map page the panels can be filtered to one click source. The split
-  // itself (bySource, below) is always computed from every click on the page so
-  // the user can switch sources; only the per-listing panels narrow.
-  const isMapPage = selectedPage != null && MAP_PAGES.has(selectedPage)
+  // On a page with a split (map surface, or the Events/Training view toggle)
+  // the panels can be filtered to one click source. The split itself (bySource,
+  // below) is always computed from every click on the page so the user can
+  // switch sources; only the per-listing panels narrow.
+  const split = selectedPage != null ? PAGE_SPLITS[selectedPage] : undefined
+  const splitSlugs = split?.map(sourceSlug) ?? []
   const selectedSource =
-    isMapPage && sourceReq && SOURCE_FILTERS.has(sourceReq) ? sourceReq : null
+    split && sourceReq && [...splitSlugs, 'untracked'].includes(sourceReq)
+      ? sourceReq
+      : null
   const matchesSource = (e: AnalyticsEvent): boolean => {
-    if (selectedSource === 'map') return e.source === 'map'
-    if (selectedSource === 'cards') return e.source === 'cards'
+    if (selectedSource == null) return true // no filter
     if (selectedSource === 'untracked')
-      return e.source !== 'map' && e.source !== 'cards'
-    return true // no filter
+      return e.source == null || !splitSlugs.includes(e.source)
+    return e.source === selectedSource
   }
 
   // For the selected page: total clicks per listing, the range of slots each was
@@ -688,24 +710,22 @@ function aggregate(
     clicks.map(e => e.position).filter((p): p is string => p != null)
   )
 
-  // Source split, only for pages with a map. Clicks are explicitly tagged 'map'
-  // or 'cards' at click time; anything untagged (logged before source tracking,
-  // or a surface we don't tag) is its own 'Untracked' bucket rather than being
-  // miscounted as a card. Honours the unique/total mode (same pageClicks). Only
+  // Source split, only for pages in PAGE_SPLITS. Clicks are explicitly tagged
+  // at click time; anything untagged (logged before source tracking, or a
+  // surface we don't tag) is its own 'Untracked' bucket rather than being
+  // miscounted. Honours the unique/total mode (same pageClicks). Only
   // non-empty buckets are shown.
   let bySource: Counted[] = []
-  if (isMapPage) {
-    let map = 0
-    let cards = 0
+  if (split) {
+    const counts = new Map<string, number>(split.map(label => [label, 0]))
     let untracked = 0
     for (const e of pageClicksAll) {
-      if (e.source === 'map') map += 1
-      else if (e.source === 'cards') cards += 1
+      const label = split.find(l => sourceSlug(l) === e.source)
+      if (label) counts.set(label, (counts.get(label) ?? 0) + 1)
       else untracked += 1
     }
     bySource = [
-      { name: 'Map', count: map },
-      { name: 'Cards', count: cards },
+      ...split.map(label => ({ name: label, count: counts.get(label) ?? 0 })),
       { name: 'Untracked', count: untracked },
     ].filter(r => r.count > 0)
   }
@@ -718,7 +738,7 @@ function aggregate(
   // same per-visitor-per-day dedupe as clicks. Map pages only — no other page
   // emits hover events.
   let topHovered: ListingRow[] = []
-  if (isMapPage) {
+  if (selectedPage != null && MAP_PAGES.has(selectedPage)) {
     const hoverHits = inRange.filter(e => e.type === 'listing_hover' && e.page)
     const hovers = (unique ? uniqueClicks(hoverHits) : hoverHits).filter(
       e => e.page === selectedPage

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -447,8 +447,6 @@ export interface DashboardData {
   /** Newsletter signup-box submits per page (the box lives on Events and
    *  Training). Submits, not confirmed Substack subscriptions. */
   newsletterByPage: Counted[]
-  /** The selected page's newsletter signup-box submits. */
-  newsletterSignups: number
   /** For pages with a map (Map, Communities): `selectedPage`'s most-hovered
    *  map listings — tooltip dwells (500 ms cursor rest on desktop, first tap
    *  on mobile), grouped like `topListings` and following the same unique/
@@ -510,7 +508,6 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   airtableByPage: [],
   airtableViews: 0,
   newsletterByPage: [],
-  newsletterSignups: 0,
   topHovered: [],
   areaClicks: [],
   funnel: { opened: 0, typed: 0, clicked: 0 },
@@ -878,9 +875,6 @@ function aggregate(
     ? uniqueClicks(newsletterHits)
     : newsletterHits
   const newsletterByPage = tally(newsletterSubmits.map(e => e.page as string))
-  const newsletterSignups = newsletterSubmits.filter(
-    e => e.page === selectedPage
-  ).length
 
   // Most-hovered map listings for the selected page — tooltip dwells
   // (listing_hover events), grouped exactly like topListings but with no
@@ -932,7 +926,6 @@ function aggregate(
     airtableByPage,
     airtableViews,
     newsletterByPage,
-    newsletterSignups,
     topHovered,
     areaClicks,
     funnel: {

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -74,6 +74,9 @@ export const ALLOWED_EVENT_TYPES = new Set<string>([
   // A visitor resting on a map listing (Map, Communities): a 500 ms cursor
   // dwell on desktop, or the tap that opens the tooltip on mobile.
   'listing_hover',
+  // A visitor turning a filter value on (sidebar checkbox or dropdown option).
+  // `source` is the filter group's title, `label` the value picked.
+  'filter_apply',
   'chatbot_open',
   'chatbot_message',
   'chatbot_click',
@@ -404,6 +407,23 @@ export interface DashboardData {
    *  page's split labels, or 'untracked'), or null for all sources. Only ever
    *  set on pages in PAGE_SPLITS. */
   selectedSource: string | null
+  /** Filter activations per resource page — the Overview's "how much do
+   *  filters get used where" table. */
+  filtersByPage: Counted[]
+  /** The selected page's filter activations per filter group ('Type',
+   *  'Focus', …). */
+  filterGroups: Counted[]
+  /** The selected page's filter activations per 'Group: Value' pair, ranked —
+   *  the "which options do people actually pick" table. */
+  filterValues: Counted[]
+  /** Distinct visitors who turned on at least one filter on the selected page
+   *  in range. */
+  filterUsers: number
+  /** Per page with filter activity: distinct visitors who turned on at least
+   *  one filter vs the page's distinct visitors — always per-visitor,
+   *  whichever count mode is active (a share of visitors only makes sense
+   *  that way). `visitors` is 0 when the range predates page-view tracking. */
+  filterShareByPage: { name: string; filtered: number; visitors: number }[]
   /** For pages with a map (Map, Communities): `selectedPage`'s most-hovered
    *  map listings — tooltip dwells (500 ms cursor rest on desktop, first tap
    *  on mobile), grouped like `topListings` and following the same unique/
@@ -455,6 +475,11 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   byPositionOverall: [],
   bySource: [],
   selectedSource: null,
+  filtersByPage: [],
+  filterGroups: [],
+  filterValues: [],
+  filterUsers: 0,
+  filterShareByPage: [],
   topHovered: [],
   areaClicks: [],
   funnel: { opened: 0, typed: 0, clicked: 0 },
@@ -563,6 +588,29 @@ function uniqueClicks(clicks: AnalyticsEvent[]): AnalyticsEvent[] {
       ? ''
       : new Date(t - 5 * 3_600_000).toISOString().slice(0, 10)
     const key = `${e.vid}\x00${day}\x00${e.page ?? ''}\x00${listingMember(e)}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(e)
+  }
+  return out
+}
+
+/** Unique-mode dedupe for filter activations: one per visitor per group+value
+ *  per Bogotá day. The group (`source`) is part of the key — the same value
+ *  under two groups (e.g. 'Online') stays two activations. */
+function uniqueFilterApplies(events: AnalyticsEvent[]): AnalyticsEvent[] {
+  const seen = new Set<string>()
+  const out: AnalyticsEvent[] = []
+  for (const e of events) {
+    if (!e.vid) {
+      out.push(e)
+      continue
+    }
+    const t = Date.parse(e.ts)
+    const day = Number.isNaN(t)
+      ? ''
+      : new Date(t - 5 * 3_600_000).toISOString().slice(0, 10)
+    const key = `${e.vid}\x00${day}\x00${e.page ?? ''}\x00${e.source ?? ''}\x00${e.label ?? ''}`
     if (seen.has(key)) continue
     seen.add(key)
     out.push(e)
@@ -730,6 +778,48 @@ function aggregate(
     ].filter(r => r.count > 0)
   }
 
+  // Filter usage. One filter_apply per value a visitor turns on; unique mode
+  // counts each group+value once per visitor per day, total mode every toggle.
+  const filterHits = inRange.filter(e => e.type === 'filter_apply' && e.page)
+  const filterApplies = unique ? uniqueFilterApplies(filterHits) : filterHits
+  const filtersByPage = tally(filterApplies.map(e => e.page as string))
+  const pageFilters = filterApplies.filter(e => e.page === selectedPage)
+  const filterGroups = tally(pageFilters.map(e => e.source ?? '(unknown)'))
+  const filterValues = tally(
+    pageFilters.map(
+      e => `${e.source ?? '(unknown)'}: ${e.label ?? '(unknown)'}`
+    )
+  )
+  const filterUsers = uniqueUsers(
+    filterHits.filter(e => e.page === selectedPage)
+  )
+
+  // % of a page's visitors who filter: distinct filtering vids per page against
+  // distinct page_view vids per page. Deliberately ignores the unique/total
+  // mode — a share of visitors is only meaningful per-visitor.
+  const filteredVidsByPage = new Map<string, Set<string>>()
+  for (const e of filterHits) {
+    if (!e.vid || !e.page) continue
+    const set = filteredVidsByPage.get(e.page) ?? new Set<string>()
+    set.add(e.vid)
+    filteredVidsByPage.set(e.page, set)
+  }
+  const viewVidsByPage = new Map<string, Set<string>>()
+  for (const e of inRange) {
+    if (e.type !== 'page_view' || !e.page || !e.vid) continue
+    const name = PAGE_NAME_BY_PATH[e.page] ?? e.page
+    const set = viewVidsByPage.get(name) ?? new Set<string>()
+    set.add(e.vid)
+    viewVidsByPage.set(name, set)
+  }
+  const filterShareByPage = [...filteredVidsByPage.entries()]
+    .map(([name, vids]) => ({
+      name,
+      filtered: vids.size,
+      visitors: viewVidsByPage.get(name)?.size ?? 0,
+    }))
+    .sort((a, b) => b.filtered - a.filtered)
+
   // Most-hovered map listings for the selected page — tooltip dwells
   // (listing_hover events), grouped exactly like topListings but with no
   // position (hovers aren't slotted) and no source narrowing (every hover is
@@ -770,6 +860,11 @@ function aggregate(
     byPositionOverall,
     bySource,
     selectedSource,
+    filtersByPage,
+    filterGroups,
+    filterValues,
+    filterUsers,
+    filterShareByPage,
     topHovered,
     areaClicks,
     funnel: {


### PR DESCRIPTION
- **Slot stamping (Training/Events)**: featured cards record F1/F2, list cards their number in the full unfiltered list — same `placementsById` wiring as every other page. Fixes the empty "Clicks by position" panel and dashed Slot column; clicks also carry the Airtable record id.
- **View split (Training/Events)**: clicks record the active view (Online / In person on Events, Upcoming / Recurring on Training). The dashboard's split pills generalise — map pages keep "Clicks by source", Training/Events get "Clicks by view" — and narrow the per-page panels. Pre-existing clicks show as Untracked; the pill row appears once a page has clicks in range.
- **Filter tracking (all resource pages)**: new `filter_apply` event when a visitor turns a filter value on, wired centrally into the shared FilterGroup/FilterDropdown components (plus the Events city search) across the 11 pages with filters. Dashboard: "Filter use by page" on the Overview (uses, filtering visitors, % of the page's visitors) and per-page "Filter usage" / "Filter values" panels.
- **Contribute + Airtable tracking (10 pages with the sidebar)**: `contribute_click` for the "Add a …" / "Suggest a correction" / extra rows, and a separate `airtable_view` for the "View data in Airtable" card. Per-page "Contribute buttons" panel (with the site's button icons) beside an Airtable count; Overview rollups for both.
- **Newsletter tracking (/events + /training)**: `newsletter_signup` fired on the form submit (Enter or arrow click). Shown only on the Overview's "Newsletter signups by page" table — submits may not all be successful signups, and the email is never recorded.
- All new data starts accumulating at deploy; the track API widens `source` to 32 chars for filter-group titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)