### PR TITLE
Move map zoom controls to top right + shared MapControls component

### DIFF
--- a/src/app/communities/CommunitiesMap.tsx
+++ b/src/app/communities/CommunitiesMap.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import Script from 'next/script'
 import Image from 'next/image'
+import MapControls from '@/components/MapControls'
 import styles from './page.module.css'
 import { Community } from '@/lib/data/communities'
 import { positionTooltip } from '@/lib/mapTooltip'
@@ -11,6 +12,9 @@ import { trackListingClick, trackListingHover } from '@/lib/analytics'
 interface CommunitiesMapProps {
   communities: Community[]
 }
+
+const INITIAL_CENTER: [number, number] = [0, 30]
+const INITIAL_ZOOM = 1.5
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 declare global {
@@ -73,15 +77,12 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
     mapboxgl.accessToken =
       'pk.eyJ1IjoiYWxpZ25tZW50ZWNvc3lzdGVtZGV2ZWxvcG1lbnQiLCJhIjoiY201YnNnbnpzNTEyNTJtcHYzMWVhand6OSJ9._HknM4VVUlEU6mbv8NagGw'
 
-    const initialCenter: [number, number] = [0, 30]
-    const initialZoom = 1.5
-
     const map = new mapboxgl.Map({
       container: mapContainer,
       style:
         'mapbox://styles/alignmentecosystemdevelopment/cmh1t3h6u00e401st9gu75gvq',
-      center: initialCenter,
-      zoom: initialZoom,
+      center: INITIAL_CENTER,
+      zoom: INITIAL_ZOOM,
       logoPosition: 'bottom-right',
     })
     mapRef.current = map
@@ -90,67 +91,10 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
     // dev tools mobile mode toggled after load).
     const isMobile = () => window.innerWidth < 768
 
-    // Touchend-blur fires only on touch devices anyway, so it's safe to
-    // always register — no need to gate on viewport width.
-    setTimeout(() => {
-      const mapButtons = document.querySelectorAll(
-        '.mapboxgl-ctrl-group button'
-      )
-      mapButtons.forEach(button => {
-        button.addEventListener('touchend', function (this: HTMLElement) {
-          setTimeout(() => this.blur(), 100)
-        })
-      })
-    }, 500)
-
-    map.addControl(new mapboxgl.NavigationControl())
-
     // Mapbox doesn't auto-resize when its container changes size (e.g. via
     // CSS media queries). Watch the container and tell Mapbox to recalculate.
     const resizeObserver = new ResizeObserver(() => map.resize())
     resizeObserver.observe(mapContainer)
-
-    const resetMapView = () => {
-      map.flyTo({
-        center: initialCenter,
-        zoom: initialZoom,
-        bearing: 0,
-        pitch: 0,
-        duration: 500,
-        essential: true,
-      })
-    }
-
-    // Repurpose Mapbox's compass button as a "reset map view" button.
-    // addControl synchronously inserts the compass into the DOM, so this
-    // runs reliably without depending on the map 'load' event or pin image
-    // load — both of which previously caused the icon and click handler to
-    // intermittently fail to apply, making the button look missing.
-    const compassButton = mapContainer.querySelector(
-      '.mapboxgl-ctrl-compass'
-    ) as HTMLElement | null
-    if (compassButton) {
-      const iconElement = compassButton.querySelector(
-        '.mapboxgl-ctrl-icon'
-      ) as HTMLElement | null
-      if (iconElement) iconElement.style.backgroundImage = 'none'
-      const resetIconDataUri =
-        "data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8 3.5a4.5 4.5 0 1 0 0 9 4.5 4.5 0 0 0 0-9ZM2.5 8a5.5 5.5 0 1 1 11 0 5.5 5.5 0 0 1-11 0Z' fill='white'/%3E%3Ccircle cx='8' cy='8' r='1.5' fill='white'/%3E%3C/svg%3E"
-      compassButton.style.backgroundImage = `url("${resetIconDataUri}")`
-      compassButton.style.backgroundSize = '18px 18px'
-      compassButton.style.backgroundRepeat = 'no-repeat'
-      compassButton.style.backgroundPosition = 'center'
-      compassButton.addEventListener(
-        'click',
-        ev => {
-          ev.preventDefault()
-          ev.stopPropagation()
-          resetMapView()
-        },
-        true
-      )
-      compassButton.setAttribute('title', 'Reset map view')
-    }
 
     // Start loading the pin image immediately, in parallel with the map
     // style. Wrapping it in a promise lets us await it alongside the map's
@@ -574,7 +518,7 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
             target.isContentEditable)
         )
           return
-        resetMapView()
+        handleResetView()
       }
 
       tooltip.addEventListener('click', handleTooltipClick)
@@ -621,6 +565,25 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
 
   function handleScriptLoad() {
     setScriptLoaded(true)
+  }
+
+  function handleZoomIn() {
+    mapRef.current?.zoomIn()
+  }
+
+  function handleZoomOut() {
+    mapRef.current?.zoomOut()
+  }
+
+  function handleResetView() {
+    mapRef.current?.flyTo({
+      center: INITIAL_CENTER,
+      zoom: INITIAL_ZOOM,
+      bearing: 0,
+      pitch: 0,
+      duration: 500,
+      essential: true,
+    })
   }
 
   function handleViewOnline() {
@@ -683,6 +646,12 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
           <p>View online communities</p>
           <Image src="/images/arrow-down.svg" alt="" width={12} height={12} />
         </button>
+        <MapControls
+          className={styles.mapControls}
+          onZoomIn={handleZoomIn}
+          onZoomOut={handleZoomOut}
+          onReset={handleResetView}
+        />
       </div>
       <div
         ref={tooltipRef}

--- a/src/app/communities/page.module.css
+++ b/src/app/communities/page.module.css
@@ -69,18 +69,16 @@
   }
 }
 
-/* Mapbox controls position - bottom-right on both desktop and mobile */
+/* Mapbox controls position - top-right on both desktop and mobile,
+   matching the /map zoom controls (24px insets) */
 :global(.mapboxgl-ctrl-top-right) {
-  top: auto !important;
-  bottom: 16px !important;
-  right: 8px !important;
+  top: 24px !important;
+  right: 24px !important;
   z-index: 3 !important;
 }
 
-@media (max-width: 991px) {
-  :global(.mapboxgl-ctrl-top-right .mapboxgl-ctrl) {
-    margin: 0 !important;
-  }
+:global(.mapboxgl-ctrl-top-right .mapboxgl-ctrl) {
+  margin: 0 !important;
 }
 
 /* Mapbox tooltip */
@@ -242,5 +240,11 @@
     top: 24px;
     max-width: none;
     white-space: nowrap;
+  }
+
+  /* The nowrap title spans nearly the full width on small screens,
+     so drop the controls below it */
+  :global(.mapboxgl-ctrl-top-right) {
+    top: 72px !important;
   }
 }

--- a/src/app/communities/page.module.css
+++ b/src/app/communities/page.module.css
@@ -69,16 +69,13 @@
   }
 }
 
-/* Mapbox controls position - top-right on both desktop and mobile,
-   matching the /map zoom controls (24px insets) */
-:global(.mapboxgl-ctrl-top-right) {
-  top: 24px !important;
-  right: 24px !important;
-  z-index: 3 !important;
-}
-
-:global(.mapboxgl-ctrl-top-right .mapboxgl-ctrl) {
-  margin: 0 !important;
+/* Map zoom controls - top-right on desktop, matching /map (24px insets);
+   bottom-right on mobile (see media query below) */
+.mapControls {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  z-index: 3;
 }
 
 /* Mapbox tooltip */
@@ -156,57 +153,6 @@
   flex-shrink: 0;
 }
 
-/* Mapbox control overrides */
-:global(.mapboxgl-ctrl-group) {
-  border-radius: 24px !important;
-  background-color: var(--teal-850) !important;
-  border: 1px solid var(--teal-700) !important;
-  box-shadow: 0px 12px 24px 0px rgba(0, 25, 27, 0.5) !important;
-  overflow: hidden !important;
-  transition: background-color var(--hover-transition) !important;
-}
-
-:global(.mapboxgl-ctrl-group:hover) {
-  background-color: var(--teal-800) !important;
-}
-
-:global(.mapboxgl-ctrl-group button) {
-  background-color: var(--teal-850) !important;
-  border: none !important;
-  box-shadow: none !important;
-  width: 40px !important;
-  height: 40px !important;
-  transition: background-color var(--hover-transition) !important;
-  -webkit-tap-highlight-color: transparent;
-  padding: 0 !important;
-  position: relative;
-  display: flex !important;
-  align-items: center !important;
-  background-size: 20px 20px !important;
-  background-repeat: no-repeat !important;
-  background-position: center !important;
-}
-
-:global(.mapboxgl-ctrl-group button:hover) {
-  background-color: var(--teal-800) !important;
-}
-
-:global(.mapboxgl-ctrl-group button + button) {
-  border-top: 1px solid var(--teal-700) !important;
-}
-
-:global(.mapboxgl-ctrl-zoom-in .mapboxgl-ctrl-icon) {
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 2.5C8.27614 2.5 8.5 2.72386 8.5 3V7.5H13C13.2761 7.5 13.5 7.72386 13.5 8C13.5 8.27614 13.2761 8.5 13 8.5H8.5V13C8.5 13.2761 8.27614 13.5 8 13.5C7.72386 13.5 7.5 13.2761 7.5 13V8.5H3C2.72386 8.5 2.5 8.27614 2.5 8C2.5 7.72386 2.72386 7.5 3 7.5H7.5V3C7.5 2.72386 7.72386 2.5 8 2.5Z' fill='white'/%3E%3C/svg%3E") !important;
-}
-
-:global(.mapboxgl-ctrl-zoom-out .mapboxgl-ctrl-icon) {
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2.5 8C2.5 7.72386 2.72386 7.5 3 7.5H13C13.2761 7.5 13.5 7.72386 13.5 8C13.5 8.27614 13.2761 8.5 13 8.5H3C2.72386 8.5 2.5 8.27614 2.5 8Z' fill='white'/%3E%3C/svg%3E") !important;
-}
-
-:global(.mapboxgl-ctrl-compass .mapboxgl-ctrl-icon) {
-  background-image: none !important;
-}
-
 :global(.mapboxgl-ctrl-bottom-right .mapboxgl-ctrl a) {
   filter: grayscale(1) brightness(0.3) !important;
   transition: filter var(--hover-transition) !important;
@@ -243,8 +189,9 @@
   }
 
   /* The nowrap title spans nearly the full width on small screens,
-     so drop the controls below it */
-  :global(.mapboxgl-ctrl-top-right) {
-    top: 72px !important;
+     so the controls move to the bottom corner instead */
+  .mapControls {
+    top: auto;
+    bottom: 24px;
   }
 }

--- a/src/app/map/D3Map.tsx
+++ b/src/app/map/D3Map.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect, useRef } from 'react'
 import * as d3 from 'd3'
+import MapControls from '@/components/MapControls'
 import { trackListingClick, trackListingHover } from '@/lib/analytics'
 import { positionTooltip } from '@/lib/mapTooltip'
 import styles from './page.module.css'
@@ -73,6 +74,13 @@ const AREA_LABELS = [
 export default function D3Map({ orgs }: D3MapProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
+  // Zoom actions live in the d3 pipeline inside useEffect; the buttons reach
+  // them through this ref.
+  const controlsRef = useRef({
+    zoomIn: () => {},
+    zoomOut: () => {},
+    reset: () => {},
+  })
 
   useEffect(() => {
     if (!containerRef.current || orgs.length === 0) return
@@ -483,25 +491,17 @@ export default function D3Map({ orgs }: D3MapProps) {
     })
 
     // Setup zoom controls
-    const zoomIn = document.getElementById('zoom-in')
-    const zoomOut = document.getElementById('zoom-out')
-    const recenter = document.getElementById('recenter')
-
-    if (zoomIn) {
-      zoomIn.onclick = () => {
-        svg.transition().duration(300).call(zoom.scaleBy, 1.5)
-      }
-    }
-    if (zoomOut) {
-      zoomOut.onclick = () => {
-        svg.transition().duration(300).call(zoom.scaleBy, 0.75)
-      }
-    }
     const resetView = () => {
       svg.transition().duration(500).call(zoom.transform, d3.zoomIdentity)
     }
-    if (recenter) {
-      recenter.onclick = resetView
+    controlsRef.current = {
+      zoomIn: () => {
+        svg.transition().duration(300).call(zoom.scaleBy, 1.5)
+      },
+      zoomOut: () => {
+        svg.transition().duration(300).call(zoom.scaleBy, 0.75)
+      },
+      reset: resetView,
     }
 
     // ESC resets the view, same as the recenter button. Skip while typing in
@@ -576,62 +576,12 @@ export default function D3Map({ orgs }: D3MapProps) {
     <>
       <div ref={containerRef} className={styles['map-container']} />
 
-      {/* Zoom controls - styled to match communities map */}
-      <div className={styles['map-controls']}>
-        <div className={styles['map-control-group']}>
-          <button
-            id="zoom-in"
-            className={styles['map-control-button']}
-            title="Zoom in"
-          >
-            <svg
-              viewBox="0 0 16 16"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 2.5C8.27614 2.5 8.5 2.72386 8.5 3V7.5H13C13.2761 7.5 13.5 7.72386 13.5 8C13.5 8.27614 13.2761 8.5 13 8.5H8.5V13C8.5 13.2761 8.27614 13.5 8 13.5C7.72386 13.5 7.5 13.2761 7.5 13V8.5H3C2.72386 8.5 2.5 8.27614 2.5 8C2.5 7.72386 2.72386 7.5 3 7.5H7.5V3C7.5 2.72386 7.72386 2.5 8 2.5Z"
-                fill="white"
-              />
-            </svg>
-          </button>
-          <button
-            id="zoom-out"
-            className={styles['map-control-button']}
-            title="Zoom out"
-          >
-            <svg
-              viewBox="0 0 16 16"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M2.5 8C2.5 7.72386 2.72386 7.5 3 7.5H13C13.2761 7.5 13.5 7.72386 13.5 8C13.5 8.27614 13.2761 8.5 13 8.5H3C2.72386 8.5 2.5 8.27614 2.5 8Z"
-                fill="white"
-              />
-            </svg>
-          </button>
-          <button
-            id="recenter"
-            className={styles['map-control-button']}
-            title="Reset view"
-          >
-            <svg
-              viewBox="0 0 16 16"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M8 3.5a4.5 4.5 0 1 0 0 9 4.5 4.5 0 0 0 0-9ZM2.5 8a5.5 5.5 0 1 1 11 0 5.5 5.5 0 0 1-11 0Z"
-                fill="white"
-              />
-              <circle cx="8" cy="8" r="1.5" fill="white" />
-            </svg>
-          </button>
-        </div>
-      </div>
+      <MapControls
+        className={styles['map-controls']}
+        onZoomIn={() => controlsRef.current.zoomIn()}
+        onZoomOut={() => controlsRef.current.zoomOut()}
+        onReset={() => controlsRef.current.reset()}
+      />
 
       {/* Tooltip — always in DOM for measuring, visibility toggled via ref */}
       <div

--- a/src/app/map/page.module.css
+++ b/src/app/map/page.module.css
@@ -25,54 +25,6 @@
   z-index: 95;
 }
 
-.map-control-group {
-  display: flex;
-  flex-direction: column;
-  width: 40px;
-  background-color: #0e2628;
-  border: 1px solid #394c4e;
-  border-radius: 24px;
-  overflow: hidden;
-  box-shadow: 0px 12px 24px 0px rgba(0, 25, 27, 0.5);
-}
-
-.map-control-group:hover {
-  background-color: #1c3334;
-}
-
-.map-control-button {
-  width: 100%;
-  height: 40px;
-  background-color: #0e2628;
-  color: white;
-  border: none;
-  border-radius: 0;
-  cursor: pointer;
-  user-select: none;
-  transition: background-color var(--hover-transition);
-  -webkit-tap-highlight-color: transparent;
-  padding: 0;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.map-control-button svg {
-  display: block;
-  width: 20px;
-  height: 20px;
-  pointer-events: none;
-}
-
-.map-control-button:hover {
-  background-color: #1c3334;
-}
-
-.map-control-button + .map-control-button {
-  border-top: 1px solid #394c4e;
-}
-
 /* Map tooltip — matches communities mapbox-tooltip */
 .map-tooltip {
   position: fixed;

--- a/src/app/map/page.module.css
+++ b/src/app/map/page.module.css
@@ -14,14 +14,14 @@
   height: 100%;
 }
 
-/* Map zoom controls - bottom-left, stacked above the View cards button
-   (the bottom-right corner belongs to the assistant bubble).
+/* Map zoom controls - top-right, clear of the assistant bubble and the
+   View cards button (both bottom corners).
    z-index must stay below the assistant scrim/panel/pill (96-100) so the
    open chat covers the controls instead of them poking through. */
 .map-controls {
   position: absolute;
-  bottom: 88px;
-  left: 24px;
+  top: 24px;
+  right: 24px;
   z-index: 95;
 }
 

--- a/src/components/MapControls.module.css
+++ b/src/components/MapControls.module.css
@@ -1,0 +1,47 @@
+.group {
+  display: flex;
+  flex-direction: column;
+  width: 40px;
+  background-color: var(--teal-850);
+  border: 1px solid var(--teal-700);
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: 0px 12px 24px 0px rgba(0, 25, 27, 0.5);
+}
+
+.group:hover {
+  background-color: var(--teal-800);
+}
+
+.button {
+  width: 100%;
+  height: 40px;
+  background-color: var(--teal-850);
+  color: white;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color var(--hover-transition);
+  -webkit-tap-highlight-color: transparent;
+  padding: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.button svg {
+  display: block;
+  width: 20px;
+  height: 20px;
+  pointer-events: none;
+}
+
+.button:hover {
+  background-color: var(--teal-800);
+}
+
+.button + .button {
+  border-top: 1px solid var(--teal-700);
+}

--- a/src/components/MapControls.tsx
+++ b/src/components/MapControls.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import styles from './MapControls.module.css'
+
+interface MapControlsProps {
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onReset: () => void
+  /** Positioning class from the page's CSS module (top/right offsets, z-index) */
+  className: string
+}
+
+export default function MapControls({
+  onZoomIn,
+  onZoomOut,
+  onReset,
+  className,
+}: MapControlsProps) {
+  return (
+    <div className={className}>
+      <div className={styles.group}>
+        <button className={styles.button} title="Zoom in" onClick={onZoomIn}>
+          <svg
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8 2.5C8.27614 2.5 8.5 2.72386 8.5 3V7.5H13C13.2761 7.5 13.5 7.72386 13.5 8C13.5 8.27614 13.2761 8.5 13 8.5H8.5V13C8.5 13.2761 8.27614 13.5 8 13.5C7.72386 13.5 7.5 13.2761 7.5 13V8.5H3C2.72386 8.5 2.5 8.27614 2.5 8C2.5 7.72386 2.72386 7.5 3 7.5H7.5V3C7.5 2.72386 7.72386 2.5 8 2.5Z"
+              fill="white"
+            />
+          </svg>
+        </button>
+        <button className={styles.button} title="Zoom out" onClick={onZoomOut}>
+          <svg
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M2.5 8C2.5 7.72386 2.72386 7.5 3 7.5H13C13.2761 7.5 13.5 7.72386 13.5 8C13.5 8.27614 13.2761 8.5 13 8.5H3C2.72386 8.5 2.5 8.27614 2.5 8Z"
+              fill="white"
+            />
+          </svg>
+        </button>
+        <button className={styles.button} title="Reset view" onClick={onReset}>
+          <svg
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M8 3.5a4.5 4.5 0 1 0 0 9 4.5 4.5 0 0 0 0-9ZM2.5 8a5.5 5.5 0 1 1 11 0 5.5 5.5 0 0 1-11 0Z"
+              fill="white"
+            />
+            <circle cx="8" cy="8" r="1.5" fill="white" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- /map and /communities zoom controls now sit top right of the map (24px insets); /communities mobile uses bottom right instead, since the title overlay spans the top of the screen there
- New shared `MapControls` component + stylesheet owns the button look on both maps (40px buttons, 20px icons) – fixes the /communities icons rendering smaller than /map's
- /communities drops Mapbox's built-in NavigationControl and the compass-repurposing workaround; the shared buttons call the map API directly (zoom, reset, ESC-to-reset unchanged)
- /poster-map keeps its own pink-themed controls on purpose

🤖 Generated with [Claude Code](https://claude.com/claude-code)