### PR TITLE
Track the footer's external links

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -368,6 +368,8 @@ function pillFor(e: { page?: string; type: string }): string | null {
   // but in the feed they should read as chatbot/search activity, not clicks.
   if (e.type.startsWith('chatbot')) return 'Chatbot'
   if (e.type.startsWith('search')) return 'Search'
+  // Footer clicks carry the raw path they happened on; 'Footer' reads better.
+  if (e.type === 'footer_click') return 'Footer'
   if (e.page) return e.page
   return null
 }
@@ -579,6 +581,7 @@ export default async function AnalyticsPage({
     (sum, r) => sum + r.count,
     0
   )
+  const footerTotal = data.footerClicks.reduce((sum, r) => sum + r.count, 0)
   const newsletterTotalByPage = data.newsletterByPage.reduce(
     (sum, r) => sum + r.count,
     0
@@ -1044,6 +1047,18 @@ export default async function AnalyticsPage({
                   Submits of the weekly-summary email box on /events and
                   /training – may not all be successful signups. Recording since
                   29 July 2026.
+                </p>
+              </Panel>
+              <Panel title="Footer clicks">
+                <CountTable
+                  rows={data.footerClicks}
+                  labelHead="Link"
+                  total={footerTotal}
+                />
+                <p className={styles.caption}>
+                  The footer&apos;s external links – the &quot;Help us out&quot;
+                  and &quot;Newsletters&quot; columns. Recording since 29 July
+                  2026.
                 </p>
               </Panel>
             </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import Image from 'next/image'
+import FooterLink from './FooterLink'
 import UpButton from './UpButton'
 import styles from './Footer.module.css'
 
@@ -38,27 +39,21 @@ export default function Footer() {
             <div
               className={`paragraph-small flex flex-col gap-8px opacity-80 ${styles.links}`}
             >
-              <Link
+              <FooterLink
                 href="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Suggest a correction
-              </Link>
-              <Link
+                section="Help us out"
+                label="Suggest a correction"
+              />
+              <FooterLink
                 href="https://airtable.com/appF8XfZUGXtfi40E/pageXZp18w3Sqm1Z7/form"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Give anonymous feedback
-              </Link>
-              <Link
+                section="Help us out"
+                label="Give anonymous feedback"
+              />
+              <FooterLink
                 href="https://www.every.org/alignment-ecosystem-development#/donate/card"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Donate
-              </Link>
+                section="Help us out"
+                label="Donate"
+              />
             </div>
           </div>
 
@@ -70,27 +65,21 @@ export default function Footer() {
             <div
               className={`paragraph-small flex flex-col gap-8px opacity-80 ${styles.links}`}
             >
-              <Link
+              <FooterLink
                 href="https://aisafetyeventsandtraining.substack.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                AI Safety Events &amp; Training
-              </Link>
-              <Link
+                section="Newsletters"
+                label="AI Safety Events & Training"
+              />
+              <FooterLink
                 href="https://aisafetyfunding.substack.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                AI Safety Funding
-              </Link>
-              <Link
+                section="Newsletters"
+                label="AI Safety Funding"
+              />
+              <FooterLink
                 href="https://aisafetycom.substack.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                AISafety.com Updates
-              </Link>
+                section="Newsletters"
+                label="AISafety.com Updates"
+              />
             </div>
           </div>
         </div>

--- a/src/components/FooterLink.tsx
+++ b/src/components/FooterLink.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import Link from 'next/link'
+import { trackFooterClick } from '@/lib/analytics'
+
+/** An external footer link that records its clicks — outbound, so nothing
+ *  else would. The tiny client wrapper keeps Footer itself server-rendered. */
+export default function FooterLink({
+  href,
+  section,
+  label,
+}: {
+  href: string
+  /** The footer column's heading, e.g. 'Help us out'. */
+  section: string
+  /** The link text, also what the click is recorded as. */
+  label: string
+}) {
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() => trackFooterClick(section, label, href)}
+    >
+      {label}
+    </Link>
+  )
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -248,6 +248,29 @@ export function trackNewsletterSignup(page: string): void {
   })
 }
 
+/**
+ * Track a click on one of the footer's external links (the "Help us out" and
+ * "Newsletters" columns) — outbound, so nothing else would record them.
+ * `section` is the column heading, `label` the link text; `page` is stamped
+ * with the path the footer was on, like page views.
+ */
+export function trackFooterClick(
+  section: string,
+  label: string,
+  url: string
+): void {
+  if (typeof window === 'undefined') return
+  if (isTrackingOptedOut()) return
+  window._paq?.push(['trackEvent', 'Footer', label, url])
+  sendTrackEvent({
+    type: 'footer_click',
+    page: window.location.pathname,
+    source: section,
+    label,
+    url,
+  })
+}
+
 /** Track a click on a page's "View data in Airtable" card. */
 export function trackAirtableView(page: string, url: string): void {
   if (typeof window === 'undefined') return

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -88,6 +88,11 @@ export const ALLOWED_EVENT_TYPES = new Set<string>([
   // attempt — the submit opens Substack's subscribe page, so completion
   // happens off-site. Never carries the email address.
   'newsletter_signup',
+  // A click on one of the footer's external links ("Help us out" /
+  // "Newsletters" columns) — outbound, so nothing else records them.
+  // `source` is the column heading, `label` the link text, `page` the path
+  // the footer was on.
+  'footer_click',
   'chatbot_open',
   'chatbot_message',
   'chatbot_click',
@@ -447,6 +452,9 @@ export interface DashboardData {
   /** Newsletter signup-box submits per page (the box lives on Events and
    *  Training). Submits, not confirmed Substack subscriptions. */
   newsletterByPage: Counted[]
+  /** Clicks on the footer's external links, one row per link ('Donate',
+   *  'AI Safety Funding', …), sitewide. */
+  footerClicks: Counted[]
   /** For pages with a map (Map, Communities): `selectedPage`'s most-hovered
    *  map listings — tooltip dwells (500 ms cursor rest on desktop, first tap
    *  on mobile), grouped like `topListings` and following the same unique/
@@ -508,6 +516,7 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   airtableByPage: [],
   airtableViews: 0,
   newsletterByPage: [],
+  footerClicks: [],
   topHovered: [],
   areaClicks: [],
   funnel: { opened: 0, typed: 0, clicked: 0 },
@@ -875,6 +884,9 @@ function aggregate(
     ? uniqueClicks(newsletterHits)
     : newsletterHits
   const newsletterByPage = tally(newsletterSubmits.map(e => e.page as string))
+  const footerHits = inRange.filter(e => e.type === 'footer_click')
+  const footerEvents = unique ? uniqueClicks(footerHits) : footerHits
+  const footerClicks = tally(footerEvents.map(e => listingMember(e)))
 
   // Most-hovered map listings for the selected page — tooltip dwells
   // (listing_hover events), grouped exactly like topListings but with no
@@ -926,6 +938,7 @@ function aggregate(
     airtableByPage,
     airtableViews,
     newsletterByPage,
+    footerClicks,
     topHovered,
     areaClicks,
     funnel: {


### PR DESCRIPTION
- New `footer_click` event for the footer's outbound links — the "Help us out" column (Suggest a correction, Give anonymous feedback, Donate) and the "Newsletters" column — carrying the column heading, link text, and the path the footer was on.
- A small FooterLink client wrapper keeps Footer itself server-rendered.
- The analytics Overview gets a "Footer clicks" panel ranking the links; clicks appear in Recent activity with a "Footer" pill.
- Counting starts at deploy; clicks count the open, not the completed action (e.g. a Donate click ≠ a donation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)