### PR TITLE
Chatbot: page "Last updated" stamps + per-listing recency dates

### DIFF
--- a/src/app/api/admin/test-run/route.ts
+++ b/src/app/api/admin/test-run/route.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/assistant/prompt'
 import { DEFAULT_MODEL_ID } from '@/lib/assistant/models'
 import { getDonationGuideText } from '@/lib/assistant/donation-guide'
+import { getPageLastUpdatedDates } from '@/lib/assistant/page-dates'
 import {
   buildApiMessages,
   runAssistantStream,
@@ -75,7 +76,10 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  const catalog = await getCatalog()
+  const [catalog, pageDates] = await Promise.all([
+    getCatalog(),
+    getPageLastUpdatedDates(),
+  ])
   const ctx: RequestContext = {
     currentPage: typeof body.currentPage === 'string' ? body.currentPage : '/',
     pageState:
@@ -91,6 +95,7 @@ export async function POST(req: NextRequest) {
       body.geo && typeof body.geo === 'object'
         ? (body.geo as { city?: string; region?: string; country?: string })
         : null,
+    pageDates,
   }
   const apiMessages = buildApiMessages(messages, buildContextLine(ctx))
   const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/assistant/stream'
 import { storeConversationTurn } from '@/lib/assistant/conversation-store'
 import { getDonationGuideText } from '@/lib/assistant/donation-guide'
+import { getPageLastUpdatedDates } from '@/lib/assistant/page-dates'
 import {
   checkAssistantRateLimit,
   getClientIp,
@@ -97,13 +98,17 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  const catalog = await getCatalog()
+  const [catalog, pageDates] = await Promise.all([
+    getCatalog(),
+    getPageLastUpdatedDates(),
+  ])
   const ctx: RequestContext = {
     currentPage: typeof body.currentPage === 'string' ? body.currentPage : '/',
     pageState: body.pageState ?? null,
     referrer: body.referrer ?? null,
     geo: readGeo(req, body.geoFallback),
     utm: body.utm ?? null,
+    pageDates,
   }
   const apiMessages = buildApiMessages(messages, buildContextLine(ctx))
   const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })

--- a/src/lib/assistant/catalog.ts
+++ b/src/lib/assistant/catalog.ts
@@ -146,6 +146,8 @@ export async function buildCatalog(): Promise<Catalog> {
       logo: f.logo ?? deriveFaviconFromUrl(f.url),
       url: f.url,
       pageUrl: '/funding',
+      dateAdded: f.dateAdded ?? undefined,
+      lastModified: f.lastModified ?? undefined,
       meta: compact({
         type: f.type,
         recipientType: f.recipientType,
@@ -164,6 +166,8 @@ export async function buildCatalog(): Promise<Catalog> {
       logo: a.logo ?? deriveFaviconFromUrl(a.url),
       url: a.url,
       pageUrl: '/advisors',
+      dateAdded: a.dateAdded ?? undefined,
+      lastModified: a.lastModified ?? undefined,
       meta: compact({
         focus: a.focus,
         status: a.status,
@@ -181,6 +185,8 @@ export async function buildCatalog(): Promise<Catalog> {
       logo: c.logo ?? deriveFaviconFromUrl(c.joinLink),
       url: c.joinLink || '#',
       pageUrl: '/communities',
+      dateAdded: c.dateAdded ?? undefined,
+      lastModified: c.lastModified ?? undefined,
       latitude: c.latitude ?? undefined,
       longitude: c.longitude ?? undefined,
       meta: compact({
@@ -205,6 +211,8 @@ export async function buildCatalog(): Promise<Catalog> {
       logo: c.image ?? deriveFaviconFromUrl(c.url),
       url: c.url,
       pageUrl: '/self-study',
+      dateAdded: c.dateAdded ?? undefined,
+      lastModified: c.lastModified ?? undefined,
       meta: compact({
         category: c.category,
         courseType: c.courseType,
@@ -222,6 +230,8 @@ export async function buildCatalog(): Promise<Catalog> {
       logo: r.image ?? deriveFaviconFromUrl(r.website),
       url: r.website,
       pageUrl: '/founders',
+      dateAdded: r.dateAdded ?? undefined,
+      lastModified: r.lastModified ?? undefined,
       meta: compact({
         type: r.type,
       }),
@@ -237,6 +247,8 @@ export async function buildCatalog(): Promise<Catalog> {
       description: clamp(p.description, 280),
       url: p.email ? `mailto:${p.email}` : '#',
       pageUrl: '/projects',
+      dateAdded: p.dateAdded ?? undefined,
+      lastModified: p.lastModified ?? undefined,
       meta: compact({
         status: p.status,
         contact: p.contact,
@@ -254,6 +266,8 @@ export async function buildCatalog(): Promise<Catalog> {
       logo: m.logo ?? deriveFaviconFromUrl(m.url),
       url: m.url,
       pageUrl: '/media-channels',
+      dateAdded: m.dateAdded ?? undefined,
+      lastModified: m.lastModified ?? undefined,
       meta: compact({
         type: m.type,
       }),
@@ -271,6 +285,8 @@ export async function buildCatalog(): Promise<Catalog> {
       logo: o.logo ?? deriveFaviconFromUrl(o.link),
       url: o.link,
       pageUrl: '/map',
+      dateAdded: o.dateAdded ?? undefined,
+      lastModified: o.lastModified ?? undefined,
       meta: compact({
         category: o.category,
         status: o.status,
@@ -292,6 +308,8 @@ export async function buildCatalog(): Promise<Catalog> {
       logo: e.logo ?? deriveFaviconFromUrl(e.url),
       url: e.url,
       pageUrl: '/events',
+      dateAdded: e.dateAdded ?? undefined,
+      lastModified: e.lastModified ?? undefined,
       meta: compact({
         type: e.type.join(', '),
         mode: e.mode,
@@ -322,6 +340,8 @@ export async function buildCatalog(): Promise<Catalog> {
       logo: t.logo ?? deriveFaviconFromUrl(t.url),
       url: t.url,
       pageUrl: '/training',
+      dateAdded: t.dateAdded ?? undefined,
+      lastModified: t.lastModified ?? undefined,
       meta: compact({
         type: t.type.join(', '),
         mode: t.mode,
@@ -353,6 +373,8 @@ export async function buildCatalog(): Promise<Catalog> {
       logo: r.logo ?? deriveFaviconFromUrl(r.url),
       url: r.url,
       pageUrl: '/training',
+      dateAdded: r.dateAdded ?? undefined,
+      lastModified: r.lastModified ?? undefined,
       meta: compact({
         recurring: 'Yes',
         type: r.type.join(', '),

--- a/src/lib/assistant/page-dates.ts
+++ b/src/lib/assistant/page-dates.ts
@@ -1,0 +1,62 @@
+import { fetchLastUpdated, validResources } from '@/lib/data/last-updated'
+
+// Which page's update stamp each last-updated resource feeds. Paths match
+// PAGES in ./pages.
+const RESOURCE_TO_PATH: Record<string, string> = {
+  events: '/events',
+  training: '/training',
+  map: '/map',
+  communities: '/communities',
+  'self-study': '/self-study',
+  jobs: '/jobs',
+  funding: '/funding',
+  'media-channels': '/media-channels',
+  advisors: '/advisors',
+  projects: '/projects',
+  founders: '/founders',
+  'donation-guide': '/donation-guide',
+}
+
+let cached: { dates: Record<string, string>; expiresAt: number } | null = null
+const CACHE_TTL_MS = 60 * 60 * 1000
+
+/** The formatted "Last updated" date behind each resource page's stamp, keyed
+ *  by page path, for the assistant's ambient context. Fetches are serialized
+ *  like fetchAllLastUpdated (Airtable rate limit) and the underlying requests
+ *  are data-cached for an hour; a complete result is memoized for the same
+ *  hour so chat turns don't refetch. A failed resource is skipped with a
+ *  warning – the assistant just won't know that page's date this turn. */
+export async function getPageLastUpdatedDates(): Promise<Record<
+  string,
+  string
+> | null> {
+  const now = Date.now()
+  if (cached && cached.expiresAt > now) return cached.dates
+
+  const dates: Record<string, string> = {}
+  let complete = true
+  for (const resource of validResources) {
+    const path = RESOURCE_TO_PATH[resource]
+    if (!path) {
+      console.warn(
+        `assistant: no page path mapped for last-updated resource '${resource}'`
+      )
+      continue
+    }
+    try {
+      const { formattedDate } = await fetchLastUpdated(resource)
+      if (formattedDate) dates[path] = formattedDate
+      else complete = false
+    } catch (err) {
+      console.warn(
+        `assistant: last-updated fetch failed for '${resource}'`,
+        err
+      )
+      complete = false
+    }
+  }
+  if (Object.keys(dates).length === 0) return null
+  // Only memoize a full set – a partial one retries on the next turn.
+  if (complete) cached = { dates, expiresAt: now + CACHE_TTL_MS }
+  return dates
+}

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES, greetingFor } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-07-29-02'
+export const PROMPT_VERSION = '2026-07-29-03'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -117,6 +117,7 @@ Parameters:
 - \`filters\` (optional): object of meta-field constraints. Each value can be a string OR an array of strings (array means OR – matches if ANY value substring matches). Case-insensitive substring match.
 - \`near\` (optional): geo filter. \`{ city: string, radiusKm?: number }\` or \`{ lat, lng, radiusKm? }\`. Default radius 500km. Geocodes the city and ranks results by distance ascending. Only \`community\` listings have coordinates today; for other types it falls back to substring match on the location meta field. **Use \`near\` for any "in/near/around X" location query – never put a place name in \`query\`.**
 - \`limit\` (optional): cap on results. Default is no limit – every match in the catalog is returned. Only pass a value if you have a reason to truncate.
+- \`sort\` (optional): \`'recently-added'\` or \`'recently-updated'\` – recency ranking for "what's new / recently added / recently updated" questions ONLY. Results come newest-first (capped at 10) and each carries its \`dateAdded\`/\`lastModified\` date. Composes with \`type\` and \`filters\`. Not supported for jobs – job results are already newest-first, so read \`datePublished\` instead. Never use it for ordinary recommendation searches: it overrides the curated order.
 
 Filter keys + complete value lists per type. Values are exact catalog labels:
 
@@ -219,7 +220,7 @@ Common patterns:
 No \`limit\` is applied by default – every matching listing comes back. The user only sees the cards you choose to display, so a wide net costs you nothing. Don't pass \`limit\` unless you have a specific reason.
 
 # Tool: get_listing
-Use when the user asks about a specific listing by name, or when you need fields not in the search summary. The id looks like \`job:rec123ABC\`.
+Use when the user asks about a specific listing by name, or when you need fields not in the search summary. The id looks like \`job:rec123ABC\`. The result includes \`dateAdded\` (when the listing was added to the site) and \`lastModified\` (when its record last changed) – see the "Last updated" section for how to talk about these.
 
 # Tool: read_listing_page
 Fetches the live text of a listing's own webpage (the site's stored link for it — you cannot fetch any other URL). This is your ONLY source for details beyond the listing fields. Use it when the user asks about a listing's specifics the fields don't cover — curriculum or chapter structure, syllabus topics, fees, session format, eligibility fine print, "does it cover X" — instead of answering from memory or giving up. Pass the listing's id exactly as a tool result returned it.
@@ -319,6 +320,13 @@ Every resource page displays an update stamp – "Last updated: 24 July 2026" on
 - Answer for the page the user is asking about (usually the one they're on) – don't recite the dates for every page. You may note the stamp is visible on the page itself so they know where to check in the future (the position rule above still applies: "on this page", never "at the top").
 - A page missing from the context line means its date isn't available to you right now – point to the stamp on that page instead of inventing a date.
 - These dates answer freshness and maintenance questions – don't volunteer them otherwise.
+
+**Per-listing dates.** Individual listings carry dates too: \`dateAdded\` (when the listing was added to the site) and \`lastModified\` (when any part of its record last changed). You see them on \`get_listing\` results and on recency-sorted searches. How to use them:
+- "When was this listing last updated?" → \`get_listing\`, answer with its \`lastModified\`. "How long has this been listed?" → \`dateAdded\`.
+- "What's new on this page / what was recently added?" → \`search_listings\` with \`sort: 'recently-added'\` (plus the matching \`type\`). "What changed recently?" → \`sort: 'recently-updated'\`. Card the top few as usual and mention their dates briefly in prose.
+- \`lastModified\` moves on ANY edit, including routine upkeep by the site's team – so say "the listing was last updated on X", and don't present a modified date as proof that something substantive changed (or that the info was re-verified) on that date. After a bulk cleanup, many listings can share the same recent date – if you notice that, don't read meaning into it.
+- Jobs have neither date – their \`datePublished\` meta (when the role was posted) is the recency answer, and job searches already return newest-first.
+- These dates are for recency questions only – never a reason to rank or prefer a listing in ordinary recommendations, where the curated order stays authoritative.
 
 # What you do not do
 - Do not list out listing details that the cards will already show

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES, greetingFor } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-07-29-01'
+export const PROMPT_VERSION = '2026-07-29-02'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -313,6 +313,13 @@ You receive the user's current page, any active filters, and approximate locatio
 
 **When you reference the resource page the user is already on, word it as "here", not as somewhere to go.** Check "Currently viewing" before you point to a page. If someone on /funding asks about grants and you want to mention the full list, say "the full list is right here on this page" or "there are more funders on this page" – NOT "browse the rest on [Funding](/funding)", which reads as if it's elsewhere and reveals you weren't tracking where they are. **You know which page they're on, but NOT where they've scrolled to or how it's laid out – so never describe a position on it ("further down this page", "below", "at the top", "scroll down"). Keep it to "on this page".** You can still link the page, but the wording must show you know they're already on it. When you're sending them to a *different* page, the normal "see [X](/x)" phrasing is correct.
 
+# "Last updated" stamps
+Every resource page displays an update stamp – "Last updated: 24 July 2026" on most pages, a relative "Updated 2 days ago" on [Jobs](/jobs), [Events](/events), and [Training programs](/training). The context block gives you the current date behind each page's stamp (the \`Resource-page "Last updated" stamps\` line). When someone asks how recent, current, or actively maintained a page or its listings are, answer with the real date for the page in question – never say the site has no update stamps, and never guess a date.
+- What the date means: listings are curated continuously – added, revised, and removed as things change, with no scheduled releases or version numbers – and the stamp is the most recent change to that page's listings. Two special cases: on [Jobs](/jobs) it's the publication date of the newest posting (the board refreshes as new roles come in), and on the [Donation guide](/donation-guide) it's when the guide's content was last revised.
+- Answer for the page the user is asking about (usually the one they're on) – don't recite the dates for every page. You may note the stamp is visible on the page itself so they know where to check in the future (the position rule above still applies: "on this page", never "at the top").
+- A page missing from the context line means its date isn't available to you right now – point to the stamp on that page instead of inventing a date.
+- These dates answer freshness and maintenance questions – don't volunteer them otherwise.
+
 # What you do not do
 - Do not list out listing details that the cards will already show
 - **Do not point out that a page or resource is NOT relevant to the user.** Telling someone what they don't need ("starting a community doesn't need the Founder toolkit", "Jobs isn't the right page for you", "skip the Donation guide") is noise, not help – it spends the user's attention on a dead end and reads as if you're second-guessing them. Just leave the irrelevant page unmentioned. Only ever name a page when you're actively sending the user toward it.
@@ -443,6 +450,8 @@ export interface RequestContext {
   referrer?: string | null
   geo?: { city?: string; region?: string; country?: string } | null
   utm?: Record<string, string> | null
+  /** Formatted "Last updated" stamp date per resource-page path. */
+  pageDates?: Record<string, string> | null
 }
 
 export function buildContextLine(ctx: RequestContext): string {
@@ -460,6 +469,13 @@ export function buildContextLine(ctx: RequestContext): string {
   )
   if (ctx.pageState && Object.keys(ctx.pageState).length > 0) {
     parts.push(`Page state: ${JSON.stringify(ctx.pageState)}`)
+  }
+  if (ctx.pageDates && Object.keys(ctx.pageDates).length > 0) {
+    parts.push(
+      `Resource-page "Last updated" stamps: ${Object.entries(ctx.pageDates)
+        .map(([path, date]) => `${path} ${date}`)
+        .join('; ')}`
+    )
   }
   if (ctx.referrer) parts.push(`Arrived from: ${ctx.referrer}`)
   if (ctx.geo) {

--- a/src/lib/assistant/search.ts
+++ b/src/lib/assistant/search.ts
@@ -104,6 +104,8 @@ export interface NearOptions {
   radiusKm?: number
 }
 
+export type RecencySort = 'recently-added' | 'recently-updated'
+
 export interface SearchOptions {
   query?: string
   type?: ListingType
@@ -111,6 +113,9 @@ export interface SearchOptions {
   /** Geo filter — keeps only listings within radius of the city/coords. */
   near?: NearOptions
   limit?: number
+  /** Re-rank matches by dateAdded/lastModified desc. Capped at 10 results
+   *  unless an explicit limit is passed. Listings without the date sort last. */
+  sort?: RecencySort
 }
 
 export interface SearchHit {
@@ -129,14 +134,32 @@ function isRecurringTraining(l: Listing): boolean {
   return l.type === 'training' && l.meta.recurring === 'Yes'
 }
 
+function recencyKey(listing: Listing, sort: RecencySort): string {
+  return (
+    (sort === 'recently-added' ? listing.dateAdded : listing.lastModified) ?? ''
+  )
+}
+
+/** Date-desc re-rank for recency-sorted searches; undated listings last. */
+function sortHitsByRecency(hits: SearchHit[], sort: RecencySort): SearchHit[] {
+  return [...hits].sort((a, b) =>
+    recencyKey(b.listing, sort).localeCompare(recencyKey(a.listing, sort))
+  )
+}
+
 export async function searchCatalog(
   catalog: Catalog,
   options: SearchOptions
 ): Promise<SearchHit[]> {
   const queryTokens = options.query ? tokenize(options.query) : []
-  // Default: no limit. Caller can pass one explicitly to cap.
+  // Default: no limit — except recency sorts, which cap at 10 so "what's new"
+  // answers don't ship the whole catalog. An explicit limit always wins.
   const limit =
-    typeof options.limit === 'number' ? Math.max(1, options.limit) : Infinity
+    typeof options.limit === 'number'
+      ? Math.max(1, options.limit)
+      : options.sort
+        ? 10
+        : Infinity
   const filters = options.filters ?? {}
 
   // Resolve geo center if `near` is present
@@ -203,7 +226,10 @@ export async function searchCatalog(
         (catalogIndex.get(b.listing.id) ?? Infinity)
       )
     })
-    return sorted.slice(0, limit).map(c => ({ listing: c.listing, score: 1 }))
+    const browseHits = sorted.map(c => ({ listing: c.listing, score: 1 }))
+    return (
+      options.sort ? sortHitsByRecency(browseHits, options.sort) : browseHits
+    ).slice(0, limit)
   }
 
   const hits: SearchHit[] = []
@@ -236,5 +262,8 @@ export async function searchCatalog(
     )
   })
 
-  return hits.slice(0, limit)
+  return (options.sort ? sortHitsByRecency(hits, options.sort) : hits).slice(
+    0,
+    limit
+  )
 }

--- a/src/lib/assistant/tools.ts
+++ b/src/lib/assistant/tools.ts
@@ -38,6 +38,8 @@ Meta fields you can read off event/training results: startDate, endDate, applica
 
 • \`limit\` — optional cap on results. Default: no limit (returns every match in the catalog). Pass a number only if you want to truncate (rarely useful).
 
+• \`sort\` — optional recency ranking, for "what's new / recently added / recently updated" questions ONLY. 'recently-added' ranks by the date the listing was added to the site; 'recently-updated' ranks by the date any part of the listing's record last changed. Results come newest-first, capped at 10 (raise/lower with \`limit\`), and each carries the relevant \`dateAdded\`/\`lastModified\` date so you can say how recent it is. Composes with \`type\`/\`filters\`/\`query\` (e.g. type: 'org' + sort: 'recently-added' = newest field-map entries). NOT supported for jobs — job results are already newest-first via \`datePublished\`, so for "newest jobs" just search jobs normally and read that field. Caveats: 'recently-updated' reflects edits of ANY kind, including routine upkeep by the site's team, so a bulk cleanup can make many listings share the same recent date — present it as "the listing was last updated on X", not as proof something substantive changed. Recency sort ignores the curated ordering (featured-first), so never use it for ordinary recommendation searches.
+
 WHEN STUCK:
 
 If a search returns 0 results, do NOT give up. Broaden:
@@ -104,6 +106,10 @@ EXAMPLES:
           },
         },
         limit: { type: 'integer', minimum: 1 },
+        sort: {
+          type: 'string',
+          enum: ['recently-added', 'recently-updated'],
+        },
       },
       required: [],
     },
@@ -111,7 +117,7 @@ EXAMPLES:
   {
     name: 'get_listing',
     description:
-      'Fetch full details on a single listing by id (e.g. "job:rec123ABC"). Use after search_listings when you need fields not in the summary, or when the user names a specific entry.',
+      'Fetch full details on a single listing by id (e.g. "job:rec123ABC"). Use after search_listings when you need fields not in the summary, or when the user names a specific entry. The result includes dateAdded (when the listing was added to the site) and lastModified (when any part of its record last changed, including routine upkeep by the site\'s team) — use these for "how current is this listing" questions; jobs have neither, but carry datePublished in meta.',
     input_schema: {
       type: 'object',
       properties: {
@@ -158,6 +164,7 @@ interface SearchInput {
   filters?: Record<string, unknown>
   near?: { city?: string; lat?: number; lng?: number; radiusKm?: number }
   limit?: number
+  sort?: 'recently-added' | 'recently-updated'
 }
 
 interface GetListingInput {
@@ -230,7 +237,10 @@ function eventApplicationStatus(
 function summariseListing(
   l: Listing,
   today: string,
-  distanceKm?: number
+  distanceKm?: number,
+  // Dates ride along only where they answer the question (recency-sorted
+  // searches, get_listing) — regular search results stay lean.
+  includeDates?: boolean
 ): object {
   const eventStatus =
     l.type === 'event' || l.type === 'training'
@@ -244,6 +254,8 @@ function summariseListing(
     description: l.description,
     meta: l.meta,
     ...(eventStatus ?? {}),
+    ...(includeDates && l.dateAdded ? { dateAdded: l.dateAdded } : {}),
+    ...(includeDates && l.lastModified ? { lastModified: l.lastModified } : {}),
     url: l.url,
     pageUrl: l.pageUrl,
     ...(l.featured ? { featured: true } : {}),
@@ -266,12 +278,17 @@ async function executeSearch(
   input: SearchInput,
   catalog: Catalog
 ): Promise<ToolExecutionResult> {
+  const sort =
+    input.sort === 'recently-added' || input.sort === 'recently-updated'
+      ? input.sort
+      : undefined
   const hits = await searchCatalog(catalog, {
     query: input.query,
     type: input.type,
     filters: input.filters,
     near: input.near,
     limit: input.limit,
+    sort,
   })
   if (hits.length === 0) {
     return {
@@ -288,7 +305,9 @@ async function executeSearch(
     ok: true,
     content: JSON.stringify({
       matches: hits.length,
-      results: hits.map(h => summariseListing(h.listing, today, h.distanceKm)),
+      results: hits.map(h =>
+        summariseListing(h.listing, today, h.distanceKm, Boolean(sort))
+      ),
     }),
     listings: hits.map(h => h.listing),
   }
@@ -311,7 +330,7 @@ function executeGetListing(
   const today = new Date().toISOString().slice(0, 10)
   return {
     ok: true,
-    content: JSON.stringify(summariseListing(listing, today)),
+    content: JSON.stringify(summariseListing(listing, today, undefined, true)),
     listings: [listing],
   }
 }

--- a/src/lib/assistant/types.ts
+++ b/src/lib/assistant/types.ts
@@ -25,6 +25,13 @@ export interface Listing {
   latitude?: number
   longitude?: number
   featured?: boolean
+  /** YYYY-MM-DD the record was added to Airtable. Not set for jobs (their
+   *  datePublished meta covers recency). Kept out of `meta` so it only reaches
+   *  the model in recency-sorted searches and get_listing. */
+  dateAdded?: string
+  /** YYYY-MM-DD any field of the record last changed (edits of any kind,
+   *  including routine maintenance). Same visibility rules as dateAdded. */
+  lastModified?: string
 }
 
 export interface Catalog {

--- a/src/lib/data/advisors.ts
+++ b/src/lib/data/advisors.ts
@@ -1,5 +1,6 @@
 import {
   fetchAirtableRecords,
+  fieldDateOnly,
   fieldAttachmentUrl,
   fieldFeatured,
   fieldString,
@@ -24,10 +25,13 @@ const FIELD = {
   sort: 'fldbIK2vKzWm61CGr', // Sort
   publish: 'fldaOmFd67ORPMfTC', // Publish?
   hide: 'fldBOSo9B5KSaTZRq', // Hide?
+  lastModified: 'fld8rTAfTkJBhnO0L', // Last modified
 } as const
 
 export interface Advisor {
   id: string
+  dateAdded: string | null
+  lastModified: string | null
   name: string
   description: string
   logo: string | null
@@ -55,6 +59,8 @@ export async function getAdvisors(): Promise<Advisor[]> {
 
     results.push({
       id: record.id,
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
+      lastModified: fieldDateOnly(f[FIELD.lastModified]),
       name,
       description: fieldString(f[FIELD.description]) || '',
       logo: fieldAttachmentUrl(f[FIELD.logo]),

--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -6,6 +6,8 @@ import { unstable_cache } from 'next/cache'
 
 export interface AirtableRawRecord {
   id: string
+  /** When the record was created, always returned by the Airtable API. */
+  createdTime?: string
   fields: Record<string, unknown>
 }
 
@@ -34,6 +36,12 @@ interface FetchOptions {
 /** String value, or null when empty or missing. */
 export function fieldString(value: unknown): string | null {
   return typeof value === 'string' && value !== '' ? value : null
+}
+
+/** Date-only YYYY-MM-DD from an Airtable date or timestamp value. */
+export function fieldDateOnly(value: unknown): string | null {
+  const s = fieldString(value)
+  return s ? s.slice(0, 10) : null
 }
 
 /** Numeric value, or null when missing. */

--- a/src/lib/data/communities.ts
+++ b/src/lib/data/communities.ts
@@ -1,5 +1,6 @@
 import {
   fetchAirtableRecords,
+  fieldDateOnly,
   fieldAttachmentUrl,
   fieldFeatured,
   fieldNumber,
@@ -33,10 +34,13 @@ const FIELD = {
   featuredTagline: 'fldDxqDvO7vgFo2m0', // Featured tagline
   publish: 'fldV8RYP1CVzOvHpf', // Publish?
   hide: 'fldQAl9W6QDPCpdew', // Hide?
+  lastModified: 'fldcsXAugffjhKmEH', // Last modified
 } as const
 
 export interface Community {
   id: string
+  dateAdded: string | null
+  lastModified: string | null
   name: string
   description: string
   logo: string | null
@@ -71,6 +75,8 @@ export async function getCommunities(): Promise<Community[]> {
 
     results.push({
       id: record.id,
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
+      lastModified: fieldDateOnly(f[FIELD.lastModified]),
       name,
       description: fieldString(f[FIELD.description]) || '',
       logo: fieldAttachmentUrl(f[FIELD.logo]),

--- a/src/lib/data/events.ts
+++ b/src/lib/data/events.ts
@@ -28,10 +28,13 @@ const FIELD = {
   featuredTagline: 'fld2rzRd4asMe18aQ',
   publish: 'flddgpgNm090Uftsq',
   hide: 'fldsYr7bsZb3eCPum',
+  lastModified: 'fldB3qONkXobywxmp',
 } as const
 
 export interface EventListing {
   id: string
+  dateAdded: string | null
+  lastModified: string | null
   name: string
   description: string
   url: string
@@ -173,6 +176,8 @@ export async function getEvents(): Promise<EventListing[]> {
 
     results.push({
       id: record.id,
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
+      lastModified: optionalString(f[FIELD.lastModified])?.slice(0, 10) ?? null,
       name,
       description: optionalString(f[FIELD.description]) || '',
       url: normalizeUrl(optionalString(f[FIELD.url]) || ''),

--- a/src/lib/data/founders.ts
+++ b/src/lib/data/founders.ts
@@ -1,5 +1,6 @@
 import {
   fetchAirtableRecords,
+  fieldDateOnly,
   fieldAttachmentUrl,
   fieldFeatured,
   fieldString,
@@ -24,10 +25,13 @@ const FIELD = {
   featuredTagline: 'fldhf703nHwICgQyl', // Featured tagline
   publish: 'fld9Epdrxu9n0FV20', // Publish?
   hide: 'fldPKsUP3i4UVujDf', // Hide?
+  lastModified: 'fldMM2jKZeORMO5mP', // Last modified
 } as const
 
 export interface FounderResource {
   id: string
+  dateAdded: string | null
+  lastModified: string | null
   name: string
   type: string
   image: string | null
@@ -57,6 +61,8 @@ export async function getFounderResources(): Promise<FounderResource[]> {
 
     results.push({
       id: record.id,
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
+      lastModified: fieldDateOnly(f[FIELD.lastModified]),
       name,
       type: fieldText(f[FIELD.type]),
       image: fieldAttachmentUrl(f[FIELD.image]),

--- a/src/lib/data/funding.ts
+++ b/src/lib/data/funding.ts
@@ -1,5 +1,6 @@
 import {
   fetchAirtableRecords,
+  fieldDateOnly,
   fieldAttachmentUrl,
   fieldFeatured,
   fieldString,
@@ -24,10 +25,13 @@ const FIELD = {
   sort: 'fldDDTHjJHiUUBz7k', // Sort
   publish: 'fldoH88AbtQLEViD7', // Publish?
   hide: 'fldU5a381Lcgjgzp8', // Hide?
+  lastModified: 'fldMZXYm96wdeq5jw', // Last modified
 } as const
 
 export interface Funder {
   id: string
+  dateAdded: string | null
+  lastModified: string | null
   name: string
   description: string
   logo: string | null
@@ -56,6 +60,8 @@ export async function getFunders(): Promise<Funder[]> {
 
     results.push({
       id: record.id,
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
+      lastModified: fieldDateOnly(f[FIELD.lastModified]),
       name,
       description: fieldString(f[FIELD.description]) || '',
       logo: fieldAttachmentUrl(f[FIELD.logo]),

--- a/src/lib/data/map.ts
+++ b/src/lib/data/map.ts
@@ -191,12 +191,7 @@ export async function getMapData(): Promise<MapData> {
 
     allRecords.push({
       id: record.id,
-      // The curated "Date added" field, falling back to the record's own
-      // creation time (they match for records added since the field existed).
-      dateAdded:
-        fieldDateOnly(f[FIELD.dateAdded]) ??
-        record.createdTime?.slice(0, 10) ??
-        null,
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
       lastModified: fieldDateOnly(f[FIELD.lastModified]),
       title,
       tooltipTitle,

--- a/src/lib/data/map.ts
+++ b/src/lib/data/map.ts
@@ -1,6 +1,7 @@
 import {
   fetchAirtableRecords,
   fieldAttachmentUrl,
+  fieldDateOnly,
   fieldNumber,
   fieldString,
   fieldStringArray,
@@ -37,10 +38,13 @@ const FIELD = {
   scale: 'fldw2bKsCY0VdTCN6', // Scale
   publish: 'fldCCQ2OYlQluuarR', // Publish?
   hide: 'fldKwedEOWPFuWSe7', // Hide?
+  lastModified: 'fld9nL9mSDBN0kaO4', // Last modified
 } as const
 
 export interface MapOrg {
   id: string
+  dateAdded: string | null
+  lastModified: string | null
   title: string
   tooltipTitle: string
   shortName: string | null
@@ -80,6 +84,7 @@ const FIELD_LIST = [
   FIELD.x,
   FIELD.y,
   FIELD.scale,
+  FIELD.lastModified,
 ]
 
 // Sort order is hardcoded so the Airtable view sort can be changed freely
@@ -186,6 +191,13 @@ export async function getMapData(): Promise<MapData> {
 
     allRecords.push({
       id: record.id,
+      // The curated "Date added" field, falling back to the record's own
+      // creation time (they match for records added since the field existed).
+      dateAdded:
+        fieldDateOnly(f[FIELD.dateAdded]) ??
+        record.createdTime?.slice(0, 10) ??
+        null,
+      lastModified: fieldDateOnly(f[FIELD.lastModified]),
       title,
       tooltipTitle,
       shortName: fieldString(f[FIELD.shortName]),

--- a/src/lib/data/media-channels.ts
+++ b/src/lib/data/media-channels.ts
@@ -1,5 +1,6 @@
 import {
   fetchAirtableRecords,
+  fieldDateOnly,
   fieldAttachmentUrl,
   fieldFeatured,
   fieldString,
@@ -24,10 +25,13 @@ const FIELD = {
   sort: 'fldhkOSt89LF6aYE5', // Sort
   publish: 'fldMN0TF3kz41HTQc', // Publish?
   hide: 'fldxzKJV6SnPk7eD8', // Hide?
+  lastModified: 'fldg46VoI3zwPRzXR', // Last modified
 } as const
 
 export interface MediaChannel {
   id: string
+  dateAdded: string | null
+  lastModified: string | null
   name: string
   description: string
   logo: string | null
@@ -54,6 +58,8 @@ export async function getMediaChannels(): Promise<MediaChannel[]> {
 
     results.push({
       id: record.id,
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
+      lastModified: fieldDateOnly(f[FIELD.lastModified]),
       name,
       description: fieldString(f[FIELD.description]) || '',
       logo: fieldAttachmentUrl(f[FIELD.image]),

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -1,5 +1,6 @@
 import {
   fetchAirtableRecords,
+  fieldDateOnly,
   fieldFeatured,
   fieldString,
   fieldText,
@@ -22,10 +23,13 @@ const FIELD = {
   sort: 'fldNvTVR11SJjYu2l', // Sort
   publish: 'fldrGDtZxpFLQfjMz', // Publish?
   hide: 'fldPjPfUW5hK98ysn', // Hide?
+  lastModified: 'fld3KsLNUU3IGj5Gg', // Last modified
 } as const
 
 export interface Project {
   id: string
+  dateAdded: string | null
+  lastModified: string | null
   name: string
   description: string
   logo: string | null
@@ -53,6 +57,8 @@ export async function getProjects(): Promise<Project[]> {
 
     results.push({
       id: record.id,
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
+      lastModified: fieldDateOnly(f[FIELD.lastModified]),
       name,
       description: fieldString(f[FIELD.descriptionShort]) || '',
       logo: null,

--- a/src/lib/data/self-study.ts
+++ b/src/lib/data/self-study.ts
@@ -1,5 +1,6 @@
 import {
   fetchAirtableRecords,
+  fieldDateOnly,
   fieldAttachmentUrl,
   fieldFeatured,
   fieldString,
@@ -26,10 +27,13 @@ const FIELD = {
   sort: 'fldThp6KjSXk03P7p', // Sort
   publish: 'fldWShxP7GkMeh6rg', // Publish?
   hide: 'fldTF2A1ibOD8w3RO', // Hide?
+  lastModified: 'fld4gwoM3vldhbyiE', // Last modified
 } as const
 
 export interface Course {
   id: string
+  dateAdded: string | null
+  lastModified: string | null
   name: string
   description: string
   category: string
@@ -58,6 +62,8 @@ export async function getCourses(): Promise<Course[]> {
 
     results.push({
       id: record.id,
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
+      lastModified: fieldDateOnly(f[FIELD.lastModified]),
       name,
       description: fieldString(f[FIELD.description]) || '',
       category: fieldText(f[FIELD.focus]),

--- a/src/lib/data/training.ts
+++ b/src/lib/data/training.ts
@@ -41,6 +41,7 @@ const TRAINING_FIELD = {
   entryBar: 'fldNGM0Z7xQciYeDW',
   timeCommitment: 'fld55R10v0Pz6Gaxp',
   stipend: 'fldttliZeFMxWW9Hb',
+  lastModified: 'fldG0Cn6ozrw0c0N9',
 } as const
 
 const RECURRING_FIELD = {
@@ -62,6 +63,7 @@ const RECURRING_FIELD = {
   timeCommitment: 'fldU91KGSj2APdDRq',
   stipend: 'fldoHJPQyRJUA8gap',
   typicalLength: 'fldYWSizGyk6GGrwu',
+  lastModified: 'fldq0bMboXuM1lYX4',
 } as const
 
 /**
@@ -80,6 +82,8 @@ export type AttendMode =
 // Card fields shared by upcoming and recurring programs.
 export interface ProgramBase {
   id: string
+  dateAdded: string | null
+  lastModified: string | null
   name: string
   description: string
   url: string
@@ -255,6 +259,7 @@ interface BaseFieldIds {
   entryBar: string
   timeCommitment: string
   stipend: string
+  lastModified: string
 }
 
 function parseBase(
@@ -290,6 +295,9 @@ function parseBase(
     logo: logoField?.[0]?.url ?? null,
     featured: featuredRaw === '1' || featuredRaw === '2' ? featuredRaw : null,
     featuredTagline: optionalString(fields[FIELD.featuredTagline]),
+    dateAdded: null, // overridden by each caller (needs the record's createdTime)
+    lastModified:
+      optionalString(fields[FIELD.lastModified])?.slice(0, 10) ?? null,
     lengthBucket: null, // overridden by each caller from its own source
   }
 }
@@ -334,6 +342,7 @@ export async function getTrainingPrograms(): Promise<TrainingProgram[]> {
 
     results.push({
       ...parseBase(f, record.id, name, TRAINING_FIELD),
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
       startDate,
       startDateApprox:
         optionalString(f[TRAINING_FIELD.startDateApprox])?.trim() || null,
@@ -376,6 +385,7 @@ export async function getRecurringPrograms(): Promise<RecurringProgram[]> {
     const typicalLength = optionalString(f[RECURRING_FIELD.typicalLength])
     results.push({
       ...parseBase(f, record.id, name, RECURRING_FIELD),
+      dateAdded: record.createdTime?.slice(0, 10) ?? null,
       typicalLength,
       lengthBucket: lengthBucketForTypical(typicalLength),
     })


### PR DESCRIPTION
- The assistant now receives the "Last updated" date behind every resource page's stamp as ambient context (per-turn, keeping the cached system prefix byte-identical), so it answers "how recent is this page?" with the real date instead of claiming the site has no update stamps – this exact failure appeared in the conversation log on /map.
- New `src/lib/assistant/page-dates.ts` maps the last-updated resources to page paths; fetches are serialized for Airtable's rate limit and memoized in-module for an hour, and a partial fetch is warned and not cached.
- Every listing except jobs now carries `dateAdded` (record createdTime) and `lastModified` (the table's Last modified field, any-field edits) – top-level `Listing` fields rather than `meta`, so ordinary search results stay lean. Jobs have no Last modified field; their `datePublished` meta already covers recency.
- `search_listings` gains `sort: 'recently-added' | 'recently-updated'` – server-side newest-first ranking capped at 10 results, each carrying its date, for "what's new on the map?"-style questions. `get_listing` always returns both dates.
- Prompt v2026-07-29-03 documents the stamps and dates, and instructs the bot to present `lastModified` as "the listing was touched" (edits include routine upkeep, e.g. bulk cleanups) rather than proof of substantive change, and never to use recency sort for ordinary recommendations where curated order wins.
- Runtime-verified on localhost against live Airtable data: freshness answers on /map and /funding, recently-added map entries, and per-listing dates for MATS all match Airtable exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)