### PR TITLE
Consistent "Updated X ago" dates on all resource page headers

### DIFF
--- a/src/app/advisors/page.tsx
+++ b/src/app/advisors/page.tsx
@@ -21,7 +21,7 @@ export default async function AdvisorsPage() {
     <div className="container-default">
       <PageHeader
         title="Advisors"
-        lastUpdated={lastUpdated.formattedDate}
+        lastUpdatedIso={lastUpdated.lastUpdated}
         description={
           <>
             <span className="color-light-teal">

--- a/src/app/communities/page.tsx
+++ b/src/app/communities/page.tsx
@@ -37,7 +37,7 @@ export default async function CommunitiesPage() {
       <div className="container-default">
         <PageHeader
           title="Communities"
-          lastUpdated={lastUpdated.formattedDate}
+          lastUpdatedIso={lastUpdated.lastUpdated}
           id="communities"
           topPadding="padding-top-40px"
           description={

--- a/src/app/donation-guide/page.tsx
+++ b/src/app/donation-guide/page.tsx
@@ -2,11 +2,9 @@
 
 import { useRef, useState } from 'react'
 import { DONATION_GUIDE_LAST_UPDATED } from '@/lib/donation-guide-date'
-import { formatDate } from '@/lib/format-date'
+import RelativeDate from '@/components/RelativeDate'
 import styles from './page.module.css'
 import { DONATION_TABS, type DonationTabKey } from './content'
-
-const donationGuideDate = formatDate(new Date(DONATION_GUIDE_LAST_UPDATED))
 
 export default function DonationGuidePage() {
   const [activeTab, setActiveTab] = useState<DonationTabKey>('tab1')
@@ -28,9 +26,10 @@ export default function DonationGuidePage() {
     <div>
       <div className="container-default">
         <h1 className="padding-top-56px padding-bottom-8px">Donation guide</h1>
-        <div className="padding-bottom-40px paragraph-small color-teal-300">
-          Last updated: {donationGuideDate}
-        </div>
+        <RelativeDate
+          iso={DONATION_GUIDE_LAST_UPDATED}
+          className="padding-bottom-40px paragraph-small color-teal-300"
+        />
         <h2 className="width-7-col padding-bottom-56px">
           This guide can help you determine the most effective way to{' '}
           <span className="color-light-teal">

--- a/src/app/founders/page.tsx
+++ b/src/app/founders/page.tsx
@@ -21,7 +21,7 @@ export default async function FoundersPage() {
     <div className="container-default">
       <PageHeader
         title="Founder toolkit"
-        lastUpdated={lastUpdated.formattedDate}
+        lastUpdatedIso={lastUpdated.lastUpdated}
         description={
           <>
             Resources for{' '}

--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -21,7 +21,7 @@ export default async function FundingPage() {
     <div className="container-default">
       <PageHeader
         title="Funding"
-        lastUpdated={lastUpdated.formattedDate}
+        lastUpdatedIso={lastUpdated.lastUpdated}
         description={
           <>
             These organizations offer{' '}

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -20,7 +20,7 @@ export default async function JobsPage() {
     <div className="container-default">
       <PageHeader
         title="Jobs"
-        lastUpdated={lastUpdated.formattedDate}
+        lastUpdatedIso={lastUpdated.lastUpdated}
         description={
           <>
             Pursuing a career in AI safety can be{' '}

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -6,6 +6,7 @@ import { useState, useMemo, useRef, useLayoutEffect } from 'react'
 import FilterGroup from '@/components/FilterGroup'
 import FilterSidebar from '@/components/FilterSidebar'
 import ContributeButtons from '@/components/ContributeButtons'
+import RelativeDate from '@/components/RelativeDate'
 import SearchBar from '@/components/SearchBar'
 import { trackListingClick } from '@/lib/analytics'
 import { placementsById } from '@/lib/placements'
@@ -65,14 +66,14 @@ interface MapOrg {
 
 interface MapClientProps {
   orgs: MapOrg[]
-  lastUpdated: string | null
+  lastUpdatedIso: string | null
   suggestEntryLink: string
   suggestCorrectionLink: string
 }
 
 export default function MapClient({
   orgs,
-  lastUpdated,
+  lastUpdatedIso,
   suggestEntryLink,
   suggestCorrectionLink,
 }: MapClientProps) {
@@ -209,9 +210,12 @@ export default function MapClient({
       </div>
 
       <div id="cards" className="container-default">
-        <p className="padding-bottom-24px paragraph-small color-teal-300">
-          {lastUpdated ? `Last updated: ${lastUpdated}` : ''}
-        </p>
+        {lastUpdatedIso && (
+          <RelativeDate
+            iso={lastUpdatedIso}
+            className="padding-bottom-24px paragraph-small color-teal-300"
+          />
+        )}
         <h2 className="width-7-col padding-bottom-56px">
           An overview of the key{' '}
           <span className="color-light-teal">

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,18 +1,19 @@
 import MapClient from './MapClient'
 import { getMapData } from '@/lib/data/map'
+import { fetchLastUpdated } from '@/lib/data/last-updated'
 
 export const metadata = {
   alternates: { canonical: '/map' },
 }
 
 export default async function MapPage() {
-  const { records, lastUpdated, suggestEntryLink, suggestCorrectionLink } =
-    await getMapData()
+  const [{ records, suggestEntryLink, suggestCorrectionLink }, lastUpdated] =
+    await Promise.all([getMapData(), fetchLastUpdated('map')])
 
   return (
     <MapClient
       orgs={records}
-      lastUpdated={lastUpdated}
+      lastUpdatedIso={lastUpdated.lastUpdated}
       suggestEntryLink={suggestEntryLink}
       suggestCorrectionLink={suggestCorrectionLink}
     />

--- a/src/app/media-channels/page.tsx
+++ b/src/app/media-channels/page.tsx
@@ -21,7 +21,7 @@ export default async function MediaChannelsPage() {
     <div className="container-default">
       <PageHeader
         title="Media channels"
-        lastUpdated={lastUpdated.formattedDate}
+        lastUpdatedIso={lastUpdated.lastUpdated}
         description={
           <>
             <span className="color-light-teal">

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -21,7 +21,7 @@ export default async function ProjectsPage() {
     <div className="container-default">
       <PageHeader
         title="Volunteer projects"
-        lastUpdated={lastUpdated.formattedDate}
+        lastUpdatedIso={lastUpdated.lastUpdated}
         description={
           <>
             Initiatives{' '}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -5,8 +5,7 @@ import styles from './PageHeader.module.css'
 
 interface PageHeaderProps {
   title: string
-  lastUpdated?: string | null
-  /** ISO date — renders a live "Updated X ago" instead of "Last updated: X". */
+  /** ISO date — renders a live "Updated X ago" line under the title. */
   lastUpdatedIso?: string | null
   description: ReactNode
   id?: string
@@ -21,7 +20,6 @@ interface PageHeaderProps {
 
 export default function PageHeader({
   title,
-  lastUpdated,
   lastUpdatedIso,
   description,
   id,
@@ -35,17 +33,11 @@ export default function PageHeader({
       <h1 className={`${topPadding} padding-bottom-8px`} id={id}>
         {title}
       </h1>
-      {lastUpdatedIso ? (
+      {lastUpdatedIso && (
         <RelativeDate
           iso={lastUpdatedIso}
           className="paragraph-small color-teal-300 margin-bottom-40px"
         />
-      ) : (
-        lastUpdated && (
-          <p className="paragraph-small color-teal-300 margin-bottom-40px">
-            Last updated: {lastUpdated}
-          </p>
-        )
       )}
       <h2 className="width-7-col margin-bottom-56px">{description}</h2>
       {children}

--- a/src/lib/data/map.ts
+++ b/src/lib/data/map.ts
@@ -63,7 +63,6 @@ export interface MapOrg {
 
 export interface MapData {
   records: MapOrg[]
-  lastUpdated: string | null
   suggestEntryLink: string
   suggestCorrectionLink: string
 }
@@ -155,7 +154,6 @@ export async function getMapData(): Promise<MapData> {
   })
 
   const allRecords: MapOrg[] = []
-  let lastUpdated: string | null = null
   let suggestEntryLink = '/map/suggest'
   let suggestCorrectionLink = '#'
 
@@ -168,10 +166,6 @@ export async function getMapData(): Promise<MapData> {
     if (!title || !description) continue
 
     const isMagic = MAGIC_ROW_NAMES.includes(title)
-
-    if (title === 'Last updated') {
-      lastUpdated = description
-    }
 
     const link = fieldString(f[FIELD.link])
     if (title === 'Suggest entry' && link) {
@@ -233,7 +227,6 @@ export async function getMapData(): Promise<MapData> {
 
   return {
     records: allRecords,
-    lastUpdated,
     suggestEntryLink,
     suggestCorrectionLink,
   }

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -28,7 +28,9 @@ export function formatRelativeDate(isoDate: string): string {
   if (diffDays === 1) return 'Updated yesterday'
   if (diffDays < 7) return `Updated ${diffDays} days ago`
   if (diffDays < 14) return 'Updated 1 week ago'
-  if (diffDays < 30) return `Updated ${Math.floor(diffDays / 7)} weeks ago`
+  if (diffDays < 28) return `Updated ${Math.floor(diffDays / 7)} weeks ago`
   if (diffDays < 60) return 'Updated 1 month ago'
-  return `Updated ${Math.floor(diffDays / 30)} months ago`
+  if (diffDays < 365) return `Updated ${Math.floor(diffDays / 30)} months ago`
+  if (diffDays < 730) return 'Updated 1 year ago'
+  return `Updated ${Math.floor(diffDays / 365)} years ago`
 }


### PR DESCRIPTION
- The new /events and /training pages showed a live relative date ("Updated yesterday") while the other resource pages showed a fixed absolute date ("Last updated: 28 July 2026"). All resource pages now use the relative format, computed in the browser so it never goes stale between deploys.
- Jobs, funding, communities, advisors, projects, founders, and media channels pass the ISO date to PageHeader instead of a pre-formatted string.
- Map: the header date now comes from fetchLastUpdated('map'); dropped the magic-row passthrough from getMapData.
- Donation guide: renders the same relative date from its date constant.
- formatRelativeDate: 4 weeks now reads "1 month ago" (weeks cap at 3), and dates over a year read "1 year ago" instead of "13 months ago".
- PageHeader: removed the now-unused absolute-date prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)