### PR TITLE
Rename events filter "Event type" to "Type"

### DIFF
--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -616,7 +616,7 @@ export default function EventsClient({ events }: EventsClientProps) {
           />
           <FilterDropdown
             trackingPage="Events"
-            title="Event type"
+            title="Type"
             options={[...EVENT_TYPES]}
             selected={selectedTypes}
             counts={typeCounts}


### PR DESCRIPTION
- Renames the /events filter label from "Event type" to "Type", matching the /training page's filter of the same name
- One-line change in `EventsClient.tsx`; dropdown options and behavior unchanged
- Analytics note: filter clicks will now be tracked under "Type" instead of "Event type"

🤖 Generated with [Claude Code](https://claude.com/claude-code)