### PR TITLE
Add /hackathon event page with application form

### DIFF
--- a/docs/hackathon-signup.md
+++ b/docs/hackathon-signup.md
@@ -42,7 +42,7 @@ version — this keeps the same `/exec` URL.
 
 Sheet columns, in order: Timestamp, Name, Email, Skills & experience,
 Allergies & dietary, Medical & mental health, Room preference, 18+, Emergency
-contact, Anything else, Arrival, Departure.
+contact, Anything else, Arrival, Departure, Personal links.
 
 The confirmation email echoes the applicant's answers back to them. It is sent
 with both `htmlBody` (what Gmail shows — flows naturally at any window width)
@@ -90,6 +90,7 @@ function doPost(e) {
       data.anythingElse || '',
       data.arrival || '',
       data.departure || '',
+      data.links || '',
     ])
 
     if (data.email) {
@@ -103,6 +104,7 @@ function doPost(e) {
           'What skills or experience could you bring to this hackathon?',
           data.skills,
         ],
+        ['Personal links', data.links],
         [
           'Do you have any allergies or dietary needs/preferences?',
           data.dietary,

--- a/docs/hackathon-signup.md
+++ b/docs/hackathon-signup.md
@@ -101,7 +101,7 @@ function doPost(e) {
         ['Full name', data.name],
         ['Email', data.email],
         [
-          'What skills or experience could you bring to this hackathon? What are your current plans and activities towards saving the world?',
+          'What skills or experience could you bring to this hackathon?',
           data.skills,
         ],
         [

--- a/docs/hackathon-signup.md
+++ b/docs/hackathon-signup.md
@@ -90,7 +90,7 @@ function doPost(e) {
 
       // Question/answer pairs in form order; empty optional answers are skipped.
       var answers = [
-        ['Full name', data.name],
+        ['Name', data.name],
         ['Email', data.email],
         [
           'What skills or experience could you bring to this hackathon?',

--- a/docs/hackathon-signup.md
+++ b/docs/hackathon-signup.md
@@ -44,9 +44,10 @@ Sheet columns, in order: Timestamp, Name, Email, Skills & experience,
 Allergies & dietary, Medical & mental health, Room preference, 18+, Emergency
 contact, Anything else, Successful projects, Arrival, Departure.
 
-The confirmation email is sent with both `htmlBody` (what Gmail shows — flows
-naturally at any window width) and a plain-text `body` fallback (hard-wrapped
-at ~76 chars by the mail pipeline, which is why htmlBody exists).
+The confirmation email echoes the applicant's answers back to them. It is sent
+with both `htmlBody` (what Gmail shows — flows naturally at any window width)
+and a plain-text `body` fallback (hard-wrapped at ~76 chars by the mail
+pipeline, which is why htmlBody exists).
 
 Current code (secret redacted; the real one is in the deployed script and in
 the env vars):
@@ -94,34 +95,88 @@ function doPost(e) {
 
     if (data.email) {
       var name = data.name || 'there'
-      // Plain-text fallback (some clients only show this); Gmail shows htmlBody.
+
+      // Question/answer pairs in form order; empty optional answers are skipped.
+      var answers = [
+        ['Full name', data.name],
+        ['Email', data.email],
+        [
+          'What skills or experience could you bring to this hackathon? What are your current plans and activities towards saving the world?',
+          data.skills,
+        ],
+        [
+          'What has been 1 or 2 of your most successful projects, and what were the outcomes?',
+          data.successfulProjects,
+        ],
+        [
+          'Do you have any allergies or dietary needs/preferences?',
+          data.dietary,
+        ],
+        [
+          'Do you have any particular medical or mental health needs you would like us to know about?',
+          data.medical,
+        ],
+        ['Room preference', data.roomPreference],
+        ['When would you arrive?', data.arrival],
+        ['When would you leave?', data.departure],
+        ['Emergency contact', data.emergencyContact],
+        ["Anything else you'd like us to know?", data.anythingElse],
+        [
+          'At least 18 years old by the date of the event',
+          data.over18 ? 'Yes' : 'No',
+        ],
+      ].filter(function (a) {
+        return a[1]
+      })
+
       var body =
         'Hi ' +
         name +
         ',\n\n' +
-        'Thanks for applying to the AISafety.com Hackathon 2026!\n\n' +
-        'The details:\n' +
-        '- Dates: Thursday 17 - Sunday 20 September 2026\n' +
-        '- Venue: CEEALAR (the EA Hotel) in Blackpool, England (ceealar.org)\n' +
-        '- Accommodation and meals are provided\n\n' +
-        'Applications close 10 August, and results will be announced by ' +
-        '21 August.\n\n' +
-        'If you have any questions, just reply to this email.\n\n' +
-        'The AISafety.com team'
+        'Thanks for applying to the AISafety.com Hackathon 2026 ' +
+        '(https://aisafety.com/hackathon)! This is an automated email ' +
+        'confirming your application submission.\n\n' +
+        "Below are the answers you gave. We'll let you know the result of " +
+        'your application by 21 August at the latest. In the meantime, feel ' +
+        'free to reply to this email with any questions or message Bryce on ' +
+        'the AISafety.com Discord server (https://discord.gg/WQG8FAGqun) at ' +
+        '@bryceerobertson.\n\n' +
+        'Best,\n' +
+        'Automated Bryce\n\n\n' +
+        'YOUR FORM ANSWERS\n\n' +
+        answers
+          .map(function (a) {
+            return a[0] + ':\n' + a[1]
+          })
+          .join('\n\n')
+
       var htmlBody =
         '<p>Hi ' +
         escapeHtml(name) +
         ',</p>' +
-        '<p>Thanks for applying to the AISafety.com Hackathon 2026!</p>' +
-        '<p>The details:<br>' +
-        '&ndash; Dates: Thursday 17 &ndash; Sunday 20 September 2026<br>' +
-        '&ndash; Venue: CEEALAR (the EA Hotel) in Blackpool, England ' +
-        '(<a href="https://www.ceealar.org">ceealar.org</a>)<br>' +
-        '&ndash; Accommodation and meals are provided</p>' +
-        '<p>Applications close 10 August, and results will be announced by ' +
-        '21 August.</p>' +
-        '<p>If you have any questions, just reply to this email.</p>' +
-        '<p>The AISafety.com team</p>'
+        '<p>Thanks for applying to the ' +
+        '<a href="https://aisafety.com/hackathon">AISafety.com Hackathon 2026</a>! ' +
+        'This is an automated email confirming your application submission.</p>' +
+        "<p>Below are the answers you gave. We'll let you know the result of " +
+        'your application by 21 August at the latest. In the meantime, feel ' +
+        'free to reply to this email with any questions or message Bryce on ' +
+        'the <a href="https://discord.gg/WQG8FAGqun">AISafety.com Discord ' +
+        'server</a> at @bryceerobertson.</p>' +
+        '<p>Best,<br>Automated Bryce</p>' +
+        '<br>' +
+        '<p><strong>Your form answers</strong></p>' +
+        answers
+          .map(function (a) {
+            return (
+              '<p><strong>' +
+              escapeHtml(a[0]) +
+              '</strong><br>' +
+              escapeHtml(a[1]).replace(/\n/g, '<br>') +
+              '</p>'
+            )
+          })
+          .join('')
+
       MailApp.sendEmail({
         to: data.email,
         subject: 'AISafety.com Hackathon 2026 - application received',

--- a/docs/hackathon-signup.md
+++ b/docs/hackathon-signup.md
@@ -40,9 +40,8 @@ app ("Execute as: Me", "Who has access: Anyone"), owned by Bryce's Google
 account. Redeploy after edits via Deploy → Manage deployments → edit → new
 version — this keeps the same `/exec` URL.
 
-Sheet columns, in order: Timestamp, Name, Email, Skills & experience,
-Allergies & dietary, Medical & mental health, Room preference, 18+, Emergency
-contact, Anything else, Arrival, Departure, Personal links.
+Sheet columns, in order: Timestamp, Name, Email, Skills & experience, 18+,
+Anything else, Personal links.
 
 The confirmation email echoes the applicant's answers back to them. It is sent
 with both `htmlBody` (what Gmail shows — flows naturally at any window width)
@@ -82,14 +81,8 @@ function doPost(e) {
       data.name || '',
       data.email || '',
       data.skills || '',
-      data.dietary || '',
-      data.medical || '',
-      data.roomPreference || '',
       data.over18 ? 'Yes' : 'No',
-      data.emergencyContact || '',
       data.anythingElse || '',
-      data.arrival || '',
-      data.departure || '',
       data.links || '',
     ])
 
@@ -105,18 +98,6 @@ function doPost(e) {
           data.skills,
         ],
         ['Personal links', data.links],
-        [
-          'Do you have any allergies or dietary needs/preferences?',
-          data.dietary,
-        ],
-        [
-          'Do you have any particular medical or mental health needs you would like us to know about?',
-          data.medical,
-        ],
-        ['Room preference', data.roomPreference],
-        ['When would you arrive?', data.arrival],
-        ['When would you leave?', data.departure],
-        ['Emergency contact', data.emergencyContact],
         ["Anything else you'd like us to know?", data.anythingElse],
         [
           'At least 18 years old by the date of the event',

--- a/docs/hackathon-signup.md
+++ b/docs/hackathon-signup.md
@@ -37,18 +37,29 @@ the form can be tested locally); production returns a 500.
 
 Lives in the applications Sheet: Extensions → Apps Script, deployed as a web
 app ("Execute as: Me", "Who has access: Anyone"), owned by Bryce's Google
-account. Redeploy (Deploy → Manage deployments → edit → new version) after
-edits.
+account. Redeploy after edits via Deploy → Manage deployments → edit → new
+version — this keeps the same `/exec` URL.
 
 Sheet columns, in order: Timestamp, Name, Email, Tracks, Skills & experience,
 Allergies & dietary, Medical & mental health, Room preference, 18+, Emergency
 contact, Anything else, Successful projects, Arrival, Departure.
+
+The confirmation email is sent with both `htmlBody` (what Gmail shows — flows
+naturally at any window width) and a plain-text `body` fallback (hard-wrapped
+at ~76 chars by the mail pipeline, which is why htmlBody exists).
 
 Current code (secret redacted; the real one is in the deployed script and in
 the env vars):
 
 ```javascript
 var SHARED_SECRET = '<HACKATHON_FORM_SECRET>'
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
 
 function doPost(e) {
   var out = ContentService.createTextOutput().setMimeType(
@@ -83,23 +94,42 @@ function doPost(e) {
     ])
 
     if (data.email) {
+      var name = data.name || 'there'
+      // Plain-text fallback (some clients only show this); Gmail shows htmlBody.
+      var body =
+        'Hi ' +
+        name +
+        ',\n\n' +
+        'Thanks for applying to the AISafety.com Hackathon 2026!\n\n' +
+        'The details:\n' +
+        '- Dates: Thursday 17 - Sunday 20 September 2026\n' +
+        '- Venue: CEEALAR (the EA Hotel) in Blackpool, England (ceealar.org)\n' +
+        '- Accommodation and meals are provided\n\n' +
+        "Applications close 10 August. Spots are limited, so we'll be in " +
+        'touch to confirm your place and share more details before the ' +
+        'event.\n\n' +
+        'If you have any questions, just reply to this email.\n\n' +
+        'The AISafety.com team'
+      var htmlBody =
+        '<p>Hi ' +
+        escapeHtml(name) +
+        ',</p>' +
+        '<p>Thanks for applying to the AISafety.com Hackathon 2026!</p>' +
+        '<p>The details:<br>' +
+        '&ndash; Dates: Thursday 17 &ndash; Sunday 20 September 2026<br>' +
+        '&ndash; Venue: CEEALAR (the EA Hotel) in Blackpool, England ' +
+        '(<a href="https://www.ceealar.org">ceealar.org</a>)<br>' +
+        '&ndash; Accommodation and meals are provided</p>' +
+        "<p>Applications close 10 August. Spots are limited, so we'll be in " +
+        'touch to confirm your place and share more details before the ' +
+        'event.</p>' +
+        '<p>If you have any questions, just reply to this email.</p>' +
+        '<p>The AISafety.com team</p>'
       MailApp.sendEmail({
         to: data.email,
         subject: 'AISafety.com Hackathon 2026 - application received',
-        body:
-          'Hi ' +
-          (data.name || 'there') +
-          ',\n\n' +
-          'Thanks for applying to the AISafety.com Hackathon 2026!\n\n' +
-          'The details:\n' +
-          '- Dates: Thursday 17 - Sunday 20 September 2026\n' +
-          '- Venue: CEEALAR (the EA Hotel) in Blackpool, England (ceealar.org)\n' +
-          '- Accommodation and meals are provided\n\n' +
-          "Applications close 10 August. Spots are limited, so we'll be in " +
-          'touch to confirm your place and share more details before the ' +
-          'event.\n\n' +
-          'If you have any questions, just reply to this email.\n\n' +
-          'The AISafety.com team',
+        body: body,
+        htmlBody: htmlBody,
       })
     }
 

--- a/docs/hackathon-signup.md
+++ b/docs/hackathon-signup.md
@@ -1,0 +1,111 @@
+# Hackathon application pipeline
+
+The `/hackathon` page hosts the event info and an application form. Applications
+flow:
+
+```
+ApplicationForm.tsx  →  POST /api/hackathon-signup  →  Google Apps Script web app
+                                                        ├─ appends a row to the private
+                                                        │  "AISafety.com Hackathon 2026
+                                                        │  Applications" Google Sheet
+                                                        └─ emails the applicant a
+                                                           confirmation
+```
+
+Applications deliberately do NOT go to Airtable: they include personal data
+(emergency contacts, medical and dietary needs) that must stay out of the
+shared base, and the team reviews them in a private Google Sheet instead.
+
+## Environment variables
+
+- `HACKATHON_SCRIPT_URL` – the Apps Script web app's `/exec` URL.
+- `HACKATHON_FORM_SECRET` – shared secret; the API route includes it in each
+  POST and the script rejects requests without it (the `/exec` URL is
+  technically public).
+
+When either is unset, dev builds log the application and pretend success (so
+the form can be tested locally); production returns a 500.
+
+## Abuse protection
+
+- Honeypot field (`website`) – filled → request is dropped with a fake success.
+- Per-IP rate limit, 5/hour, via the existing Upstash Redis (protects the
+  Gmail quota behind confirmation emails, ~100 sends/day).
+- Every field is length-capped server-side.
+
+## The Apps Script
+
+Lives in the applications Sheet: Extensions → Apps Script, deployed as a web
+app ("Execute as: Me", "Who has access: Anyone"), owned by Bryce's Google
+account. Redeploy (Deploy → Manage deployments → edit → new version) after
+edits.
+
+Sheet columns, in order: Timestamp, Name, Email, Tracks, Skills & experience,
+Allergies & dietary, Medical & mental health, Room preference, 18+, Emergency
+contact, Anything else, Successful projects, Arrival, Departure.
+
+Current code (secret redacted; the real one is in the deployed script and in
+the env vars):
+
+```javascript
+var SHARED_SECRET = '<HACKATHON_FORM_SECRET>'
+
+function doPost(e) {
+  var out = ContentService.createTextOutput().setMimeType(
+    ContentService.MimeType.JSON
+  )
+
+  try {
+    var data = JSON.parse(e.postData.contents)
+
+    if (data.secret !== SHARED_SECRET) {
+      return out.setContent(
+        JSON.stringify({ ok: false, error: 'unauthorized' })
+      )
+    }
+
+    var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheets()[0]
+    sheet.appendRow([
+      new Date(),
+      data.name || '',
+      data.email || '',
+      (data.tracks || []).join(', '),
+      data.skills || '',
+      data.dietary || '',
+      data.medical || '',
+      data.roomPreference || '',
+      data.over18 ? 'Yes' : 'No',
+      data.emergencyContact || '',
+      data.anythingElse || '',
+      data.successfulProjects || '',
+      data.arrival || '',
+      data.departure || '',
+    ])
+
+    if (data.email) {
+      MailApp.sendEmail({
+        to: data.email,
+        subject: 'AISafety.com Hackathon 2026 - application received',
+        body:
+          'Hi ' +
+          (data.name || 'there') +
+          ',\n\n' +
+          'Thanks for applying to the AISafety.com Hackathon 2026!\n\n' +
+          'The details:\n' +
+          '- Dates: Thursday 17 - Sunday 20 September 2026\n' +
+          '- Venue: CEEALAR (the EA Hotel) in Blackpool, England (ceealar.org)\n' +
+          '- Accommodation and meals are provided\n\n' +
+          "Applications close 10 August. Spots are limited, so we'll be in " +
+          'touch to confirm your place and share more details before the ' +
+          'event.\n\n' +
+          'If you have any questions, just reply to this email.\n\n' +
+          'The AISafety.com team',
+      })
+    }
+
+    return out.setContent(JSON.stringify({ ok: true }))
+  } catch (err) {
+    return out.setContent(JSON.stringify({ ok: false, error: String(err) }))
+  }
+}
+```

--- a/docs/hackathon-signup.md
+++ b/docs/hackathon-signup.md
@@ -42,7 +42,7 @@ version — this keeps the same `/exec` URL.
 
 Sheet columns, in order: Timestamp, Name, Email, Skills & experience,
 Allergies & dietary, Medical & mental health, Room preference, 18+, Emergency
-contact, Anything else, Successful projects, Arrival, Departure.
+contact, Anything else, Arrival, Departure.
 
 The confirmation email echoes the applicant's answers back to them. It is sent
 with both `htmlBody` (what Gmail shows — flows naturally at any window width)
@@ -88,7 +88,6 @@ function doPost(e) {
       data.over18 ? 'Yes' : 'No',
       data.emergencyContact || '',
       data.anythingElse || '',
-      data.successfulProjects || '',
       data.arrival || '',
       data.departure || '',
     ])
@@ -103,10 +102,6 @@ function doPost(e) {
         [
           'What skills or experience could you bring to this hackathon?',
           data.skills,
-        ],
-        [
-          'What has been 1 or 2 of your most successful projects, and what were the outcomes?',
-          data.successfulProjects,
         ],
         [
           'Do you have any allergies or dietary needs/preferences?',

--- a/docs/hackathon-signup.md
+++ b/docs/hackathon-signup.md
@@ -40,7 +40,7 @@ app ("Execute as: Me", "Who has access: Anyone"), owned by Bryce's Google
 account. Redeploy after edits via Deploy → Manage deployments → edit → new
 version — this keeps the same `/exec` URL.
 
-Sheet columns, in order: Timestamp, Name, Email, Skills & experience, 18+,
+Sheet columns, in order: Timestamp, Name, Email, Skills & experience,
 Anything else, Personal links.
 
 The confirmation email echoes the applicant's answers back to them. It is sent
@@ -81,7 +81,6 @@ function doPost(e) {
       data.name || '',
       data.email || '',
       data.skills || '',
-      data.over18 ? 'Yes' : 'No',
       data.anythingElse || '',
       data.links || '',
     ])
@@ -99,10 +98,6 @@ function doPost(e) {
         ],
         ['Personal links', data.links],
         ["Anything else you'd like us to know?", data.anythingElse],
-        [
-          'At least 18 years old by the date of the event',
-          data.over18 ? 'Yes' : 'No',
-        ],
       ].filter(function (a) {
         return a[1]
       })

--- a/docs/hackathon-signup.md
+++ b/docs/hackathon-signup.md
@@ -40,7 +40,7 @@ app ("Execute as: Me", "Who has access: Anyone"), owned by Bryce's Google
 account. Redeploy after edits via Deploy → Manage deployments → edit → new
 version — this keeps the same `/exec` URL.
 
-Sheet columns, in order: Timestamp, Name, Email, Tracks, Skills & experience,
+Sheet columns, in order: Timestamp, Name, Email, Skills & experience,
 Allergies & dietary, Medical & mental health, Room preference, 18+, Emergency
 contact, Anything else, Successful projects, Arrival, Departure.
 
@@ -80,7 +80,6 @@ function doPost(e) {
       new Date(),
       data.name || '',
       data.email || '',
-      (data.tracks || []).join(', '),
       data.skills || '',
       data.dietary || '',
       data.medical || '',
@@ -105,9 +104,8 @@ function doPost(e) {
         '- Dates: Thursday 17 - Sunday 20 September 2026\n' +
         '- Venue: CEEALAR (the EA Hotel) in Blackpool, England (ceealar.org)\n' +
         '- Accommodation and meals are provided\n\n' +
-        "Applications close 10 August. Spots are limited, so we'll be in " +
-        'touch to confirm your place and share more details before the ' +
-        'event.\n\n' +
+        'Applications close 10 August, and results will be announced by ' +
+        '21 August.\n\n' +
         'If you have any questions, just reply to this email.\n\n' +
         'The AISafety.com team'
       var htmlBody =
@@ -120,9 +118,8 @@ function doPost(e) {
         '&ndash; Venue: CEEALAR (the EA Hotel) in Blackpool, England ' +
         '(<a href="https://www.ceealar.org">ceealar.org</a>)<br>' +
         '&ndash; Accommodation and meals are provided</p>' +
-        "<p>Applications close 10 August. Spots are limited, so we'll be in " +
-        'touch to confirm your place and share more details before the ' +
-        'event.</p>' +
+        '<p>Applications close 10 August, and results will be announced by ' +
+        '21 August.</p>' +
         '<p>If you have any questions, just reply to this email.</p>' +
         '<p>The AISafety.com team</p>'
       MailApp.sendEmail({

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,4 +24,5 @@ The site does not publish articles or research. It is a directory and discovery 
 ## Other Pages
 
 - [About](https://aisafety.com/about): Information about the team, mission, and how to get involved
+- [Hackathon 2026](https://aisafety.com/hackathon): The annual AISafety.com hackathon – event details and signup
 - [AISafety.info](https://aisafety.info): Sister site explaining what AI safety is, why it matters, and what you can do to help

--- a/src/app/api/hackathon-signup/route.ts
+++ b/src/app/api/hackathon-signup/route.ts
@@ -66,11 +66,10 @@ export async function POST(req: NextRequest) {
     skills: str(b.skills, 5000),
     links: str(b.links, 2000),
     anythingElse: str(b.anythingElse, 5000),
-    over18: b.over18 === true,
   }
 
   const required: (keyof typeof application)[] = ['name', 'email', 'skills']
-  if (required.some(f => !application[f]) || !application.over18) {
+  if (required.some(f => !application[f])) {
     return new Response('missing required fields', { status: 400 })
   }
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(application.email)) {

--- a/src/app/api/hackathon-signup/route.ts
+++ b/src/app/api/hackathon-signup/route.ts
@@ -65,23 +65,11 @@ export async function POST(req: NextRequest) {
     email: str(b.email, 320),
     skills: str(b.skills, 5000),
     links: str(b.links, 2000),
-    dietary: str(b.dietary, 2000),
-    medical: str(b.medical, 2000),
-    roomPreference: str(b.roomPreference, 100),
-    emergencyContact: str(b.emergencyContact, 500),
     anythingElse: str(b.anythingElse, 5000),
-    arrival: str(b.arrival, 20),
-    departure: str(b.departure, 20),
     over18: b.over18 === true,
   }
 
-  const required: (keyof typeof application)[] = [
-    'name',
-    'email',
-    'skills',
-    'roomPreference',
-    'emergencyContact',
-  ]
+  const required: (keyof typeof application)[] = ['name', 'email', 'skills']
   if (required.some(f => !application[f]) || !application.over18) {
     return new Response('missing required fields', { status: 400 })
   }

--- a/src/app/api/hackathon-signup/route.ts
+++ b/src/app/api/hackathon-signup/route.ts
@@ -64,6 +64,7 @@ export async function POST(req: NextRequest) {
     name: str(b.name, 200),
     email: str(b.email, 320),
     skills: str(b.skills, 5000),
+    links: str(b.links, 2000),
     dietary: str(b.dietary, 2000),
     medical: str(b.medical, 2000),
     roomPreference: str(b.roomPreference, 100),

--- a/src/app/api/hackathon-signup/route.ts
+++ b/src/app/api/hackathon-signup/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest } from 'next/server'
+import { Ratelimit } from '@upstash/ratelimit'
+import { Redis } from '@upstash/redis'
+import { getClientIp } from '@/lib/assistant/rate-limit'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+// The Apps Script roundtrip (append row + send confirmation email) can take a
+// few seconds on a cold start.
+export const maxDuration = 30
+
+// Google Apps Script web app attached to the private applications Sheet. It
+// appends a row and emails the applicant a confirmation — see
+// docs/hackathon-signup.md.
+const SCRIPT_URL = process.env.HACKATHON_SCRIPT_URL
+const SECRET = process.env.HACKATHON_FORM_SECRET
+
+// Same env fallbacks as lib/assistant/rate-limit.ts (Vercel-Upstash naming
+// first, upstream Upstash naming second).
+const restUrl =
+  process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL
+const restToken =
+  process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN
+const redis =
+  restUrl && restToken ? new Redis({ url: restUrl, token: restToken }) : null
+
+// Loose per-IP cap. Its real job is protecting the Gmail quota behind the
+// confirmation emails (~100 sends/day) from a scripted flood.
+const limiter = redis
+  ? new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(5, '1 h'),
+      analytics: false,
+      prefix: 'aisafety:hackathon',
+    })
+  : null
+
+/** Coerce an unknown to a trimmed, length-capped string. */
+function str(v: unknown, max: number): string {
+  if (typeof v !== 'string') return ''
+  const s = v.trim()
+  return s.length > max ? s.slice(0, max) : s
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return new Response('invalid JSON', { status: 400 })
+  }
+  if (!body || typeof body !== 'object') {
+    return new Response('invalid application', { status: 400 })
+  }
+  const b = body as Record<string, unknown>
+
+  // Honeypot filled in → almost certainly a bot. Pretend success so it
+  // doesn't learn to adapt; nothing is stored or emailed.
+  if (str(b.website, 10)) {
+    return new Response(null, { status: 204 })
+  }
+
+  const tracks = Array.isArray(b.tracks)
+    ? b.tracks
+        .map(t => str(t, 120))
+        .filter(Boolean)
+        .slice(0, 10)
+    : []
+
+  const application = {
+    name: str(b.name, 200),
+    email: str(b.email, 320),
+    tracks,
+    skills: str(b.skills, 5000),
+    dietary: str(b.dietary, 2000),
+    medical: str(b.medical, 2000),
+    roomPreference: str(b.roomPreference, 100),
+    emergencyContact: str(b.emergencyContact, 500),
+    anythingElse: str(b.anythingElse, 5000),
+    successfulProjects: str(b.successfulProjects, 5000),
+    arrival: str(b.arrival, 20),
+    departure: str(b.departure, 20),
+    over18: b.over18 === true,
+  }
+
+  const required: (keyof typeof application)[] = [
+    'name',
+    'email',
+    'skills',
+    'roomPreference',
+    'emergencyContact',
+  ]
+  if (
+    required.some(f => !application[f]) ||
+    tracks.length === 0 ||
+    !application.over18
+  ) {
+    return new Response('missing required fields', { status: 400 })
+  }
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(application.email)) {
+    return new Response('invalid email', { status: 400 })
+  }
+
+  if (limiter) {
+    const { success } = await limiter.limit(getClientIp(req.headers))
+    if (!success) {
+      return new Response('rate limited', { status: 429 })
+    }
+  }
+
+  if (!SCRIPT_URL || !SECRET) {
+    if (process.env.NODE_ENV !== 'production') {
+      // Lets the form be exercised locally before the Apps Script exists.
+      console.log('[hackathon-signup] not configured; would send:', application)
+      return new Response(null, { status: 204 })
+    }
+    console.error(
+      '[hackathon-signup] HACKATHON_SCRIPT_URL / HACKATHON_FORM_SECRET not set'
+    )
+    return new Response('application not configured', { status: 500 })
+  }
+
+  // Await the write: the user needs to know their application was actually
+  // stored before we show success. (Apps Script replies via a 302 fetch
+  // follows.)
+  let result: { ok?: boolean }
+  try {
+    const res = await fetch(SCRIPT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...application, secret: SECRET }),
+      signal: AbortSignal.timeout(20_000),
+    })
+    result = (await res.json()) as { ok?: boolean }
+  } catch (err) {
+    console.error('[hackathon-signup] Apps Script call failed:', err)
+    return new Response('application failed', { status: 502 })
+  }
+  if (!result.ok) {
+    console.error(
+      '[hackathon-signup] Apps Script rejected application:',
+      result
+    )
+    return new Response('application failed', { status: 502 })
+  }
+
+  return new Response(null, { status: 204 })
+}

--- a/src/app/api/hackathon-signup/route.ts
+++ b/src/app/api/hackathon-signup/route.ts
@@ -60,17 +60,9 @@ export async function POST(req: NextRequest) {
     return new Response(null, { status: 204 })
   }
 
-  const tracks = Array.isArray(b.tracks)
-    ? b.tracks
-        .map(t => str(t, 120))
-        .filter(Boolean)
-        .slice(0, 10)
-    : []
-
   const application = {
     name: str(b.name, 200),
     email: str(b.email, 320),
-    tracks,
     skills: str(b.skills, 5000),
     dietary: str(b.dietary, 2000),
     medical: str(b.medical, 2000),
@@ -90,11 +82,7 @@ export async function POST(req: NextRequest) {
     'roomPreference',
     'emergencyContact',
   ]
-  if (
-    required.some(f => !application[f]) ||
-    tracks.length === 0 ||
-    !application.over18
-  ) {
+  if (required.some(f => !application[f]) || !application.over18) {
     return new Response('missing required fields', { status: 400 })
   }
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(application.email)) {

--- a/src/app/api/hackathon-signup/route.ts
+++ b/src/app/api/hackathon-signup/route.ts
@@ -69,7 +69,6 @@ export async function POST(req: NextRequest) {
     roomPreference: str(b.roomPreference, 100),
     emergencyContact: str(b.emergencyContact, 500),
     anythingElse: str(b.anythingElse, 5000),
-    successfulProjects: str(b.successfulProjects, 5000),
     arrival: str(b.arrival, 20),
     departure: str(b.departure, 20),
     over18: b.over18 === true,

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -132,7 +132,7 @@ export default function ApplicationForm() {
 
       <fieldset className={`${styles.full} ${styles.fieldset}`}>
         <legend className="paragraph-small color-teal-300 padding-bottom-8px">
-          Which project track(s) are you interested in? See above for details.
+          Which project track(s) are you interested in?
         </legend>
         <div className={styles.field}>
           {TRACKS.map(track => (

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -12,7 +12,6 @@ const EMPTY = {
   roomPreference: '',
   emergencyContact: '',
   anythingElse: '',
-  successfulProjects: '',
   arrival: '',
   departure: '',
   // Honeypot – hidden from people, filled in by naive bots.
@@ -123,23 +122,6 @@ export default function ApplicationForm() {
           value={form.skills}
           onChange={set('skills')}
           required
-        />
-      </div>
-
-      <div className={`${styles.field} ${styles.full}`}>
-        <label
-          className="paragraph-small color-teal-300"
-          htmlFor="successfulProjects"
-        >
-          What has been 1 or 2 of your most successful projects (in AI safety or
-          otherwise), and what were the outcomes? A brief answer is fine.{' '}
-          <Optional />
-        </label>
-        <textarea
-          id="successfulProjects"
-          className={`text-field ${styles.textarea}`}
-          value={form.successfulProjects}
-          onChange={set('successfulProjects')}
         />
       </div>
 

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -28,7 +28,15 @@ export default function ApplicationForm() {
       e: React.ChangeEvent<
         HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
       >
-    ) => setForm({ ...form, [field]: e.target.value })
+    ) => {
+      const el = e.target
+      // Textareas grow with their content instead of scrolling internally.
+      if (el instanceof HTMLTextAreaElement) {
+        el.style.height = 'auto'
+        el.style.height = `${el.scrollHeight + 2}px`
+      }
+      setForm({ ...form, [field]: el.value })
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -19,7 +19,6 @@ function Optional() {
 
 export default function ApplicationForm() {
   const [form, setForm] = useState(EMPTY)
-  const [over18, setOver18] = useState(false)
   const [busy, setBusy] = useState(false)
   const [done, setDone] = useState(false)
   const [error, setError] = useState('')
@@ -41,7 +40,7 @@ export default function ApplicationForm() {
       const res = await fetch('/api/hackathon-signup', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...form, over18 }),
+        body: JSON.stringify(form),
       })
       if (res.ok) {
         setDone(true)
@@ -158,19 +157,6 @@ export default function ApplicationForm() {
           onChange={set('website')}
         />
       </div>
-
-      <label className={`flex items-center cursor-pointer ${styles.full}`}>
-        <input
-          type="checkbox"
-          className="checkbox"
-          checked={over18}
-          onChange={e => setOver18(e.target.checked)}
-          required
-        />
-        <span className="paragraph-small color-teal-300">
-          I will be at least 18 years old by the date of this event
-        </span>
-      </label>
 
       <div className={styles.full}>
         <button type="submit" className="button-primary" disabled={busy}>

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -87,7 +87,7 @@ export default function ApplicationForm() {
     >
       <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="name">
-          Full name
+          Name
         </label>
         <input
           id="name"

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -78,7 +78,7 @@ export default function ApplicationForm() {
       className={`${styles.fields} padding-bottom-56px`}
       onSubmit={handleSubmit}
     >
-      <div className={styles.field}>
+      <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="name">
           Full name
         </label>
@@ -92,7 +92,7 @@ export default function ApplicationForm() {
         />
       </div>
 
-      <div className={styles.field}>
+      <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="email">
           Email
         </label>

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -128,6 +128,23 @@ export default function ApplicationForm() {
       </div>
 
       <div className={`${styles.field} ${styles.full}`}>
+        <label
+          className="paragraph-small color-teal-300"
+          htmlFor="successfulProjects"
+        >
+          What has been 1 or 2 of your most successful projects (in AI safety or
+          otherwise), and what were the outcomes? A brief answer is fine.{' '}
+          <Optional />
+        </label>
+        <textarea
+          id="successfulProjects"
+          className={`text-field ${styles.textarea}`}
+          value={form.successfulProjects}
+          onChange={set('successfulProjects')}
+        />
+      </div>
+
+      <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="dietary">
           Do you have any allergies or dietary needs/preferences? If so, please
           list the allergen and its severity. All food will be vegan.{' '}
@@ -179,6 +196,38 @@ export default function ApplicationForm() {
         </select>
       </div>
 
+      <p className={`paragraph-xs color-teal-300 ${styles.full}`}>
+        We expect most participants will arrive on 16 or 17 September and depart
+        on 20 or 21 September. If you can&apos;t make the whole event, list your
+        arrival and departure dates below. <Optional />
+      </p>
+
+      <div className={styles.field}>
+        <label className="paragraph-small color-teal-300" htmlFor="arrival">
+          When would you arrive?
+        </label>
+        <input
+          id="arrival"
+          type="date"
+          className={`text-field ${styles.date}`}
+          value={form.arrival}
+          onChange={set('arrival')}
+        />
+      </div>
+
+      <div className={styles.field}>
+        <label className="paragraph-small color-teal-300" htmlFor="departure">
+          When would you leave?
+        </label>
+        <input
+          id="departure"
+          type="date"
+          className={`text-field ${styles.date}`}
+          value={form.departure}
+          onChange={set('departure')}
+        />
+      </div>
+
       <div className={`${styles.field} ${styles.full}`}>
         <label
           className="paragraph-small color-teal-300"
@@ -209,55 +258,6 @@ export default function ApplicationForm() {
           className={`text-field ${styles.textarea}`}
           value={form.anythingElse}
           onChange={set('anythingElse')}
-        />
-      </div>
-
-      <div className={`${styles.field} ${styles.full}`}>
-        <label
-          className="paragraph-small color-teal-300"
-          htmlFor="successfulProjects"
-        >
-          What has been 1 or 2 of your most successful projects (in AI safety or
-          otherwise), and what were the outcomes? A brief answer is fine.{' '}
-          <Optional />
-        </label>
-        <textarea
-          id="successfulProjects"
-          className={`text-field ${styles.textarea}`}
-          value={form.successfulProjects}
-          onChange={set('successfulProjects')}
-        />
-      </div>
-
-      <p className={`paragraph-xs color-teal-300 ${styles.full}`}>
-        We expect most participants will arrive on 16 or 17 September and depart
-        on 20 or 21 September. If you can&apos;t make the whole event, list your
-        arrival and departure dates below. <Optional />
-      </p>
-
-      <div className={styles.field}>
-        <label className="paragraph-small color-teal-300" htmlFor="arrival">
-          When would you arrive?
-        </label>
-        <input
-          id="arrival"
-          type="date"
-          className={`text-field ${styles.date}`}
-          value={form.arrival}
-          onChange={set('arrival')}
-        />
-      </div>
-
-      <div className={styles.field}>
-        <label className="paragraph-small color-teal-300" htmlFor="departure">
-          When would you leave?
-        </label>
-        <input
-          id="departure"
-          type="date"
-          className={`text-field ${styles.date}`}
-          value={form.departure}
-          onChange={set('departure')}
         />
       </div>
 

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -1,0 +1,350 @@
+'use client'
+
+import { useState } from 'react'
+import styles from './page.module.css'
+
+const TRACKS = [
+  'Product and design',
+  'Development',
+  'Project management',
+  'Promotion',
+]
+
+const EMPTY = {
+  name: '',
+  email: '',
+  otherTrack: '',
+  skills: '',
+  dietary: '',
+  medical: '',
+  roomPreference: '',
+  emergencyContact: '',
+  anythingElse: '',
+  successfulProjects: '',
+  arrival: '',
+  departure: '',
+  // Honeypot – hidden from people, filled in by naive bots.
+  website: '',
+}
+
+export default function ApplicationForm() {
+  const [form, setForm] = useState(EMPTY)
+  const [tracks, setTracks] = useState<string[]>([])
+  const [over18, setOver18] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [done, setDone] = useState(false)
+  const [error, setError] = useState('')
+
+  function set(field: keyof typeof EMPTY) {
+    return (
+      e: React.ChangeEvent<
+        HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+      >
+    ) => setForm({ ...form, [field]: e.target.value })
+  }
+
+  function toggleTrack(track: string) {
+    setTracks(t =>
+      t.includes(track) ? t.filter(x => x !== track) : [...t, track]
+    )
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (busy) return
+    const allTracks = form.otherTrack.trim()
+      ? [...tracks, `Other: ${form.otherTrack.trim()}`]
+      : tracks
+    if (allTracks.length === 0) {
+      setError('Please pick at least one project track.')
+      return
+    }
+    setBusy(true)
+    setError('')
+    try {
+      const res = await fetch('/api/hackathon-signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...form, tracks: allTracks, over18 }),
+      })
+      if (res.ok) {
+        setDone(true)
+      } else if (res.status === 429) {
+        setError(
+          'Too many applications from your connection – please try again in an hour.'
+        )
+      } else {
+        setError(
+          'Something went wrong sending your application. Please try again, or email bryceerobertson@gmail.com.'
+        )
+      }
+    } catch {
+      setError('Network error – please check your connection and try again.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (done) {
+    return (
+      <div className="padding-bottom-56px">
+        <h3 className="padding-bottom-16px">Application received!</h3>
+        <p className="color-teal-300">
+          We&apos;ve emailed you a confirmation. Applications close 10 August –
+          we&apos;ll be in touch to confirm your place.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form
+      className={`${styles.fields} padding-bottom-56px`}
+      onSubmit={handleSubmit}
+    >
+      <div className={styles.field}>
+        <label className="paragraph-small color-teal-300" htmlFor="name">
+          Full name
+        </label>
+        <input
+          id="name"
+          type="text"
+          className="text-field"
+          value={form.name}
+          onChange={set('name')}
+          required
+        />
+      </div>
+
+      <div className={styles.field}>
+        <label className="paragraph-small color-teal-300" htmlFor="email">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          className="text-field"
+          value={form.email}
+          onChange={set('email')}
+          required
+        />
+      </div>
+
+      <fieldset className={`${styles.full} ${styles.fieldset}`}>
+        <legend className="paragraph-small color-teal-300 padding-bottom-8px">
+          Which project track(s) are you interested in? See above for details.
+        </legend>
+        <div className={styles.field}>
+          {TRACKS.map(track => (
+            <label key={track} className="flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                className="checkbox"
+                checked={tracks.includes(track)}
+                onChange={() => toggleTrack(track)}
+              />
+              <span className="paragraph-small color-teal-300">{track}</span>
+            </label>
+          ))}
+          <label
+            className="paragraph-small color-teal-300 margin-top-16px"
+            htmlFor="otherTrack"
+          >
+            Other
+          </label>
+          <input
+            id="otherTrack"
+            type="text"
+            className="text-field"
+            value={form.otherTrack}
+            onChange={set('otherTrack')}
+          />
+        </div>
+      </fieldset>
+
+      <div className={`${styles.field} ${styles.full}`}>
+        <label className="paragraph-small color-teal-300" htmlFor="skills">
+          What skills or experience could you bring to this hackathon (link to
+          CV welcome, but not required)? What are your current plans and
+          activities towards saving the world?
+        </label>
+        <textarea
+          id="skills"
+          className={`text-field ${styles.textarea}`}
+          value={form.skills}
+          onChange={set('skills')}
+          required
+        />
+      </div>
+
+      <div className={`${styles.field} ${styles.full}`}>
+        <label className="paragraph-small color-teal-300" htmlFor="dietary">
+          Do you have any allergies or dietary needs/preferences? If so, please
+          list the allergen and its severity. All food will be vegan. (optional)
+        </label>
+        <textarea
+          id="dietary"
+          className={`text-field ${styles.textarea}`}
+          value={form.dietary}
+          onChange={set('dietary')}
+        />
+      </div>
+
+      <div className={`${styles.field} ${styles.full}`}>
+        <label className="paragraph-small color-teal-300" htmlFor="medical">
+          Do you have any particular medical or mental health needs you would
+          like us to know about? (optional)
+        </label>
+        <textarea
+          id="medical"
+          className={`text-field ${styles.textarea}`}
+          value={form.medical}
+          onChange={set('medical')}
+        />
+      </div>
+
+      <div className={`${styles.field} ${styles.full}`}>
+        <label
+          className="paragraph-small color-teal-300"
+          htmlFor="roomPreference"
+        >
+          It&apos;s possible that some people may need to share a room – either
+          all female or all male, max 2 people per room. Do you have a
+          preference for having your own room?
+        </label>
+        <select
+          id="roomPreference"
+          className="text-field"
+          value={form.roomPreference}
+          onChange={set('roomPreference')}
+          required
+        >
+          <option value="" disabled>
+            Choose one
+          </option>
+          <option>Fine with sharing</option>
+          <option>Weak preference for own room</option>
+          <option>Strong preference for own room</option>
+        </select>
+      </div>
+
+      <div className={`${styles.field} ${styles.full}`}>
+        <label
+          className="paragraph-small color-teal-300"
+          htmlFor="emergencyContact"
+        >
+          Please provide the name and contact details of your emergency contact.
+          We would use this only in case of a medical or other emergency.
+        </label>
+        <input
+          id="emergencyContact"
+          type="text"
+          className="text-field"
+          value={form.emergencyContact}
+          onChange={set('emergencyContact')}
+          required
+        />
+      </div>
+
+      <div className={`${styles.field} ${styles.full}`}>
+        <label
+          className="paragraph-small color-teal-300"
+          htmlFor="anythingElse"
+        >
+          Anything else you&apos;d like us to know? (optional)
+        </label>
+        <textarea
+          id="anythingElse"
+          className={`text-field ${styles.textarea}`}
+          value={form.anythingElse}
+          onChange={set('anythingElse')}
+        />
+      </div>
+
+      <div className={`${styles.field} ${styles.full}`}>
+        <label
+          className="paragraph-small color-teal-300"
+          htmlFor="successfulProjects"
+        >
+          What has been 1 or 2 of your most successful projects (in AI safety or
+          otherwise), and what were the outcomes? A brief answer is fine.
+          (optional)
+        </label>
+        <textarea
+          id="successfulProjects"
+          className={`text-field ${styles.textarea}`}
+          value={form.successfulProjects}
+          onChange={set('successfulProjects')}
+        />
+      </div>
+
+      <p className={`paragraph-xs color-teal-300 ${styles.full}`}>
+        We expect most participants will arrive on 16 or 17 September and depart
+        on 20 or 21 September. If you can&apos;t make the whole event, list your
+        arrival and departure dates below. (optional)
+      </p>
+
+      <div className={styles.field}>
+        <label className="paragraph-small color-teal-300" htmlFor="arrival">
+          When would you arrive?
+        </label>
+        <input
+          id="arrival"
+          type="date"
+          className={`text-field ${styles.date}`}
+          value={form.arrival}
+          onChange={set('arrival')}
+        />
+      </div>
+
+      <div className={styles.field}>
+        <label className="paragraph-small color-teal-300" htmlFor="departure">
+          When would you leave?
+        </label>
+        <input
+          id="departure"
+          type="date"
+          className={`text-field ${styles.date}`}
+          value={form.departure}
+          onChange={set('departure')}
+        />
+      </div>
+
+      <div className={styles.hp} aria-hidden="true">
+        <label htmlFor="website">Website</label>
+        <input
+          id="website"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+          value={form.website}
+          onChange={set('website')}
+        />
+      </div>
+
+      <label className={`flex items-center cursor-pointer ${styles.full}`}>
+        <input
+          type="checkbox"
+          className="checkbox"
+          checked={over18}
+          onChange={e => setOver18(e.target.checked)}
+          required
+        />
+        <span className="paragraph-small color-teal-300">
+          I will be at least 18 years old by the date of this event
+        </span>
+      </label>
+
+      <div className={styles.full}>
+        <button type="submit" className="button-primary" disabled={busy}>
+          {busy ? 'Applying…' : 'Apply'}
+        </button>
+        {error && (
+          <p className="paragraph-small color-orange margin-top-16px">
+            {error}
+          </p>
+        )}
+      </div>
+    </form>
+  )
+}

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -7,6 +7,7 @@ const EMPTY = {
   name: '',
   email: '',
   skills: '',
+  links: '',
   dietary: '',
   medical: '',
   roomPreference: '',
@@ -113,8 +114,7 @@ export default function ApplicationForm() {
 
       <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="skills">
-          What skills or experience could you bring to this hackathon (link to
-          CV welcome, but not required)?
+          What skills or experience could you bring to this hackathon?
         </label>
         <textarea
           id="skills"
@@ -122,6 +122,19 @@ export default function ApplicationForm() {
           value={form.skills}
           onChange={set('skills')}
           required
+        />
+      </div>
+
+      <div className={`${styles.field} ${styles.full}`}>
+        <label className="paragraph-small color-teal-300" htmlFor="links">
+          Please share any personal links e.g. LinkedIn, LessWrong, CV, etc.{' '}
+          <Optional />
+        </label>
+        <textarea
+          id="links"
+          className={`text-field ${styles.textarea}`}
+          value={form.links}
+          onChange={set('links')}
         />
       </div>
 

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -3,17 +3,9 @@
 import { useState } from 'react'
 import styles from './page.module.css'
 
-const TRACKS = [
-  'Product and design',
-  'Development',
-  'Project management',
-  'Promotion',
-]
-
 const EMPTY = {
   name: '',
   email: '',
-  otherTrack: '',
   skills: '',
   dietary: '',
   medical: '',
@@ -27,9 +19,12 @@ const EMPTY = {
   website: '',
 }
 
+function Optional() {
+  return <em className="color-teal-400">(optional)</em>
+}
+
 export default function ApplicationForm() {
   const [form, setForm] = useState(EMPTY)
-  const [tracks, setTracks] = useState<string[]>([])
   const [over18, setOver18] = useState(false)
   const [busy, setBusy] = useState(false)
   const [done, setDone] = useState(false)
@@ -43,29 +38,16 @@ export default function ApplicationForm() {
     ) => setForm({ ...form, [field]: e.target.value })
   }
 
-  function toggleTrack(track: string) {
-    setTracks(t =>
-      t.includes(track) ? t.filter(x => x !== track) : [...t, track]
-    )
-  }
-
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (busy) return
-    const allTracks = form.otherTrack.trim()
-      ? [...tracks, `Other: ${form.otherTrack.trim()}`]
-      : tracks
-    if (allTracks.length === 0) {
-      setError('Please pick at least one project track.')
-      return
-    }
     setBusy(true)
     setError('')
     try {
       const res = await fetch('/api/hackathon-signup', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...form, tracks: allTracks, over18 }),
+        body: JSON.stringify({ ...form, over18 }),
       })
       if (res.ok) {
         setDone(true)
@@ -90,8 +72,8 @@ export default function ApplicationForm() {
       <div className="padding-bottom-56px">
         <h3 className="padding-bottom-16px">Application received!</h3>
         <p className="color-teal-300">
-          We&apos;ve emailed you a confirmation. Applications close 10 August –
-          we&apos;ll be in touch to confirm your place.
+          We&apos;ve emailed you a confirmation. Application results will be
+          announced by 21 August.
         </p>
       </div>
     )
@@ -130,38 +112,6 @@ export default function ApplicationForm() {
         />
       </div>
 
-      <fieldset className={`${styles.full} ${styles.fieldset}`}>
-        <legend className="paragraph-small color-teal-300 padding-bottom-8px">
-          Which project track(s) are you interested in?
-        </legend>
-        <div className={styles.field}>
-          {TRACKS.map(track => (
-            <label key={track} className="flex items-center cursor-pointer">
-              <input
-                type="checkbox"
-                className="checkbox"
-                checked={tracks.includes(track)}
-                onChange={() => toggleTrack(track)}
-              />
-              <span className="paragraph-small color-teal-300">{track}</span>
-            </label>
-          ))}
-          <label
-            className="paragraph-small color-teal-300 margin-top-16px"
-            htmlFor="otherTrack"
-          >
-            Other
-          </label>
-          <input
-            id="otherTrack"
-            type="text"
-            className="text-field"
-            value={form.otherTrack}
-            onChange={set('otherTrack')}
-          />
-        </div>
-      </fieldset>
-
       <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="skills">
           What skills or experience could you bring to this hackathon (link to
@@ -180,7 +130,8 @@ export default function ApplicationForm() {
       <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="dietary">
           Do you have any allergies or dietary needs/preferences? If so, please
-          list the allergen and its severity. All food will be vegan. (optional)
+          list the allergen and its severity. All food will be vegan.{' '}
+          <Optional />
         </label>
         <textarea
           id="dietary"
@@ -193,7 +144,7 @@ export default function ApplicationForm() {
       <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="medical">
           Do you have any particular medical or mental health needs you would
-          like us to know about? (optional)
+          like us to know about? <Optional />
         </label>
         <textarea
           id="medical"
@@ -251,7 +202,7 @@ export default function ApplicationForm() {
           className="paragraph-small color-teal-300"
           htmlFor="anythingElse"
         >
-          Anything else you&apos;d like us to know? (optional)
+          Anything else you&apos;d like us to know? <Optional />
         </label>
         <textarea
           id="anythingElse"
@@ -267,8 +218,8 @@ export default function ApplicationForm() {
           htmlFor="successfulProjects"
         >
           What has been 1 or 2 of your most successful projects (in AI safety or
-          otherwise), and what were the outcomes? A brief answer is fine.
-          (optional)
+          otherwise), and what were the outcomes? A brief answer is fine.{' '}
+          <Optional />
         </label>
         <textarea
           id="successfulProjects"
@@ -281,7 +232,7 @@ export default function ApplicationForm() {
       <p className={`paragraph-xs color-teal-300 ${styles.full}`}>
         We expect most participants will arrive on 16 or 17 September and depart
         on 20 or 21 September. If you can&apos;t make the whole event, list your
-        arrival and departure dates below. (optional)
+        arrival and departure dates below. <Optional />
       </p>
 
       <div className={styles.field}>

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -115,8 +115,7 @@ export default function ApplicationForm() {
       <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="skills">
           What skills or experience could you bring to this hackathon (link to
-          CV welcome, but not required)? What are your current plans and
-          activities towards saving the world?
+          CV welcome, but not required)?
         </label>
         <textarea
           id="skills"

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -8,13 +8,7 @@ const EMPTY = {
   email: '',
   skills: '',
   links: '',
-  dietary: '',
-  medical: '',
-  roomPreference: '',
-  emergencyContact: '',
   anythingElse: '',
-  arrival: '',
-  departure: '',
   // Honeypot – hidden from people, filled in by naive bots.
   website: '',
 }
@@ -135,108 +129,6 @@ export default function ApplicationForm() {
           className={`text-field ${styles.textarea}`}
           value={form.links}
           onChange={set('links')}
-        />
-      </div>
-
-      <div className={`${styles.field} ${styles.full}`}>
-        <label className="paragraph-small color-teal-300" htmlFor="dietary">
-          Do you have any allergies or dietary needs/preferences? If so, please
-          list the allergen and its severity. All food will be vegan.{' '}
-          <Optional />
-        </label>
-        <textarea
-          id="dietary"
-          className={`text-field ${styles.textarea}`}
-          value={form.dietary}
-          onChange={set('dietary')}
-        />
-      </div>
-
-      <div className={`${styles.field} ${styles.full}`}>
-        <label className="paragraph-small color-teal-300" htmlFor="medical">
-          Do you have any particular medical or mental health needs you would
-          like us to know about? <Optional />
-        </label>
-        <textarea
-          id="medical"
-          className={`text-field ${styles.textarea}`}
-          value={form.medical}
-          onChange={set('medical')}
-        />
-      </div>
-
-      <div className={`${styles.field} ${styles.full}`}>
-        <label
-          className="paragraph-small color-teal-300"
-          htmlFor="roomPreference"
-        >
-          It&apos;s possible that some people may need to share a room – either
-          all female or all male, max 2 people per room. Do you have a
-          preference for having your own room?
-        </label>
-        <select
-          id="roomPreference"
-          className="text-field"
-          value={form.roomPreference}
-          onChange={set('roomPreference')}
-          required
-        >
-          <option value="" disabled>
-            Choose one
-          </option>
-          <option>Fine with sharing</option>
-          <option>Weak preference for own room</option>
-          <option>Strong preference for own room</option>
-        </select>
-      </div>
-
-      <p className={`paragraph-xs color-teal-300 ${styles.full}`}>
-        We expect most participants will arrive on 16 or 17 September and depart
-        on 20 or 21 September. If you can&apos;t make the whole event, list your
-        arrival and departure dates below. <Optional />
-      </p>
-
-      <div className={styles.field}>
-        <label className="paragraph-small color-teal-300" htmlFor="arrival">
-          When would you arrive?
-        </label>
-        <input
-          id="arrival"
-          type="date"
-          className={`text-field ${styles.date}`}
-          value={form.arrival}
-          onChange={set('arrival')}
-        />
-      </div>
-
-      <div className={styles.field}>
-        <label className="paragraph-small color-teal-300" htmlFor="departure">
-          When would you leave?
-        </label>
-        <input
-          id="departure"
-          type="date"
-          className={`text-field ${styles.date}`}
-          value={form.departure}
-          onChange={set('departure')}
-        />
-      </div>
-
-      <div className={`${styles.field} ${styles.full}`}>
-        <label
-          className="paragraph-small color-teal-300"
-          htmlFor="emergencyContact"
-        >
-          Please provide the name and contact details of your emergency contact.
-          We would use this only in case of a medical or other emergency.
-        </label>
-        <input
-          id="emergencyContact"
-          type="text"
-          className="text-field"
-          value={form.emergencyContact}
-          onChange={set('emergencyContact')}
-          required
         />
       </div>
 

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -34,11 +34,6 @@
   list-style: circle;
 }
 
-/* Match the native date-picker controls to the dark theme. */
-.date {
-  color-scheme: dark;
-}
-
 /* .text-field is a fixed-height single-line input; let textareas grow. */
 .textarea {
   height: auto;

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -16,11 +16,12 @@
 /* The form follows the reader down the page. margin-top (not padding)
    aligns it with the h1 while unstuck; max-height + overflow keep the
    whole form reachable on short viewports. */
+/* top clears the sticky global nav (88px tall) plus breathing room. */
 .sticky {
   position: sticky;
-  top: 32px;
+  top: 112px;
   margin-top: 56px;
-  max-height: calc(100vh - 64px);
+  max-height: calc(100vh - 136px);
   overflow-y: auto;
 }
 

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -10,7 +10,7 @@
 /* The global reset flattens <strong> to weight 400 against 300 body text;
    make bold actually bold on this page. */
 .layout strong {
-  font-weight: 600;
+  font-weight: 500;
 }
 
 /* The form follows the reader down the page. margin-top (not padding)

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -16,12 +16,13 @@
 /* The form follows the reader down the page. margin-top (not padding)
    aligns it with the h1 while unstuck; max-height + overflow keep the
    whole form reachable on short viewports. */
-/* top clears the sticky global nav (88px tall) plus breathing room. */
+/* top = nav height (88px) + the form's 56px starting offset, so the form
+   pins exactly where it already sits — no visible shift on first scroll. */
 .sticky {
   position: sticky;
-  top: 112px;
+  top: 144px;
   margin-top: 56px;
-  max-height: calc(100vh - 136px);
+  max-height: calc(100vh - 168px);
   overflow-y: auto;
 }
 

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -16,11 +16,16 @@
   grid-column: 1 / -1;
 }
 
-/* Reset browser fieldset chrome for the track-checkbox group. */
-.fieldset {
-  border: none;
+/* No global list styling exists; give the who-we're-looking-for list its
+   bullets here. */
+.bullets {
   margin: 0;
-  padding: 0;
+  padding-left: 24px;
+  list-style: disc;
+}
+
+.bullets li {
+  margin-bottom: 8px;
 }
 
 /* Match the native date-picker controls to the dark theme. */

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -44,7 +44,7 @@
 .fields {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 20px 24px;
+  gap: 16px 24px;
 }
 
 .field {
@@ -78,7 +78,7 @@
 /* .text-field is a fixed-height single-line input; let textareas grow. */
 .textarea {
   height: auto;
-  min-height: 120px;
+  min-height: 80px;
   padding: 14px 16px;
   resize: vertical;
 }

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -7,6 +7,12 @@
   align-items: start;
 }
 
+/* The global reset flattens <strong> to weight 400 against 300 body text;
+   make bold actually bold on this page. */
+.layout strong {
+  font-weight: 600;
+}
+
 /* The form follows the reader down the page. margin-top (not padding)
    aligns it with the h1 while unstuck; max-height + overflow keep the
    whole form reachable on short viewports. */

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -81,6 +81,7 @@
   min-height: 80px;
   padding: 14px 16px;
   resize: vertical;
+  overflow-y: hidden;
 }
 
 /* Honeypot field: moved off-screen rather than display:none so naive bots

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -1,0 +1,51 @@
+/* Signup form layout — everything else on the page uses global utilities. */
+
+.fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px 24px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.full {
+  grid-column: 1 / -1;
+}
+
+/* Reset browser fieldset chrome for the track-checkbox group. */
+.fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Match the native date-picker controls to the dark theme. */
+.date {
+  color-scheme: dark;
+}
+
+/* .text-field is a fixed-height single-line input; let textareas grow. */
+.textarea {
+  height: auto;
+  min-height: 120px;
+  padding: 14px 16px;
+  resize: vertical;
+}
+
+/* Honeypot field: moved off-screen rather than display:none so naive bots
+   still "see" and fill it. */
+.hp {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+}
+
+@media (max-width: 991px) {
+  .fields {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -1,3 +1,19 @@
+/* Two-column page: event info left, application form right; stacks on
+   mobile. */
+.layout {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 64px;
+  align-items: start;
+}
+
+@media (max-width: 991px) {
+  .layout {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+}
+
 /* Signup form layout — everything else on the page uses global utilities. */
 
 .fields {

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -28,6 +28,12 @@
   margin-bottom: 8px;
 }
 
+.bullets ul {
+  margin: 8px 0 0;
+  padding-left: 24px;
+  list-style: circle;
+}
+
 /* Match the native date-picker controls to the dark theme. */
 .date {
   color-scheme: dark;

--- a/src/app/hackathon/page.module.css
+++ b/src/app/hackathon/page.module.css
@@ -3,14 +3,31 @@
 .layout {
   display: grid;
   grid-template-columns: 1.1fr 1fr;
-  gap: 64px;
+  gap: 96px;
   align-items: start;
+}
+
+/* The form follows the reader down the page. margin-top (not padding)
+   aligns it with the h1 while unstuck; max-height + overflow keep the
+   whole form reachable on short viewports. */
+.sticky {
+  position: sticky;
+  top: 32px;
+  margin-top: 56px;
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
 }
 
 @media (max-width: 991px) {
   .layout {
     grid-template-columns: 1fr;
     gap: 0;
+  }
+
+  .sticky {
+    position: static;
+    max-height: none;
+    overflow: visible;
   }
 }
 

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -10,9 +10,9 @@ export const metadata = {
 
 export default function HackathonPage() {
   return (
-    <div className="container-narrow">
-      <div className="flex justify-center">
-        <div className="width-9-col-narrow">
+    <div className="container-default">
+      <div className={styles.layout}>
+        <div>
           <h1 className="padding-top-56px padding-bottom-24px">
             AISafety.com Hackathon 2026
           </h1>
@@ -188,7 +188,9 @@ export default function HackathonPage() {
             </a>
             .
           </p>
+        </div>
 
+        <div className="padding-top-56px">
           <h3 className="padding-bottom-16px" id="apply">
             Apply
           </h3>

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -57,9 +57,8 @@ export default function HackathonPage() {
           <p className="color-teal-300 padding-bottom-40px">
             Once a year, the core AISafety.com team gets together with a group
             of amazing volunteers and spends an extended weekend getting a bunch
-            of stuff done to improve the site. Outside work sessions, we do some
-            relaxed fun activities like going for walks, board games, and movie
-            nights.
+            of stuff done to improve the site. We also do some relaxed fun
+            activities between work sessions.
           </p>
           <h3 className="padding-bottom-16px">Who we&apos;re looking for</h3>
           <ul

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -77,14 +77,14 @@ export default function HackathonPage() {
             <li>
               <strong>Project managers</strong>
               <ul>
-                <li>To lead and organize project efforts and lead sprints</li>
+                <li>To lead and organize project efforts and run sprints</li>
               </ul>
             </li>
             <li>
               <strong>Developers</strong>
               <ul>
                 <li>
-                  To work with product managers, designers, and Claude Code to
+                  To work with product managers, designers, and AI tools to
                   bring some amazing new things to life
                 </li>
               </ul>

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -150,11 +150,6 @@ export default function HackathonPage() {
               aside time each day for beach walks, games, etc.
             </li>
             <li>
-              <strong>Food and room</strong> covered. Most likely each person
-              will have their own room, but if the hotel happens to be very full
-              some people may need to share.
-            </li>
-            <li>
               <strong>Help save the world!</strong>
             </li>
           </ul>

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -51,7 +51,7 @@ export default function HackathonPage() {
           <p className="padding-bottom-40px">
             <strong>Applications close</strong>
             <br />
-            14 August 2026
+            14 August 2026 (decisions by 21 August)
           </p>
 
           <p className="color-teal-300 padding-bottom-40px">

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -17,17 +17,18 @@ export default function HackathonPage() {
           </h1>
 
           <h2 className="padding-bottom-40px">
-            A four-day hackathon to{' '}
-            <span className="color-light-teal">make AISafety.com better</span>,
-            together in person.
+            A four-day, in-person hackathon to{' '}
+            <span className="color-light-teal">
+              improve the AI safety resource hub
+            </span>
+            .
           </h2>
 
           <p className="padding-bottom-8px">
-            <span className="color-light-teal">When</span> – Thursday 17 to
-            Sunday 20 September 2026
+            <strong>When</strong> – Thursday 17 to Sunday 20 September 2026
           </p>
           <p className="padding-bottom-8px">
-            <span className="color-light-teal">Where</span> –{' '}
+            <strong>Where</strong> –{' '}
             <a
               href="https://www.ceealar.org"
               target="_blank"
@@ -39,39 +40,18 @@ export default function HackathonPage() {
             (the EA Hotel) in Blackpool, England
           </p>
           <p className="padding-bottom-8px">
-            <span className="color-light-teal">Cost</span> – Free, including
-            accommodation and all meals
+            <strong>Cost</strong> – Free, including accommodation and all meals
           </p>
           <p className="padding-bottom-40px">
-            <span className="color-light-teal">Applications close</span> – 10
-            August 2026
+            <strong>Applications close</strong> – 10 August 2026
           </p>
 
           <p className="color-teal-300 padding-bottom-40px">
-            Once a year, the core AISafety.com team gets together with a bunch
+            Once a year, the core AISafety.com team gets together with a group
             of amazing volunteers and spends an extended weekend getting a bunch
             of stuff done to improve the hub for AI safety resources. Outside
             work sessions, we do some relaxed fun activities like going for
             walks, board games, and movie nights.
-          </p>
-
-          <h3 className="padding-bottom-16px">The tracks</h3>
-          <p className="color-teal-300 padding-bottom-8px">
-            <span className="color-light-teal">Product and design</span> – UI/UX
-            design, giving feedback (&quot;dogfooding&quot;), user research
-          </p>
-          <p className="color-teal-300 padding-bottom-8px">
-            <span className="color-light-teal">Development</span> – building the
-            things
-          </p>
-          <p className="color-teal-300 padding-bottom-8px">
-            <span className="color-light-teal">Project management</span> – the
-            meta track: helping everything run well
-          </p>
-          <p className="color-teal-300 padding-bottom-40px">
-            <span className="color-light-teal">Promotion</span> – community
-            outreach (Discords, the EA Forum, etc.), social media, content, and
-            maybe some SEO
           </p>
 
           <h3 className="padding-bottom-16px">Who we&apos;re looking for</h3>
@@ -86,18 +66,70 @@ export default function HackathonPage() {
           <p className="color-teal-300 padding-bottom-8px">
             Subject-matter experts who know the AI safety ecosystem really well
           </p>
-          <p className="color-teal-300 padding-bottom-40px">
+          <p className="color-teal-300 padding-bottom-16px">
             Connectors – people who know lots of people in AI safety, or have an
             audience
+          </p>
+          <p className="color-teal-300 padding-bottom-40px">
+            If you have other ideas for increasing AISafety.com&apos;s impact,
+            you&apos;re welcome to make your own track.
+          </p>
+
+          <h3 className="padding-bottom-16px">The venue</h3>
+          <p className="color-teal-300 padding-bottom-16px">
+            We&apos;ll be hosted at{' '}
+            <a
+              href="https://www.ceealar.org"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="color-light-teal"
+            >
+              CEEALAR
+            </a>{' '}
+            (AKA the EA Hotel), a place worth experiencing in its own right –
+            Bryce spent 4 months there transitioning to working full-time on AI
+            safety a few years back and enjoyed it a lot. Most likely each
+            person will have their own room, but if the hotel happens to be very
+            full some people may need to share. If you have a strong preference
+            for having your own room you can note that in the form.
+          </p>
+          <p className="color-teal-300 padding-bottom-16px">
+            The town of Blackpool is pretty average but there&apos;s a huge
+            beach and promenade 2 minutes away from the hotel which is lovely to
+            walk along. The hotel itself is also a great vibe, since everyone
+            there is working on some kind of impactful work – mostly AI safety.
+          </p>
+          <p className="color-teal-300 padding-bottom-40px">
+            If you have any questions please message Bryce on the{' '}
+            <a
+              href="https://discord.gg/WQG8FAGqun"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="color-light-teal"
+            >
+              AISafety.com Discord server
+            </a>{' '}
+            at @bryceerobertson or email{' '}
+            <a
+              href="mailto:bryceerobertson@gmail.com"
+              className="color-light-teal"
+            >
+              bryceerobertson@gmail.com
+            </a>
+            .
           </p>
 
           <h3 className="padding-bottom-16px" id="apply">
             Apply
           </h3>
-          <p className="color-teal-300 padding-bottom-24px">
+          <p className="color-teal-300 padding-bottom-16px">
             Fill in the form and we&apos;ll email you a confirmation right away.
             Spots are limited (around 15), so we&apos;ll be in touch to confirm
             your place.
+          </p>
+          <p className="color-teal-300 padding-bottom-24px">
+            Please avoid copy-pasting large amounts of AI written text into your
+            answers, it&apos;s no fun to read...
           </p>
 
           <ApplicationForm />

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -155,7 +155,7 @@ export default function HackathonPage() {
           </ul>
 
           <p className="color-teal-300 padding-bottom-40px">
-            If you have any questions please message Bryce on the{' '}
+            If you have any questions, please message Bryce on the{' '}
             <a
               href="https://discord.gg/WQG8FAGqun"
               target="_blank"
@@ -164,7 +164,7 @@ export default function HackathonPage() {
             >
               AISafety.com Discord server
             </a>{' '}
-            at @bryceerobertson or email{' '}
+            at @bryceerobertson, or email{' '}
             <a
               href="mailto:bryceerobertson@gmail.com"
               className="color-light-teal"

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -69,7 +69,7 @@ export default function HackathonPage() {
               <ul>
                 <li>
                   To execute the vision for new projects, build out design
-                  mockups, conduct user research, offer consulting, and/or
+                  mockups, conduct user research, offer consulting, and
                   brainstorm product solutions
                 </li>
               </ul>
@@ -77,9 +77,7 @@ export default function HackathonPage() {
             <li>
               <strong>Project managers</strong>
               <ul>
-                <li>
-                  To lead and organize project efforts and/or lead sprints
-                </li>
+                <li>To lead and organize project efforts and lead sprints</li>
               </ul>
             </li>
             <li>
@@ -98,8 +96,8 @@ export default function HackathonPage() {
               <ul>
                 <li>
                   To help us with targeted community outreach, general community
-                  outreach, social media, and/or to give takes to product
-                  managers and designers
+                  outreach, social media, and to give takes to product managers
+                  and designers
                 </li>
               </ul>
             </li>
@@ -108,7 +106,7 @@ export default function HackathonPage() {
               <ul>
                 <li>
                   To help us with targeted community outreach, general community
-                  outreach, social media, and/or SEO
+                  outreach, social media, and SEO
                 </li>
               </ul>
             </li>

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -190,19 +190,7 @@ export default function HackathonPage() {
           </p>
         </div>
 
-        <div className="padding-top-56px">
-          <h3 className="padding-bottom-16px" id="apply">
-            Apply
-          </h3>
-          <p className="color-teal-300 padding-bottom-16px">
-            Fill in the form below to apply. Application results will be
-            announced by 21 August.
-          </p>
-          <p className="color-teal-300 padding-bottom-24px">
-            Please avoid copy-pasting large amounts of AI written text into your
-            answers, it&apos;s no fun to read...
-          </p>
-
+        <div className={styles.sticky}>
           <ApplicationForm />
         </div>
       </div>

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -91,13 +91,13 @@ export default function HackathonPage() {
             </li>
             <li>
               <strong>
-                Connectors, influential people, and subject-matter experts
+                Connectors, people with an audience, and subject-matter experts
               </strong>
               <ul>
                 <li>
-                  To help us with targeted community outreach, general community
-                  outreach, social media, and to give takes to product managers
-                  and designers
+                  To help us with targeted community outreach, general outreach,
+                  social media, and to give takes to product managers and
+                  designers
                 </li>
               </ul>
             </li>

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -61,25 +61,98 @@ export default function HackathonPage() {
             work sessions, we do some relaxed fun activities like going for
             walks, board games, and movie nights.
           </p>
+          <p className="color-teal-300 padding-bottom-40px">
+            On the first evening of the hackathon, we will divide team members
+            into 3–4 small teams by{' '}
+            <a
+              href="https://app.notion.com/p/15aaef8c3f9640018d6b256d39b4ee8a?pvs=21"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="color-light-teal"
+            >
+              project
+            </a>
+            . Members will get to decide which projects they work on and what
+            they bring to each project. We&apos;re also open to new project
+            suggestions.
+          </p>
+
+          <h3 className="padding-bottom-16px">Why it&apos;s worth it!</h3>
+          <ul
+            className={`color-teal-300 padding-bottom-40px ${styles.bullets}`}
+          >
+            <li>
+              Build your resume, career capital, and make connections (everyone
+              at the EA hotel, beyond just our hackathon, is working on
+              something high-impact, mostly AI safety)
+            </li>
+            <li>Help save the world</li>
+            <li>
+              Have fun beyond just the work! We set aside two sessions a day for
+              beach walks, games, music, and more.
+            </li>
+            <li>
+              Food and room covered. Most likely each person will have their own
+              room, but if the hotel happens to be very full some people may
+              need to share.
+            </li>
+          </ul>
 
           <h3 className="padding-bottom-16px">Who we&apos;re looking for</h3>
           <ul
             className={`color-teal-300 padding-bottom-40px ${styles.bullets}`}
           >
-            <li>Product managers and designers</li>
-            <li>Developers</li>
-            <li>Project managers</li>
             <li>
-              People with experience promoting smaller projects, especially in
-              EA
+              Product managers and designers
+              <ul>
+                <li>
+                  To execute the vision for some new projects, build out design
+                  mockups, conduct user research, offer consulting, and/or
+                  brainstorm product solutions
+                </li>
+              </ul>
             </li>
             <li>
-              Subject-matter experts who know the AI safety ecosystem really
-              well
+              Project managers
+              <ul>
+                <li>
+                  To lead and organize project efforts and/or lead sprints
+                </li>
+              </ul>
             </li>
             <li>
-              Connectors – people who know lots of people in AI safety, or have
-              an audience
+              Developers
+              <ul>
+                <li>
+                  To work with product managers, designers, and Claude Code to
+                  bring some amazing new things to life
+                </li>
+              </ul>
+            </li>
+            <li>
+              Connectors, influential people, and subject-matter experts
+              <ul>
+                <li>
+                  To help us with targeted community outreach, general community
+                  outreach, social media, and/or to give takes to product
+                  managers and designers
+                </li>
+              </ul>
+            </li>
+            <li>
+              Promotion people
+              <ul>
+                <li>
+                  To help us with targeted community outreach, general community
+                  outreach, social media, and/or SEO
+                </li>
+              </ul>
+            </li>
+            <li>
+              Anything else
+              <ul>
+                <li>Just tell us how you can help!</li>
+              </ul>
             </li>
           </ul>
 

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -57,9 +57,9 @@ export default function HackathonPage() {
           <p className="color-teal-300 padding-bottom-40px">
             Once a year, the core AISafety.com team gets together with a group
             of amazing volunteers and spends an extended weekend getting a bunch
-            of stuff done to improve the hub for AI safety resources. Outside
-            work sessions, we do some relaxed fun activities like going for
-            walks, board games, and movie nights.
+            of stuff done to improve the site. Outside work sessions, we do some
+            relaxed fun activities like going for walks, board games, and movie
+            nights.
           </p>
           <h3 className="padding-bottom-16px">Who we&apos;re looking for</h3>
           <ul

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -68,7 +68,7 @@ export default function HackathonPage() {
               <strong>Product managers and designers</strong>
               <ul>
                 <li>
-                  To execute the vision for some new projects, build out design
+                  To execute the vision for new projects, build out design
                   mockups, conduct user research, offer consulting, and/or
                   brainstorm product solutions
                 </li>

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -146,8 +146,8 @@ export default function HackathonPage() {
               on something high-impact – mostly AI safety)
             </li>
             <li>
-              <strong>Have fun</strong> beyond just the work! We set aside two
-              sessions a day for beach walks, games, music, and more.
+              <strong>Have fun</strong> beyond just the work. We&apos;ll set
+              aside time each day for beach walks, games, etc.
             </li>
             <li>
               <strong>Food and room</strong> covered. Most likely each person

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -119,8 +119,8 @@ export default function HackathonPage() {
           </ul>
 
           <p className="color-teal-300 padding-bottom-40px">
-            On the first evening of the hackathon, we will divide team members
-            into 3–4 small teams by{' '}
+            On the first day of the hackathon we will divide everyone into small
+            teams by{' '}
             <a
               href="https://app.notion.com/p/15aaef8c3f9640018d6b256d39b4ee8a?pvs=21"
               target="_blank"
@@ -129,8 +129,8 @@ export default function HackathonPage() {
             >
               project
             </a>
-            . Members will get to decide which projects they work on and what
-            they bring to each project. We&apos;re also open to new project
+            . Participants will get to decide which projects they work on and in
+            what way they contribute. We&apos;re also open to new project
             suggestions.
           </p>
 

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -28,7 +28,7 @@ export default function HackathonPage() {
           <p className="padding-bottom-16px">
             <strong>When</strong>
             <br />
-            Thursday 17 to Sunday 20 September 2026
+            Thursday 17th September – Sunday 20th September 2026
           </p>
           <p className="padding-bottom-16px">
             <strong>Where</strong>

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -154,19 +154,6 @@ export default function HackathonPage() {
             </li>
           </ul>
 
-          <h3 className="padding-bottom-16px">The venue</h3>
-          <p className="color-teal-300 padding-bottom-16px">
-            We&apos;ll be hosted at{' '}
-            <a
-              href="https://www.ceealar.org"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="color-light-teal"
-            >
-              CEEALAR
-            </a>{' '}
-            (AKA the EA Hotel), a place worth experiencing in its own right.
-          </p>
           <p className="color-teal-300 padding-bottom-40px">
             If you have any questions please message Bryce on the{' '}
             <a

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -105,8 +105,8 @@ export default function HackathonPage() {
               <strong>Promotion people</strong>
               <ul>
                 <li>
-                  To help us with targeted community outreach, general community
-                  outreach, social media, and SEO
+                  To help us spread awareness of the site and its various
+                  resource pages in various ways, maybe including SEO
                 </li>
               </ul>
             </li>

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -1,4 +1,5 @@
 import ApplicationForm from './ApplicationForm'
+import styles from './page.module.css'
 
 export const metadata = {
   title: 'Hackathon 2026 – AISafety.com',
@@ -24,11 +25,14 @@ export default function HackathonPage() {
             .
           </h2>
 
-          <p className="padding-bottom-8px">
-            <strong>When</strong> – Thursday 17 to Sunday 20 September 2026
+          <p className="padding-bottom-16px">
+            <strong>When</strong>
+            <br />
+            Thursday 17 to Sunday 20 September 2026
           </p>
-          <p className="padding-bottom-8px">
-            <strong>Where</strong> –{' '}
+          <p className="padding-bottom-16px">
+            <strong>Where</strong>
+            <br />
             <a
               href="https://www.ceealar.org"
               target="_blank"
@@ -39,11 +43,15 @@ export default function HackathonPage() {
             </a>{' '}
             (the EA Hotel) in Blackpool, England
           </p>
-          <p className="padding-bottom-8px">
-            <strong>Cost</strong> – Free, including accommodation and all meals
+          <p className="padding-bottom-16px">
+            <strong>Cost</strong>
+            <br />
+            Free, including accommodation and all meals
           </p>
           <p className="padding-bottom-40px">
-            <strong>Applications close</strong> – 10 August 2026
+            <strong>Applications close</strong>
+            <br />
+            10 August 2026
           </p>
 
           <p className="color-teal-300 padding-bottom-40px">
@@ -55,25 +63,25 @@ export default function HackathonPage() {
           </p>
 
           <h3 className="padding-bottom-16px">Who we&apos;re looking for</h3>
-          <p className="color-teal-300 padding-bottom-8px">
-            Product managers and designers
-          </p>
-          <p className="color-teal-300 padding-bottom-8px">Developers</p>
-          <p className="color-teal-300 padding-bottom-8px">Project managers</p>
-          <p className="color-teal-300 padding-bottom-8px">
-            People with experience promoting smaller projects, especially in EA
-          </p>
-          <p className="color-teal-300 padding-bottom-8px">
-            Subject-matter experts who know the AI safety ecosystem really well
-          </p>
-          <p className="color-teal-300 padding-bottom-16px">
-            Connectors – people who know lots of people in AI safety, or have an
-            audience
-          </p>
-          <p className="color-teal-300 padding-bottom-40px">
-            If you have other ideas for increasing AISafety.com&apos;s impact,
-            you&apos;re welcome to make your own track.
-          </p>
+          <ul
+            className={`color-teal-300 padding-bottom-40px ${styles.bullets}`}
+          >
+            <li>Product managers and designers</li>
+            <li>Developers</li>
+            <li>Project managers</li>
+            <li>
+              People with experience promoting smaller projects, especially in
+              EA
+            </li>
+            <li>
+              Subject-matter experts who know the AI safety ecosystem really
+              well
+            </li>
+            <li>
+              Connectors – people who know lots of people in AI safety, or have
+              an audience
+            </li>
+          </ul>
 
           <h3 className="padding-bottom-16px">The venue</h3>
           <p className="color-teal-300 padding-bottom-16px">
@@ -123,9 +131,8 @@ export default function HackathonPage() {
             Apply
           </h3>
           <p className="color-teal-300 padding-bottom-16px">
-            Fill in the form and we&apos;ll email you a confirmation right away.
-            Spots are limited (around 15), so we&apos;ll be in touch to confirm
-            your place.
+            Fill in the form below to apply. Application results will be
+            announced by 21 August.
           </p>
           <p className="color-teal-300 padding-bottom-24px">
             Please avoid copy-pasting large amounts of AI written text into your

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -143,10 +143,7 @@ export default function HackathonPage() {
                 Build your resume, gain career capital, and make connections
               </strong>{' '}
               (everyone at the EA hotel, beyond just our hackathon, is working
-              on something high-impact, mostly AI safety)
-            </li>
-            <li>
-              <strong>Help save the world</strong>
+              on something high-impact – mostly AI safety)
             </li>
             <li>
               <strong>Have fun</strong> beyond just the work! We set aside two
@@ -156,6 +153,9 @@ export default function HackathonPage() {
               <strong>Food and room</strong> covered. Most likely each person
               will have their own room, but if the hotel happens to be very full
               some people may need to share.
+            </li>
+            <li>
+              <strong>Help save the world</strong>
             </li>
           </ul>
 

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -105,8 +105,8 @@ export default function HackathonPage() {
               <strong>Promotion people</strong>
               <ul>
                 <li>
-                  To help us spread awareness of the site and its various
-                  resource pages in various ways, maybe including SEO
+                  To help us spread awareness of the site and each resource page
+                  in various ways, maybe including SEO
                 </li>
               </ul>
             </li>

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -4,7 +4,7 @@ import styles from './page.module.css'
 export const metadata = {
   title: 'Hackathon 2026 – AISafety.com',
   description:
-    'Join the AISafety.com team at CEEALAR in Blackpool, England, 17–20 September 2026, for a four-day hackathon to improve the site. Free to attend – applications close 10 August.',
+    'Join the AISafety.com team at CEEALAR in Blackpool, England, 17–20 September 2026, for a four-day hackathon to improve the site. Free to attend – applications close 14 August.',
   alternates: { canonical: '/hackathon' },
 }
 
@@ -51,7 +51,7 @@ export default function HackathonPage() {
           <p className="padding-bottom-40px">
             <strong>Applications close</strong>
             <br />
-            10 August 2026
+            14 August 2026
           </p>
 
           <p className="color-teal-300 padding-bottom-40px">

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -1,0 +1,108 @@
+import ApplicationForm from './ApplicationForm'
+
+export const metadata = {
+  title: 'Hackathon 2026 – AISafety.com',
+  description:
+    'Join the AISafety.com team at CEEALAR in Blackpool, England, 17–20 September 2026, for a four-day hackathon to improve the site. Free to attend – applications close 10 August.',
+  alternates: { canonical: '/hackathon' },
+}
+
+export default function HackathonPage() {
+  return (
+    <div className="container-narrow">
+      <div className="flex justify-center">
+        <div className="width-9-col-narrow">
+          <h1 className="padding-top-56px padding-bottom-24px">
+            AISafety.com Hackathon 2026
+          </h1>
+
+          <h2 className="padding-bottom-40px">
+            A four-day hackathon to{' '}
+            <span className="color-light-teal">make AISafety.com better</span>,
+            together in person.
+          </h2>
+
+          <p className="padding-bottom-8px">
+            <span className="color-light-teal">When</span> – Thursday 17 to
+            Sunday 20 September 2026
+          </p>
+          <p className="padding-bottom-8px">
+            <span className="color-light-teal">Where</span> –{' '}
+            <a
+              href="https://www.ceealar.org"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="color-light-teal"
+            >
+              CEEALAR
+            </a>{' '}
+            (the EA Hotel) in Blackpool, England
+          </p>
+          <p className="padding-bottom-8px">
+            <span className="color-light-teal">Cost</span> – Free, including
+            accommodation and all meals
+          </p>
+          <p className="padding-bottom-40px">
+            <span className="color-light-teal">Applications close</span> – 10
+            August 2026
+          </p>
+
+          <p className="color-teal-300 padding-bottom-40px">
+            Once a year, the core AISafety.com team gets together with a bunch
+            of amazing volunteers and spends an extended weekend getting a bunch
+            of stuff done to improve the hub for AI safety resources. Outside
+            work sessions, we do some relaxed fun activities like going for
+            walks, board games, and movie nights.
+          </p>
+
+          <h3 className="padding-bottom-16px">The tracks</h3>
+          <p className="color-teal-300 padding-bottom-8px">
+            <span className="color-light-teal">Product and design</span> – UI/UX
+            design, giving feedback (&quot;dogfooding&quot;), user research
+          </p>
+          <p className="color-teal-300 padding-bottom-8px">
+            <span className="color-light-teal">Development</span> – building the
+            things
+          </p>
+          <p className="color-teal-300 padding-bottom-8px">
+            <span className="color-light-teal">Project management</span> – the
+            meta track: helping everything run well
+          </p>
+          <p className="color-teal-300 padding-bottom-40px">
+            <span className="color-light-teal">Promotion</span> – community
+            outreach (Discords, the EA Forum, etc.), social media, content, and
+            maybe some SEO
+          </p>
+
+          <h3 className="padding-bottom-16px">Who we&apos;re looking for</h3>
+          <p className="color-teal-300 padding-bottom-8px">
+            Product managers and designers
+          </p>
+          <p className="color-teal-300 padding-bottom-8px">Developers</p>
+          <p className="color-teal-300 padding-bottom-8px">Project managers</p>
+          <p className="color-teal-300 padding-bottom-8px">
+            People with experience promoting smaller projects, especially in EA
+          </p>
+          <p className="color-teal-300 padding-bottom-8px">
+            Subject-matter experts who know the AI safety ecosystem really well
+          </p>
+          <p className="color-teal-300 padding-bottom-40px">
+            Connectors – people who know lots of people in AI safety, or have an
+            audience
+          </p>
+
+          <h3 className="padding-bottom-16px" id="apply">
+            Apply
+          </h3>
+          <p className="color-teal-300 padding-bottom-24px">
+            Fill in the form and we&apos;ll email you a confirmation right away.
+            Spots are limited (around 15), so we&apos;ll be in touch to confirm
+            your place.
+          </p>
+
+          <ApplicationForm />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -167,18 +167,7 @@ export default function HackathonPage() {
             >
               CEEALAR
             </a>{' '}
-            (AKA the EA Hotel), a place worth experiencing in its own right –
-            Bryce spent 4 months there transitioning to working full-time on AI
-            safety a few years back and enjoyed it a lot. Most likely each
-            person will have their own room, but if the hotel happens to be very
-            full some people may need to share. If you have a strong preference
-            for having your own room you can note that in the form.
-          </p>
-          <p className="color-teal-300 padding-bottom-16px">
-            The town of Blackpool is pretty average but there&apos;s a huge
-            beach and promenade 2 minutes away from the hotel which is lovely to
-            walk along. The hotel itself is also a great vibe, since everyone
-            there is working on some kind of impactful work – mostly AI safety.
+            (AKA the EA Hotel), a place worth experiencing in its own right.
           </p>
           <p className="color-teal-300 padding-bottom-40px">
             If you have any questions please message Bryce on the{' '}

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -134,13 +134,13 @@ export default function HackathonPage() {
             suggestions.
           </p>
 
-          <h3 className="padding-bottom-16px">Why it&apos;s worth it!</h3>
+          <h3 className="padding-bottom-16px">Why it&apos;s worth it</h3>
           <ul
             className={`color-teal-300 padding-bottom-40px ${styles.bullets}`}
           >
             <li>
               <strong>
-                Build your resume, career capital, and make connections
+                Build your resume, gain career capital, and make connections
               </strong>{' '}
               (everyone at the EA hotel, beyond just our hackathon, is working
               on something high-impact, mostly AI safety)

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -61,43 +61,6 @@ export default function HackathonPage() {
             work sessions, we do some relaxed fun activities like going for
             walks, board games, and movie nights.
           </p>
-          <p className="color-teal-300 padding-bottom-40px">
-            On the first evening of the hackathon, we will divide team members
-            into 3–4 small teams by{' '}
-            <a
-              href="https://app.notion.com/p/15aaef8c3f9640018d6b256d39b4ee8a?pvs=21"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="color-light-teal"
-            >
-              project
-            </a>
-            . Members will get to decide which projects they work on and what
-            they bring to each project. We&apos;re also open to new project
-            suggestions.
-          </p>
-
-          <h3 className="padding-bottom-16px">Why it&apos;s worth it!</h3>
-          <ul
-            className={`color-teal-300 padding-bottom-40px ${styles.bullets}`}
-          >
-            <li>
-              Build your resume, career capital, and make connections (everyone
-              at the EA hotel, beyond just our hackathon, is working on
-              something high-impact, mostly AI safety)
-            </li>
-            <li>Help save the world</li>
-            <li>
-              Have fun beyond just the work! We set aside two sessions a day for
-              beach walks, games, music, and more.
-            </li>
-            <li>
-              Food and room covered. Most likely each person will have their own
-              room, but if the hotel happens to be very full some people may
-              need to share.
-            </li>
-          </ul>
-
           <h3 className="padding-bottom-16px">Who we&apos;re looking for</h3>
           <ul
             className={`color-teal-300 padding-bottom-40px ${styles.bullets}`}
@@ -153,6 +116,43 @@ export default function HackathonPage() {
               <ul>
                 <li>Just tell us how you can help!</li>
               </ul>
+            </li>
+          </ul>
+
+          <p className="color-teal-300 padding-bottom-40px">
+            On the first evening of the hackathon, we will divide team members
+            into 3–4 small teams by{' '}
+            <a
+              href="https://app.notion.com/p/15aaef8c3f9640018d6b256d39b4ee8a?pvs=21"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="color-light-teal"
+            >
+              project
+            </a>
+            . Members will get to decide which projects they work on and what
+            they bring to each project. We&apos;re also open to new project
+            suggestions.
+          </p>
+
+          <h3 className="padding-bottom-16px">Why it&apos;s worth it!</h3>
+          <ul
+            className={`color-teal-300 padding-bottom-40px ${styles.bullets}`}
+          >
+            <li>
+              Build your resume, career capital, and make connections (everyone
+              at the EA hotel, beyond just our hackathon, is working on
+              something high-impact, mostly AI safety)
+            </li>
+            <li>Help save the world</li>
+            <li>
+              Have fun beyond just the work! We set aside two sessions a day for
+              beach walks, games, music, and more.
+            </li>
+            <li>
+              Food and room covered. Most likely each person will have their own
+              room, but if the hotel happens to be very full some people may
+              need to share.
             </li>
           </ul>
 

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -155,7 +155,7 @@ export default function HackathonPage() {
               some people may need to share.
             </li>
             <li>
-              <strong>Help save the world</strong>
+              <strong>Help save the world!</strong>
             </li>
           </ul>
 

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -66,7 +66,7 @@ export default function HackathonPage() {
             className={`color-teal-300 padding-bottom-40px ${styles.bullets}`}
           >
             <li>
-              Product managers and designers
+              <strong>Product managers and designers</strong>
               <ul>
                 <li>
                   To execute the vision for some new projects, build out design
@@ -76,7 +76,7 @@ export default function HackathonPage() {
               </ul>
             </li>
             <li>
-              Project managers
+              <strong>Project managers</strong>
               <ul>
                 <li>
                   To lead and organize project efforts and/or lead sprints
@@ -84,7 +84,7 @@ export default function HackathonPage() {
               </ul>
             </li>
             <li>
-              Developers
+              <strong>Developers</strong>
               <ul>
                 <li>
                   To work with product managers, designers, and Claude Code to
@@ -93,7 +93,9 @@ export default function HackathonPage() {
               </ul>
             </li>
             <li>
-              Connectors, influential people, and subject-matter experts
+              <strong>
+                Connectors, influential people, and subject-matter experts
+              </strong>
               <ul>
                 <li>
                   To help us with targeted community outreach, general community
@@ -103,7 +105,7 @@ export default function HackathonPage() {
               </ul>
             </li>
             <li>
-              Promotion people
+              <strong>Promotion people</strong>
               <ul>
                 <li>
                   To help us with targeted community outreach, general community
@@ -112,7 +114,7 @@ export default function HackathonPage() {
               </ul>
             </li>
             <li>
-              Anything else
+              <strong>Anything else</strong>
               <ul>
                 <li>Just tell us how you can help!</li>
               </ul>
@@ -140,19 +142,23 @@ export default function HackathonPage() {
             className={`color-teal-300 padding-bottom-40px ${styles.bullets}`}
           >
             <li>
-              Build your resume, career capital, and make connections (everyone
-              at the EA hotel, beyond just our hackathon, is working on
-              something high-impact, mostly AI safety)
-            </li>
-            <li>Help save the world</li>
-            <li>
-              Have fun beyond just the work! We set aside two sessions a day for
-              beach walks, games, music, and more.
+              <strong>
+                Build your resume, career capital, and make connections
+              </strong>{' '}
+              (everyone at the EA hotel, beyond just our hackathon, is working
+              on something high-impact, mostly AI safety)
             </li>
             <li>
-              Food and room covered. Most likely each person will have their own
-              room, but if the hotel happens to be very full some people may
-              need to share.
+              <strong>Help save the world</strong>
+            </li>
+            <li>
+              <strong>Have fun</strong> beyond just the work! We set aside two
+              sessions a day for beach walks, games, music, and more.
+            </li>
+            <li>
+              <strong>Food and room</strong> covered. Most likely each person
+              will have their own room, but if the hotel happens to be very full
+              some people may need to share.
             </li>
           </ul>
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,6 +11,7 @@ const ROUTES = [
   '/events',
   '/founders',
   '/funding',
+  '/hackathon',
   '/jobs',
   '/map',
   '/media-channels',

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -40,6 +40,11 @@ export default function Footer() {
               className={`paragraph-small flex flex-col gap-8px opacity-80 ${styles.links}`}
             >
               <FooterLink
+                href="/hackathon"
+                section="Help us out"
+                label="Join the hackathon"
+              />
+              <FooterLink
                 href="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
                 section="Help us out"
                 label="Suggest a correction"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -40,11 +40,6 @@ export default function Footer() {
               className={`paragraph-small flex flex-col gap-8px opacity-80 ${styles.links}`}
             >
               <FooterLink
-                href="/hackathon"
-                section="Help us out"
-                label="Join the hackathon"
-              />
-              <FooterLink
                 href="https://airtable.com/appF8XfZUGXtfi40E/pagndDvdya1DSqoxN/form"
                 section="Help us out"
                 label="Suggest a correction"
@@ -58,6 +53,11 @@ export default function Footer() {
                 href="https://www.every.org/alignment-ecosystem-development#/donate/card"
                 section="Help us out"
                 label="Donate"
+              />
+              <FooterLink
+                href="/hackathon"
+                section="Help us out"
+                label="Join the hackathon"
               />
             </div>
           </div>

--- a/src/components/FooterLink.tsx
+++ b/src/components/FooterLink.tsx
@@ -16,11 +16,14 @@ export default function FooterLink({
   /** The link text, also what the click is recorded as. */
   label: string
 }) {
+  // Internal links (e.g. /hackathon) navigate in place; external ones open a
+  // new tab as before.
+  const external = href.startsWith('http')
   return (
     <Link
       href={href}
-      target="_blank"
-      rel="noopener noreferrer"
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener noreferrer' : undefined}
       onClick={() => trackFooterClick(section, label, href)}
     >
       {label}

--- a/src/lib/data/search-index.ts
+++ b/src/lib/data/search-index.ts
@@ -109,6 +109,12 @@ const STATIC_PAGES: SearchEntry[] = [
     'Volunteer projects you can join.'
   ),
   page(
+    'Hackathon 2026',
+    '/hackathon',
+    '/images/calendar.svg',
+    'The annual AISafety.com hackathon – 17–20 September 2026 at CEEALAR, Blackpool, UK.'
+  ),
+  page(
     'Founder toolkit',
     '/founders',
     '/images/rocket.svg',


### PR DESCRIPTION
- New `/hackathon` page: event info and application form for the AISafety.com Hackathon 2026 (17–20 September at CEEALAR, Blackpool), replacing the Google Form
- Two-column desktop layout — event info left, sticky application form right (stacks on mobile); auto-growing text boxes
- Application form: name, email, skills/experience, personal links, anything else
- Applications POST to `/api/hackathon-signup`, which forwards them to a private Google Apps Script that appends a row to a private Google Sheet and emails the applicant a confirmation echoing their answers (see `docs/hackathon-signup.md`)
- Spam protection: honeypot field, per-IP rate limit (5/hour via the existing Upstash Redis), and server-side length caps on every field
- Footer gains a sitewide "Join the hackathon" link under Help us out; internal footer links now open in the same tab
- Registered in the sitemap, site search, and llms.txt; deliberately not in the main nav
- `HACKATHON_SCRIPT_URL` and `HACKATHON_FORM_SECRET` are set in Vercel for Preview and Production; the full pipeline (form → Sheet → confirmation email) is verified end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)