### PR TITLE
Featured queue: ranked backups auto-fill the featured slots on /events and /training

### DIFF
--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -18,6 +18,7 @@ import FilterDropdown from '@/components/FilterDropdown'
 import ModeToggle from '@/components/ModeToggle'
 import StickyBar, { scrollToAnchor } from '@/components/StickyBar'
 import { EVENT_TYPES, eventTypeColor } from '@/lib/event-types'
+import { selectFeatured } from '@/lib/featured'
 import { trackFilterApply } from '@/lib/analytics'
 import { placementsById } from '@/lib/placements'
 import type { EventListing } from '@/lib/data/events'
@@ -114,15 +115,20 @@ function titleMetaFor(event: EventListing) {
   const date = formatEventDate(event.startDate, event.endDate)
   const time = formatEventTime(event.startTime, event.endTime)
   const rows: { icon: string; value: string }[] = []
-  // Hybrid events can be attended either way, so the card spells out both
-  // facets ("Online & Oxford, UK") the way /training listings do. The raw
-  // location stays city-only in Airtable so the city filter isn't polluted.
-  if (event.location)
+  // Online events say so via Mode rather than the Location text (mirroring
+  // /training), so Location in Airtable can stay empty for them. Hybrid
+  // events can be attended either way, so the card spells out both facets
+  // ("Online & Oxford, UK") the way /training listings do. The raw location
+  // stays city-only in Airtable so the city filter isn't polluted.
+  if (event.mode === 'Online') {
+    rows.push({ icon: '/images/icons/computer.svg', value: 'Online' })
+  } else if (event.location) {
     rows.push({
       icon: '/images/icons/pin.svg',
       value:
         event.mode === 'Hybrid' ? `Online & ${event.location}` : event.location,
     })
+  }
   if (date) rows.push({ icon: '/images/icons/calendar.svg', value: date })
   if (time) rows.push({ icon: '/images/icons/timer.svg', value: time })
   return rows
@@ -422,10 +428,15 @@ export default function EventsClient({ events }: EventsClientProps) {
     [events, mode]
   )
 
+  const featuredEvents = useMemo(() => selectFeatured(modeEvents), [modeEvents])
+
   // Each event's slot in the full (unfiltered) order of the active mode, so a
   // click is tagged with the rank the visitor saw — not its position within an
   // active filter.
-  const placements = useMemo(() => placementsById(modeEvents), [modeEvents])
+  const placements = useMemo(
+    () => placementsById(modeEvents, new Set(featuredEvents.map(e => e.id))),
+    [modeEvents, featuredEvents]
+  )
 
   const cities = useMemo(() => {
     const set = new Set<string>()
@@ -435,14 +446,6 @@ export default function EventsClient({ events }: EventsClientProps) {
     }
     return Array.from(set).sort((a, b) => a.localeCompare(b))
   }, [modeEvents])
-
-  const featuredEvents = useMemo(
-    () =>
-      (['1', '2'] as const)
-        .map(rank => modeEvents.find(e => e.featured === rank))
-        .filter((e): e is EventListing => e != null),
-    [modeEvents]
-  )
 
   // Each dropdown's counts are faceted (like the 80,000 Hours job board):
   // an option's number is how many events would show if you picked it,

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -23,6 +23,7 @@ import {
   TRAINING_TYPES,
   trainingTypeColor,
 } from '@/lib/training-types'
+import { selectFeatured } from '@/lib/featured'
 import { placementsById } from '@/lib/placements'
 import type {
   ProgramBase,
@@ -259,17 +260,26 @@ export default function TrainingClient({
 
   const modePrograms: ProgramBase[] = mode === 'upcoming' ? programs : recurring
 
+  // Programs whose applications closed are passed over when an open backup
+  // is queued behind them (recurring programs have no applications and
+  // always count as open).
+  const featuredPrograms = useMemo(
+    () =>
+      selectFeatured(modePrograms, p =>
+        'applicationStatus' in p
+          ? (p as TrainingProgram).applicationStatus === 'Open'
+          : true
+      ),
+    [modePrograms]
+  )
+
   // Each program's slot in the full (unfiltered) order of the active set, so a
   // click is tagged with the rank the visitor saw — not its position within an
   // active filter.
-  const placements = useMemo(() => placementsById(modePrograms), [modePrograms])
-
-  const featuredPrograms = useMemo(
+  const placements = useMemo(
     () =>
-      (['1', '2'] as const)
-        .map(rank => modePrograms.find(p => p.featured === rank))
-        .filter((p): p is ProgramBase => p != null),
-    [modePrograms]
+      placementsById(modePrograms, new Set(featuredPrograms.map(p => p.id))),
+    [modePrograms, featuredPrograms]
   )
 
   // Each dropdown's counts are faceted (like the 80,000 Hours job board):

--- a/src/lib/assistant/catalog.ts
+++ b/src/lib/assistant/catalog.ts
@@ -9,6 +9,7 @@ import { getMediaChannels } from '@/lib/data/media-channels'
 import { getMapData } from '@/lib/data/map'
 import { getEvents } from '@/lib/data/events'
 import { getTrainingPrograms, getRecurringPrograms } from '@/lib/data/training'
+import { selectFeatured } from '@/lib/featured'
 import type { Catalog, Listing } from './types'
 
 // Known job-board domains. Their favicons are the platform logo, not the
@@ -64,6 +65,13 @@ function deriveFaviconAvoidingJobBoards(
 
 function isFeatured(item: { featured?: string | null }): boolean {
   return item.featured === '1' || item.featured === '2'
+}
+
+// Events and training use a ranked featured queue instead of the fixed
+// 1/2 slots, so "featured" for them means "currently displayed" — the
+// same selection the page itself makes via selectFeatured().
+function displayedIds(items: Array<{ id: string }>): Set<string> {
+  return new Set(items.map(i => i.id))
 }
 
 function compact(
@@ -298,6 +306,12 @@ export async function buildCatalog(): Promise<Catalog> {
     })
   }
 
+  const featuredEventIds = displayedIds(selectFeatured(events))
+  const featuredTrainingIds = displayedIds(
+    selectFeatured(trainingPrograms, p => p.applicationStatus === 'Open')
+  )
+  const featuredRecurringIds = displayedIds(selectFeatured(recurringPrograms))
+
   for (const e of events) {
     listings.push({
       id: `event:${e.id}`,
@@ -323,7 +337,7 @@ export async function buildCatalog(): Promise<Catalog> {
         notYetOpen: e.notYetOpen ? 'Yes' : null,
         featuredTagline: e.featuredTagline,
       }),
-      featured: isFeatured(e),
+      featured: featuredEventIds.has(e.id),
     })
   }
 
@@ -359,7 +373,7 @@ export async function buildCatalog(): Promise<Catalog> {
         notYetOpen: t.notYetOpen ? 'Yes' : null,
         featuredTagline: t.featuredTagline,
       }),
-      featured: isFeatured(t),
+      featured: featuredTrainingIds.has(t.id),
     })
   }
 
@@ -389,7 +403,7 @@ export async function buildCatalog(): Promise<Catalog> {
         length: r.lengthBucket,
         featuredTagline: r.featuredTagline,
       }),
-      featured: isFeatured(r),
+      featured: featuredRecurringIds.has(r.id),
     })
   }
 

--- a/src/lib/data/events.ts
+++ b/src/lib/data/events.ts
@@ -1,5 +1,6 @@
 import { fetchAirtableRecords } from './airtable'
 import { EVENT_TYPES, type EventType } from '../event-types'
+import { parseFeaturedRank } from '../featured'
 import { parseAttendMode, type AttendMode } from './training'
 
 const TABLE_ID = 'tblXbN9swwldwq8f7'
@@ -53,7 +54,8 @@ export interface EventListing {
   notYetOpen: boolean
   deadlineType: 'Apply' | 'Register' | null
   logo: string | null
-  featured: '1' | '2' | null
+  /** Rank in the featured queue — the two lowest live ranks are displayed. */
+  featured: number | null
   featuredTagline: string | null
 }
 
@@ -196,7 +198,7 @@ export async function getEvents(): Promise<EventListing[]> {
       notYetOpen,
       deadlineType,
       logo: logoField?.[0]?.url ?? null,
-      featured: featuredRaw === '1' || featuredRaw === '2' ? featuredRaw : null,
+      featured: parseFeaturedRank(featuredRaw),
       featuredTagline: optionalString(f[FIELD.featuredTagline]),
     })
   }

--- a/src/lib/data/training.ts
+++ b/src/lib/data/training.ts
@@ -6,6 +6,7 @@ import {
   type LengthBucket,
   type TrainingType,
 } from '../training-types'
+import { parseFeaturedRank } from '../featured'
 
 // The redesigned /training page reads from two tables: "Training" holds
 // dated upcoming iterations, "Recurring training" holds evergreen programs
@@ -97,7 +98,8 @@ export interface ProgramBase {
   timeCommitment: string | null
   stipend: string | null
   logo: string | null
-  featured: '1' | '2' | null
+  /** Rank in the featured queue — the two lowest live ranks are displayed. */
+  featured: number | null
   featuredTagline: string | null
   /** From dates for upcoming programs, from "Typical length" for recurring. */
   lengthBucket: LengthBucket | null
@@ -293,7 +295,7 @@ function parseBase(
     timeCommitment: optionalString(fields[FIELD.timeCommitment]),
     stipend: optionalString(fields[FIELD.stipend]),
     logo: logoField?.[0]?.url ?? null,
-    featured: featuredRaw === '1' || featuredRaw === '2' ? featuredRaw : null,
+    featured: parseFeaturedRank(featuredRaw),
     featuredTagline: optionalString(fields[FIELD.featuredTagline]),
     dateAdded: null, // overridden by each caller (needs the record's createdTime)
     lastModified:

--- a/src/lib/featured.ts
+++ b/src/lib/featured.ts
@@ -1,0 +1,35 @@
+// Featured queue. The Featured field in Airtable holds a rank (1, 2, 3, …):
+// the page shows the two lowest-ranked entries that are still live, so ranks
+// 3+ are curated backups that step in automatically when a slot expires.
+// A daily local job (~/featured-queue on Bryce's Mac) clears the rank of
+// records that have left the page and shifts the rest up, so the numbers in
+// Airtable stay small and gapless.
+
+/** Airtable single-select rank ("1", "2", …) → number, or null. */
+export function parseFeaturedRank(value: unknown): number | null {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null
+  return Number(value)
+}
+
+/**
+ * Pick the (up to) two queue entries a page should display, in rank order.
+ *
+ * When `isOpen` is given (the /training page), entries whose applications
+ * have closed are passed over while an open backup exists further down the
+ * queue — but a closed entry still fills a slot when there is no better
+ * candidate, so the row keeps two cards for as long as the queue allows.
+ */
+export function selectFeatured<T extends { featured: number | null }>(
+  items: T[],
+  isOpen?: (item: T) => boolean
+): T[] {
+  const queue = items
+    .filter(item => item.featured != null)
+    .sort((a, b) => a.featured! - b.featured!)
+  const picked = (isOpen ? queue.filter(isOpen) : queue).slice(0, 2)
+  for (const item of queue) {
+    if (picked.length >= 2) break
+    if (!picked.includes(item)) picked.push(item)
+  }
+  return picked.sort((a, b) => a.featured! - b.featured!)
+}

--- a/src/lib/placements.ts
+++ b/src/lib/placements.ts
@@ -6,20 +6,31 @@
 /** A listing that may be one of the two featured cards on a resource page. */
 interface Placeable {
   id: string
-  featured?: '1' | '2' | null
+  featured?: string | number | null
 }
 
-/** Each listing's slot on its page, keyed by record id: the two featured cards
- *  (if the page has them) are 'F1'/'F2'; everything else is numbered '1', '2',
+/** Each listing's slot on its page, keyed by record id: the featured cards
+ *  (if the page has them) are 'F<rank>'; everything else is numbered '1', '2',
  *  '3'… in display order. Pages without featured cards just get the numbered
  *  list. Pass items in the order they render so the slot matches what the
- *  visitor saw. */
-export function placementsById(items: Placeable[]): Map<string, string> {
+ *  visitor saw.
+ *
+ *  Pages with a featured queue (/events, /training) pass `featuredIds` — the
+ *  records their queue actually displays — since a queued backup (rank 3+)
+ *  renders as a normal grid card and must get a grid number, not an F-slot.
+ *  Without `featuredIds`, ranks 1 and 2 count as featured (the fixed-slot
+ *  pages). */
+export function placementsById(
+  items: Placeable[],
+  featuredIds?: Set<string>
+): Map<string, string> {
   const placements = new Map<string, string>()
   let n = 0
   for (const item of items) {
-    if (item.featured === '1') placements.set(item.id, 'F1')
-    else if (item.featured === '2') placements.set(item.id, 'F2')
+    const isFeaturedCard = featuredIds
+      ? featuredIds.has(item.id)
+      : item.featured === '1' || item.featured === '2'
+    if (isFeaturedCard) placements.set(item.id, `F${item.featured}`)
     else {
       n += 1
       placements.set(item.id, String(n))


### PR DESCRIPTION
- The Featured field is now a queue rank (1, 2, 3, …): each page shows the two lowest-ranked entries that are still live, so a curated backup steps in the moment a featured listing expires — the featured row never drops to one lonely card while a backup is queued.
- /events keeps separate queues per view — online and in person each have their own 1 and 2, with hybrid events eligible for both.
- /training passes over a featured program whose applications have closed when an open backup is queued behind it, but still uses closed entries to keep two cards showing.
- Click analytics: displayed featured cards are tagged F<rank>; queued backups count as normal grid slots.
- The chatbot catalog now marks as featured exactly the cards the pages display.
- Online events no longer need "Online" written in the Location field — the card derives the label from the Mode field (computer icon), matching /training. Location can stay empty for online-only listings.
- Companion automation (outside this PR): a daily local job compacts the queue in Airtable (clears expired ranks, shifts the rest up) and emails when a featured spot will run empty within 7 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)