### PR TITLE
Newsletter signup box on /funding

### DIFF
--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -23,7 +23,7 @@ export default async function FundingPage() {
         title="Funding"
         lastUpdatedIso={lastUpdated.lastUpdated}
         newsletter
-        newsletterHeading="Get a weekly summary of all new funding opportunities"
+        newsletterHeading="Get notified when new funding opportunities are announced"
         newsletterSubscribeUrl="https://aisafetyfunding.substack.com/subscribe"
         newsletterTrackingPage="Funding"
         description={

--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -22,6 +22,10 @@ export default async function FundingPage() {
       <PageHeader
         title="Funding"
         lastUpdatedIso={lastUpdated.lastUpdated}
+        newsletter
+        newsletterHeading="Get a weekly summary of all new funding opportunities"
+        newsletterSubscribeUrl="https://aisafetyfunding.substack.com/subscribe"
+        newsletterTrackingPage="Funding"
         description={
           <>
             These organizations offer{' '}

--- a/src/components/NewsletterSignup.module.css
+++ b/src/components/NewsletterSignup.module.css
@@ -18,10 +18,11 @@
   gap: 8px;
   width: 100%;
   height: fit-content;
-  padding: 4px 4px 4px 16px;
+  padding: 4px;
   border: 1px solid transparent;
   border-radius: 999px;
   background-color: color-mix(in srgb, var(--bright-teal-500) 20%, transparent);
+  cursor: text;
 }
 
 .field:focus-within {
@@ -30,7 +31,10 @@
 
 .input {
   flex: 1 1 auto;
+  align-self: stretch;
   min-width: 0;
+  /* With the field's own 4px, keeps the text 16px from the pill edge. */
+  padding-left: 12px;
   border: none;
   outline: none;
   background-color: transparent;

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -38,7 +38,8 @@ export default function NewsletterSignup({
   return (
     <form className={`width-4-col ${styles.card}`} onSubmit={handleSubmit}>
       <p className={`paragraph-small ${styles.heading}`}>{heading}</p>
-      <div className={styles.field}>
+      {/* A label so clicks anywhere on the pill focus the input. */}
+      <label className={styles.field}>
         <input
           type="email"
           className={`paragraph-small ${styles.input}`}
@@ -55,7 +56,7 @@ export default function NewsletterSignup({
             unoptimized
           />
         </button>
-      </div>
+      </label>
     </form>
   )
 }

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -5,15 +5,19 @@ import Image from 'next/image'
 import { trackNewsletterSignup } from '@/lib/analytics'
 import styles from './NewsletterSignup.module.css'
 
-const SUBSCRIBE_URL = 'https://aisafetyeventsandtraining.substack.com/subscribe'
+const DEFAULT_SUBSCRIBE_URL =
+  'https://aisafetyeventsandtraining.substack.com/subscribe'
 
-// Temporary Substack subscribe box shared by /events and /training until the
-// custom newsletter platform lands.
+// Temporary Substack subscribe box shared by /events, /training, and /funding
+// until the custom newsletter platform lands.
 export default function NewsletterSignup({
   heading = 'Get a weekly summary of all new events and training programs',
+  subscribeUrl = DEFAULT_SUBSCRIBE_URL,
   trackingPage,
 }: {
   heading?: string
+  /** Substack subscribe page the box opens (defaults to events & training). */
+  subscribeUrl?: string
   /** Analytics page name (e.g. 'Events'). When set, a submit records a
    *  newsletter_signup event under this page. */
   trackingPage?: string
@@ -26,8 +30,8 @@ export default function NewsletterSignup({
     if (trackingPage) trackNewsletterSignup(trackingPage)
     const trimmed = email.trim()
     const url = trimmed
-      ? `${SUBSCRIBE_URL}?email=${encodeURIComponent(trimmed)}`
-      : SUBSCRIBE_URL
+      ? `${subscribeUrl}?email=${encodeURIComponent(trimmed)}`
+      : subscribeUrl
     window.open(url, '_blank', 'noopener,noreferrer')
   }
 

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -12,6 +12,10 @@ interface PageHeaderProps {
   topPadding?: string
   /** Show the newsletter signup beside the header (stacked below on mobile). */
   newsletter?: boolean
+  /** Heading for the signup box (defaults to the events & training one). */
+  newsletterHeading?: string
+  /** Substack subscribe page the signup box opens. */
+  newsletterSubscribeUrl?: string
   /** Analytics page name for the signup box's submits (e.g. 'Events'). */
   newsletterTrackingPage?: string
   /** Extra content under the description, e.g. a cross-link to a sister page. */
@@ -25,6 +29,8 @@ export default function PageHeader({
   id,
   topPadding = 'padding-top-56px',
   newsletter,
+  newsletterHeading,
+  newsletterSubscribeUrl,
   newsletterTrackingPage,
   children,
 }: PageHeaderProps) {
@@ -50,7 +56,11 @@ export default function PageHeader({
     <div className={`${styles.heroRow} padding-bottom-56px`}>
       <div className={styles.heroHeader}>{header}</div>
       <div className={styles.newsletterSlot}>
-        <NewsletterSignup trackingPage={newsletterTrackingPage} />
+        <NewsletterSignup
+          heading={newsletterHeading}
+          subscribeUrl={newsletterSubscribeUrl}
+          trackingPage={newsletterTrackingPage}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
- Adds the newsletter signup box to /funding, pointed at the funding Substack (aisafetyfunding.substack.com), with the heading "Get notified when new funding opportunities are announced".
- Same shared component as /events and /training: top right on desktop, stacked below the intro on mobile. Submits are tracked in analytics under "Newsletter - Funding".
- Fixes the box's click target on all three pages: the email input was only text-height inside the pill, so clicks near the edges did nothing. The input now fills the pill and the pill is a label, so a click anywhere in it focuses the email field. The arrow button is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)