### PR TITLE
Contributor mode: run the site with no credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,24 @@ npm install
 npm run dev
 ```
 
-Create `.env.local`:
+That's it — no credentials needed. Without Airtable credentials the dev
+server runs in **contributor mode**: it fetches the site's data from the
+live site's public [Data API](./docs/api.md), so anyone can clone the repo
+and see the full site locally.
+
+A few things work differently in contributor mode:
+
+- Featured cards don't show (their curation data is internal).
+- The "Updated X days ago" line under page titles is hidden.
+- Features that need private credentials — the suggestion forms, the admin
+  panel, and the chatbot — won't work.
+
+None of that gets in the way of working on pages, components, styling, or
+the map.
+
+### Team setup (direct Airtable access)
+
+Team members with access to the Airtable base create `.env.local`:
 
 ```
 AIRTABLE_TOKEN=your_token

--- a/src/lib/api/handler.ts
+++ b/src/lib/api/handler.ts
@@ -11,8 +11,12 @@ import {
 
 type Loader = () => Promise<readonly unknown[]>
 
-// Site curation metadata (drives the featured cards); internal, so stripped
-// from every endpoint's output.
+// Featured-card curation metadata. On most collections the featured slot and
+// tagline are rendered on the public page, so they stay in the output
+// (featuredPublic in the registry) — contributor mode needs them to render
+// the same featured cards as the live site. The events/training featured
+// queue is different: ranks 3+ are unpublished backups, so those collections
+// keep stripping the fields.
 const INTERNAL_KEYS = ['featured', 'featuredTagline']
 
 function stripInternal(
@@ -35,7 +39,7 @@ export function createCollectionHandler(slug: string, loader: Loader) {
       const all = (await loader()) as Record<string, unknown>[]
       // Strip before filtering so the free-text `q` search can't match on
       // hidden values.
-      const visible = all.map(stripInternal)
+      const visible = def.featuredPublic ? all : all.map(stripInternal)
       const { searchParams } = new URL(request.url)
       const filtered = applyQuery(visible, searchParams, def.filterFields)
       const origin = getOrigin(request)

--- a/src/lib/api/registry.ts
+++ b/src/lib/api/registry.ts
@@ -12,6 +12,9 @@ export interface EndpointDef {
   fields: string[]
   // CDN cache TTL (seconds) for this endpoint's responses.
   cacheSeconds: number
+  // Featured slot + tagline are rendered on the public page, so the API
+  // keeps them in the output (default: stripped — see handler.ts).
+  featuredPublic?: boolean
 }
 
 export const ENDPOINTS: EndpointDef[] = [
@@ -42,8 +45,11 @@ export const ENDPOINTS: EndpointDef[] = [
       'size',
       'latitude',
       'longitude',
+      'featured',
+      'featuredTagline',
     ],
     cacheSeconds: 3600,
+    featuredPublic: true,
   },
   {
     slug: 'organizations',
@@ -176,8 +182,11 @@ export const ENDPOINTS: EndpointDef[] = [
       'recipientType',
       'acceptingApplications',
       'url',
+      'featured',
+      'featuredTagline',
     ],
     cacheSeconds: 3600,
+    featuredPublic: true,
   },
   {
     slug: 'courses',
@@ -193,40 +202,83 @@ export const ENDPOINTS: EndpointDef[] = [
       'organizer',
       'url',
       'image',
+      'featured',
+      'featuredTagline',
     ],
     cacheSeconds: 3600,
+    featuredPublic: true,
   },
   {
     slug: 'advisors',
     title: 'Advisors',
     description: 'People offering AI safety career and research advice.',
     filterFields: ['focus', 'status'],
-    fields: ['id', 'name', 'description', 'logo', 'focus', 'status', 'url'],
+    fields: [
+      'id',
+      'name',
+      'description',
+      'logo',
+      'focus',
+      'status',
+      'url',
+      'featured',
+      'featuredTagline',
+    ],
     cacheSeconds: 3600,
+    featuredPublic: true,
   },
   {
     slug: 'media-channels',
     title: 'Media channels',
     description: 'Podcasts, newsletters, blogs, and video channels.',
     filterFields: ['type'],
-    fields: ['id', 'name', 'description', 'logo', 'type', 'url'],
+    fields: [
+      'id',
+      'name',
+      'description',
+      'logo',
+      'type',
+      'url',
+      'featured',
+      'featuredTagline',
+    ],
     cacheSeconds: 3600,
+    featuredPublic: true,
   },
   {
     slug: 'founder-resources',
     title: 'Founder resources',
     description: 'Resources for founders of AI safety projects.',
     filterFields: ['type'],
-    fields: ['id', 'name', 'description', 'image', 'type', 'website'],
+    fields: [
+      'id',
+      'name',
+      'description',
+      'image',
+      'type',
+      'website',
+      'featured',
+      'featuredTagline',
+    ],
     cacheSeconds: 3600,
+    featuredPublic: true,
   },
   {
     slug: 'projects',
     title: 'Projects',
     description: 'Volunteer and collaboration opportunities.',
     filterFields: ['status'],
-    fields: ['id', 'name', 'description', 'status', 'contact'],
+    fields: [
+      'id',
+      'name',
+      'description',
+      'status',
+      'contact',
+      'featured',
+      'featuredTagline',
+    ],
     cacheSeconds: 3600,
+    featuredPublic: true,
   },
 ]
 

--- a/src/lib/data/advisors.ts
+++ b/src/lib/data/advisors.ts
@@ -7,6 +7,7 @@ import {
   fieldText,
   publishedFormula,
 } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 
 const TABLE_ID = 'tblf3KKYnmgcjVGhD'
 const VIEW_ID = 'viwIdRmaCar2Y6gPi'
@@ -43,6 +44,7 @@ export interface Advisor {
 }
 
 export async function getAdvisors(): Promise<Advisor[]> {
+  if (!hasAirtableCredentials()) return fetchPublicData<Advisor>('advisors')
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,

--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -360,8 +360,16 @@ async function fetchAirtableRecordsImpl(
   const baseId = process.env.AIRTABLE_BASE_ID
 
   if (!token || !baseId) {
-    console.error('Airtable credentials not configured')
-    return []
+    // Every data module checks hasAirtableCredentials() and falls back to the
+    // public Data API before reaching this point, so landing here means a code
+    // path is missing its contributor-mode fallback. Fail loudly rather than
+    // silently rendering an empty page.
+    throw new Error(
+      'Airtable credentials not configured and this code path has no ' +
+        'contributor-mode fallback (see src/lib/data/public-api.ts). Add ' +
+        'AIRTABLE_TOKEN and AIRTABLE_BASE_ID to .env.local, or add a ' +
+        'fetchPublicData() fallback to the calling data module.'
+    )
   }
 
   const allRecords: AirtableRawRecord[] = []

--- a/src/lib/data/communities.ts
+++ b/src/lib/data/communities.ts
@@ -8,6 +8,7 @@ import {
   fieldStringArray,
   publishedFormula,
 } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 
 const TABLE_ID = 'tbluI5Dll697WiSm8'
 const VIEW_ID = 'viwFIU3lKQHZlpc0b'
@@ -59,6 +60,8 @@ export interface Community {
 }
 
 export async function getCommunities(): Promise<Community[]> {
+  if (!hasAirtableCredentials())
+    return fetchPublicData<Community>('communities')
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,

--- a/src/lib/data/counts.ts
+++ b/src/lib/data/counts.ts
@@ -1,7 +1,16 @@
 import { fetchAirtableRecords } from './airtable'
+import { getAdvisors } from './advisors'
+import { getCommunities } from './communities'
 import { getEvents } from './events'
+import { getFounderResources } from './founders'
+import { getFunders } from './funding'
+import { getJobs } from './jobs'
+import { getMapData } from './map'
+import { getMediaChannels } from './media-channels'
+import { getProjects } from './projects'
 import { getCourses } from './self-study'
 import { getTrainingPrograms, getRecurringPrograms } from './training'
+import { hasAirtableCredentials } from './public-api'
 
 // Each resource's table ID, view to count from, and a minimal field (by
 // permanent field ID — rename-proof) to fetch.
@@ -67,6 +76,28 @@ const resources = [
 export async function fetchAllCounts(): Promise<
   Partial<Record<string, number>>
 > {
+  // Contributor mode: derive every count from the same public data the pages
+  // render, so each badge matches its page. The Airtable view counts below
+  // aren't available without credentials.
+  if (!hasAirtableCredentials()) {
+    const mapData = await getMapData()
+    return {
+      '/map': mapData.records.filter(r => !r.isMagic).length,
+      '/communities': (await getCommunities()).length,
+      '/jobs': (await getJobs()).length,
+      '/funding': (await getFunders()).length,
+      '/media-channels': (await getMediaChannels()).length,
+      '/advisors': (await getAdvisors()).length,
+      '/projects': (await getProjects()).length,
+      '/founders': (await getFounderResources()).length,
+      '/self-study': (await getCourses()).length,
+      '/events': (await getEvents()).length,
+      '/training':
+        (await getTrainingPrograms()).length +
+        (await getRecurringPrograms()).length,
+    }
+  }
+
   const counts: Partial<Record<string, number>> = {}
   for (const r of resources) {
     const raw = await fetchAirtableRecords({

--- a/src/lib/data/events.ts
+++ b/src/lib/data/events.ts
@@ -1,4 +1,5 @@
 import { fetchAirtableRecords } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 import { EVENT_TYPES, type EventType } from '../event-types'
 import { parseFeaturedRank } from '../featured'
 import { parseAttendMode, type AttendMode } from './training'
@@ -97,6 +98,8 @@ export async function getEvents(): Promise<EventListing[]> {
       readFileSync(join(process.cwd(), 'events.mock.json'), 'utf8')
     ) as EventListing[]
   }
+
+  if (!hasAirtableCredentials()) return fetchPublicData<EventListing>('events')
 
   if (!TABLE_ID) {
     console.warn(

--- a/src/lib/data/founders.ts
+++ b/src/lib/data/founders.ts
@@ -7,6 +7,7 @@ import {
   fieldText,
   publishedFormula,
 } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 
 const TABLE_ID = 'tbl59Ye8oxvPjoVJv'
 const VIEW_ID = 'viwzMBhPBk1GpQXnn'
@@ -42,6 +43,8 @@ export interface FounderResource {
 }
 
 export async function getFounderResources(): Promise<FounderResource[]> {
+  if (!hasAirtableCredentials())
+    return fetchPublicData<FounderResource>('founder-resources')
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,

--- a/src/lib/data/funding.ts
+++ b/src/lib/data/funding.ts
@@ -7,6 +7,7 @@ import {
   fieldText,
   publishedFormula,
 } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 
 const TABLE_ID = 'tblzMTLDZWZKqTxrq'
 const VIEW_ID = 'viwxv2w8utSEhUeiJ'
@@ -44,6 +45,7 @@ export interface Funder {
 }
 
 export async function getFunders(): Promise<Funder[]> {
+  if (!hasAirtableCredentials()) return fetchPublicData<Funder>('funding')
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,

--- a/src/lib/data/jobs.ts
+++ b/src/lib/data/jobs.ts
@@ -4,6 +4,7 @@ import {
   fieldString,
   fieldText,
 } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 
 const TABLE_ID = 'tblyLelYCQjP6w3nV'
 const VIEW_ID = 'viwBfn9CIUVqQHUy6'
@@ -43,6 +44,7 @@ export interface Job {
 }
 
 export async function getJobs(): Promise<Job[]> {
+  if (!hasAirtableCredentials()) return fetchPublicData<Job>('jobs')
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,

--- a/src/lib/data/last-updated.ts
+++ b/src/lib/data/last-updated.ts
@@ -141,8 +141,9 @@ export async function fetchLastUpdated(
 
   const token = process.env.AIRTABLE_TOKEN
   const baseId = process.env.AIRTABLE_BASE_ID
-  if (!token || !baseId)
-    throw new Error('Missing AIRTABLE_TOKEN or AIRTABLE_BASE_ID')
+  // Contributor mode: last-edit dates aren't in the public API, so pages
+  // simply omit their "Updated X ago" line.
+  if (!token || !baseId) return { lastUpdated: null, formattedDate: null }
 
   if (config.type === 'record') {
     const response = await fetchAirtableWithRetry(

--- a/src/lib/data/map.ts
+++ b/src/lib/data/map.ts
@@ -7,6 +7,7 @@ import {
   fieldStringArray,
   publishedFormula,
 } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 
 const TABLE_ID = 'tblvzbGL9q9dOO9Nc'
 const VIEW_ID = 'viwJgtDFDmaP8PyoI'
@@ -141,6 +142,18 @@ function compareCategoryIndices(a: number[], b: number[]): number {
 }
 
 export async function getMapData(): Promise<MapData> {
+  if (!hasAirtableCredentials()) {
+    // The public collection excludes the magic control rows (Merch, Last
+    // updated, Suggest entry/correction), so those cards don't appear in
+    // contributor mode and the suggest links use the defaults below.
+    const orgs = await fetchPublicData<Omit<MapOrg, 'isMagic'>>('organizations')
+    return {
+      records: orgs.map(org => ({ ...org, isMagic: false })),
+      suggestEntryLink: '/map/suggest',
+      suggestCorrectionLink: '#',
+    }
+  }
+
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,

--- a/src/lib/data/media-channels.ts
+++ b/src/lib/data/media-channels.ts
@@ -7,6 +7,7 @@ import {
   fieldText,
   publishedFormula,
 } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 
 const TABLE_ID = 'tblCTOMzyH3vILL5I'
 const VIEW_ID = 'viwT8KTwupcVyGKLZ'
@@ -42,6 +43,8 @@ export interface MediaChannel {
 }
 
 export async function getMediaChannels(): Promise<MediaChannel[]> {
+  if (!hasAirtableCredentials())
+    return fetchPublicData<MediaChannel>('media-channels')
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -6,6 +6,7 @@ import {
   fieldText,
   publishedFormula,
 } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 
 const TABLE_ID = 'tblHT29QNgMYKB8iW'
 const VIEW_ID = 'viwVgPN3hgpGa8dRE'
@@ -41,6 +42,7 @@ export interface Project {
 }
 
 export async function getProjects(): Promise<Project[]> {
+  if (!hasAirtableCredentials()) return fetchPublicData<Project>('projects')
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,

--- a/src/lib/data/public-api.ts
+++ b/src/lib/data/public-api.ts
@@ -6,7 +6,10 @@
 // minus the internal curation fields (featured / featuredTagline) — so in
 // contributor mode everything renders except the featured cards.
 
-const PUBLIC_API_ORIGIN = 'https://aisafety.com'
+// Override for testing against a local or preview deployment's API,
+// e.g. PUBLIC_DATA_ORIGIN=http://localhost:3241.
+const PUBLIC_API_ORIGIN =
+  process.env.PUBLIC_DATA_ORIGIN || 'https://aisafety.com'
 
 export function hasAirtableCredentials(): boolean {
   return Boolean(process.env.AIRTABLE_TOKEN && process.env.AIRTABLE_BASE_ID)

--- a/src/lib/data/public-api.ts
+++ b/src/lib/data/public-api.ts
@@ -1,0 +1,37 @@
+// Contributor mode: when Airtable credentials aren't configured, the data
+// layer falls back to the site's own public Data API (docs/api.md), so anyone
+// can clone the repo and run the site locally with no secrets at all.
+//
+// The public API serves the exact objects the src/lib/data modules produce,
+// minus the internal curation fields (featured / featuredTagline) — so in
+// contributor mode everything renders except the featured cards.
+
+const PUBLIC_API_ORIGIN = 'https://aisafety.com'
+
+export function hasAirtableCredentials(): boolean {
+  return Boolean(process.env.AIRTABLE_TOKEN && process.env.AIRTABLE_BASE_ID)
+}
+
+let noticeLogged = false
+
+export async function fetchPublicData<T>(slug: string): Promise<T[]> {
+  if (!noticeLogged) {
+    noticeLogged = true
+    console.log(
+      '[contributor mode] No Airtable credentials in .env.local — ' +
+        'fetching public data from aisafety.com instead. See README.md.'
+    )
+  }
+
+  const url = `${PUBLIC_API_ORIGIN}/api/v1/${slug}`
+  const response = await fetch(url, { next: { revalidate: 3600 } })
+  if (!response.ok) {
+    throw new Error(
+      `Contributor-mode fetch failed: ${response.status} for ${url}. ` +
+        'The live site may be briefly unavailable — retry in a moment.'
+    )
+  }
+
+  const body = (await response.json()) as { data: T[] }
+  return body.data
+}

--- a/src/lib/data/self-study.ts
+++ b/src/lib/data/self-study.ts
@@ -7,6 +7,7 @@ import {
   fieldText,
   publishedFormula,
 } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 
 const TABLE_ID = 'tblRNYJ0m1cmJXKKk'
 const VIEW_ID = 'viwblgaia3x1gsqBo'
@@ -46,6 +47,7 @@ export interface Course {
 }
 
 export async function getCourses(): Promise<Course[]> {
+  if (!hasAirtableCredentials()) return fetchPublicData<Course>('courses')
   const raw = await fetchAirtableRecords({
     tableId: TABLE_ID,
     viewId: VIEW_ID,

--- a/src/lib/data/training.ts
+++ b/src/lib/data/training.ts
@@ -1,4 +1,5 @@
 import { fetchAirtableRecords } from './airtable'
+import { fetchPublicData, hasAirtableCredentials } from './public-api'
 import {
   ENTRY_BARS,
   TRAINING_TYPES,
@@ -305,6 +306,13 @@ function parseBase(
 }
 
 export async function getTrainingPrograms(): Promise<TrainingProgram[]> {
+  if (!hasAirtableCredentials()) {
+    const all = await fetchPublicData<TrainingProgram & { recurring: boolean }>(
+      'training'
+    )
+    return all.filter(p => !p.recurring)
+  }
+
   // Publish/Hide filtering and sorting happen in code below rather than in
   // the Airtable query — filterByFormula and sort reference fields by name,
   // which would break when a field is renamed.
@@ -369,6 +377,13 @@ export async function getTrainingPrograms(): Promise<TrainingProgram[]> {
 }
 
 export async function getRecurringPrograms(): Promise<RecurringProgram[]> {
+  if (!hasAirtableCredentials()) {
+    const all = await fetchPublicData<
+      RecurringProgram & { recurring: boolean }
+    >('training')
+    return all.filter(p => p.recurring)
+  }
+
   const raw = await fetchAirtableRecords({
     tableId: RECURRING_TABLE_ID,
     viewId: RECURRING_VIEW_ID,


### PR DESCRIPTION
- With no `.env.local` at all, the dev server now runs in **contributor mode**: every data module falls back to the live site's public Data API (`/api/v1`), so volunteers can clone the repo, `npm run dev`, and see the full site — no Airtable access, no secrets.
- With credentials present, nothing changes — the Airtable path is untouched.
- The public API now passes `featured` + `featuredTagline` through for the seven collections whose featured cards are already rendered publicly (advisors, communities, funding, courses, media-channels, founder-resources, projects), so contributor mode shows the same featured cards as the live site. The events/training featured queue (ranks 3+ are unpublished backups) stays stripped, and those pages degrade gracefully.
- Contributor-mode niceties: nav counts derive from the same public data so badges match the pages; "Updated X ago" labels hide instead of throwing; a missing-credentials hit on any uncovered data path now fails loudly instead of silently rendering an empty page.
- `PUBLIC_DATA_ORIGIN` env override lets contributor mode point at a local or preview API for testing.
- README rewritten: zero-config start for contributors, credentialed setup moved under "Team setup".

Verified locally in both modes: full build + all pages + search index with zero credentials; featured cards and updated labels confirmed intact with credentials. Note: featured cards in contributor mode start appearing once this deploys (the live API doesn't serve the featured fields until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)