### PR TITLE
Map: clicking View cards writes #cards to the URL

### DIFF
--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -90,6 +90,14 @@ export default function MapClient({
 
   const scrollToCards = () => {
     if (!mapWrapperRef.current) return
+
+    // Surface the shareable /map#cards link (issue #226). replaceState rather
+    // than setting location.hash: the latter jump-scrolls instantly, fighting
+    // the animation below, and would stack a history entry per click.
+    const url = new URL(window.location.href)
+    url.hash = 'cards'
+    window.history.replaceState(window.history.state, '', url)
+
     const mapRect = mapWrapperRef.current.getBoundingClientRect()
     const scrollTarget = window.scrollY + mapRect.bottom
 


### PR DESCRIPTION
- Clicking the **View cards** button on /map now updates the address bar to `/map#cards`, so visitors can see the cards section has a direct, shareable link. Fixes #226.
- Uses `history.replaceState` (same approach as the /training view toggle): no history entries stack up when clicking repeatedly, and no native jump-scroll fights the existing smooth-scroll animation.
- The existing `/map#cards` link is unchanged and still lands directly on the cards section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)