### PR TITLE
Serve permanent image URLs via Vercel Blob instead of expiring Airtable links

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -43,8 +43,8 @@ Every collection endpoint returns a wrapped envelope:
 ```
 
 - IDs are stable Airtable record IDs.
-- Image fields (`logo`, `image`, `mapLogo`) are absolute URLs on the serving
-  origin (the build-time image cache), not Airtable's expiring attachment URLs.
+- Image fields (`logo`, `image`, `mapLogo`) are permanent Vercel Blob URLs
+  (`*.public.blob.vercel-storage.com`), not Airtable's expiring attachment URLs.
 - Dates are ISO-8601 strings.
 
 ## Filtering
@@ -72,7 +72,7 @@ fields are excluded by allowlist.
 src/lib/api/
   constants.ts   license / attribution / base path
   registry.ts    single source of truth for endpoints (filters, fields, TTLs)
-  response.ts    CORS, envelope, meta, absolute-URL helper
+  response.ts    CORS, envelope, meta
   filter.ts      in-memory query/search
   handler.ts     createCollectionHandler() + OPTIONS
 src/lib/data/events.ts            events normalizer (shared with the chatbot)
@@ -84,11 +84,9 @@ src/app/developers/page.tsx       human docs
 
 ## Known limitations and future work
 
-- **Image freshness:** images come from the build-time cache. A brand-new image
-  in Airtable appears after the next redeploy (same model as the site). If an
-  image-bearing collection is fetched at runtime before a redeploy and a new
-  image was just added, that request can 503 until the redeploy, then self-heals.
-  A streaming image proxy would remove this entirely (deferred).
+- **Image freshness:** a brand-new image in Airtable is mirrored to Vercel Blob
+  on the next data refresh (at most an hour, no redeploy needed) and its URL is
+  permanent from then on.
 - **Per-dataset `lastUpdated`** in `meta` (deferred; `generatedAt` is provided).
 - **Pagination** and **server-side sorting** (deferred; collections are small).
 - **UI embed widget**, a zero-code drop-in for non-technical chapters (deferred).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/d3": "^7.4.3",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.38.0",
+        "@vercel/blob": "^2.7.0",
         "airtable": "^0.12.2",
         "d3": "^7.9.0",
         "franc-min": "^6.2.0",
@@ -2490,6 +2491,68 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.7.0.tgz",
+      "integrity": "sha512-cWo8XeRI+eq+pTAQOGZEljSeARw/PZfvNCez9xioGcz/KFvwTR5ESGuKd4wPkGnhbPXyxJJMEgP4oOkwQ4uNGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "^3.6.1",
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.2.tgz",
+      "integrity": "sha512-kAy35eymNzRBfmcqEViVQge0KJ59FYEKsPqGNCSJQ7M9HTuFGWd3qPcZos1A5cZpAWRBdiYe82Bcz9P7pIZvUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.1.tgz",
+      "integrity": "sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.2.tgz",
+      "integrity": "sha512-nmVSeQ7tewCkqYBNB/MNL8aPB9sTvtjvqIE6+U17U4IuTyehuWVERDlWrSn0DVfiFAstRlRkGLHBlKHB2FyzbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.2",
+        "@vercel/cli-exec": "1.0.1",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2806,6 +2869,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -3204,7 +3276,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4516,6 +4587,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4798,6 +4913,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -5003,6 +5130,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -5161,6 +5297,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-bun-module": {
@@ -5351,6 +5510,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5424,6 +5589,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -5534,7 +5711,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -5563,6 +5739,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6101,6 +6286,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6123,6 +6314,15 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-function": {
@@ -6359,6 +6559,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6516,6 +6728,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -6601,7 +6822,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6925,6 +7145,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7173,7 +7402,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7186,7 +7414,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7517,6 +7744,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7598,6 +7834,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinyglobby": {
@@ -7873,6 +8121,15 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -7976,7 +8233,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8147,6 +8403,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/d3": "^7.4.3",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
+    "@vercel/blob": "^2.7.0",
     "airtable": "^0.12.2",
     "d3": "^7.9.0",
     "franc-min": "^6.2.0",

--- a/src/components/CardLogo.tsx
+++ b/src/components/CardLogo.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+
+// Card logo that removes itself (wrapper included) when the image fails to
+// load, so a dead URL degrades to a logo-less card instead of the browser's
+// broken-image icon. Matches ListingCard's onError behavior for the featured
+// cards, which are server components and can't attach the handler themselves.
+export default function CardLogo({ src, alt }: { src: string; alt: string }) {
+  // Track the failed URL rather than a boolean so a new src gets a fresh try.
+  const [failedSrc, setFailedSrc] = useState<string | null>(null)
+  if (failedSrc === src) return null
+
+  return (
+    <div className="featured-img">
+      <Image
+        src={src}
+        alt={alt}
+        width={64}
+        height={64}
+        className="card-image"
+        unoptimized
+        onError={() => setFailedSrc(src)}
+      />
+    </div>
+  )
+}

--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import CardLogo from './CardLogo'
 import TrackedLink from './TrackedLink'
 import styles from './FeaturedCard.module.css'
 
@@ -114,18 +115,7 @@ export default function FeaturedCard({
           titleMeta && titleMeta.length > 0 ? 'items-start' : 'items-center'
         }`}
       >
-        {logo && (
-          <div className="featured-img">
-            <Image
-              src={logo}
-              alt={`${name} logo`}
-              width={64}
-              height={64}
-              className="card-image"
-              unoptimized
-            />
-          </div>
-        )}
+        {logo && <CardLogo src={logo} alt={`${name} logo`} />}
         <div>
           <h3>{name}</h3>
           {titleMeta && titleMeta.length > 0 && (

--- a/src/components/FeaturedCardLegacy.tsx
+++ b/src/components/FeaturedCardLegacy.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import CardLogo from './CardLogo'
 import TrackedLink from './TrackedLink'
 import styles from './FeaturedCardLegacy.module.css'
 
@@ -54,16 +55,7 @@ export default function FeaturedCardLegacy({
       </p>
       {logo ? (
         <div className="flex items-center gap-16px padding-bottom-24px">
-          <div className="featured-img">
-            <Image
-              src={logo}
-              alt={`${name} logo`}
-              width={64}
-              height={64}
-              className="card-image"
-              unoptimized
-            />
-          </div>
+          <CardLogo src={logo} alt={`${name} logo`} />
           <h3>{name}</h3>
         </div>
       ) : (

--- a/src/lib/api/handler.ts
+++ b/src/lib/api/handler.ts
@@ -1,13 +1,6 @@
 import { getEndpoint } from './registry'
 import { applyQuery } from './filter'
-import {
-  absolutizeAssets,
-  buildMeta,
-  getOrigin,
-  jsonError,
-  jsonResponse,
-  preflight,
-} from './response'
+import { buildMeta, jsonError, jsonResponse, preflight } from './response'
 
 type Loader = () => Promise<readonly unknown[]>
 
@@ -28,7 +21,7 @@ function stripInternal(
 }
 
 // Builds a GET route handler for a collection endpoint:
-//   load → filter (whitelist + free-text q) → absolutize asset URLs → envelope.
+//   load → filter (whitelist + free-text q) → envelope.
 // The loader reuses the existing src/lib/data getX() functions, so data shaping
 // lives in one place and the API stays a thin, consistent skin over it.
 export function createCollectionHandler(slug: string, loader: Loader) {
@@ -41,9 +34,7 @@ export function createCollectionHandler(slug: string, loader: Loader) {
       // hidden values.
       const visible = def.featuredPublic ? all : all.map(stripInternal)
       const { searchParams } = new URL(request.url)
-      const filtered = applyQuery(visible, searchParams, def.filterFields)
-      const origin = getOrigin(request)
-      const data = filtered.map(record => absolutizeAssets(record, origin))
+      const data = applyQuery(visible, searchParams, def.filterFields)
       return jsonResponse(
         { data, meta: buildMeta(data.length) },
         { cacheSeconds: def.cacheSeconds }

--- a/src/lib/api/response.ts
+++ b/src/lib/api/response.ts
@@ -78,23 +78,3 @@ export function getOrigin(request: Request): string {
     (host.includes('localhost') || host.startsWith('127.') ? 'http' : 'https')
   return `${proto}://${host}`
 }
-
-const CACHE_PATH_PREFIX = '/images/airtable-cache/'
-
-// Locally-cached Airtable images are stored as site-relative paths
-// (/images/airtable-cache/...). Cross-origin API consumers need absolute URLs,
-// so rewrite those specific paths to absolute against the serving origin.
-// Returns a shallow copy when a rewrite happens; never mutates the (cached) input.
-export function absolutizeAssets<T extends Record<string, unknown>>(
-  record: T,
-  origin: string
-): T {
-  let copy: T | null = null
-  for (const [key, value] of Object.entries(record)) {
-    if (typeof value === 'string' && value.startsWith(CACHE_PATH_PREFIX)) {
-      if (!copy) copy = { ...record }
-      ;(copy as Record<string, unknown>)[key] = origin + value
-    }
-  }
-  return copy ?? record
-}

--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -1,7 +1,5 @@
-import fs from 'fs'
 import path from 'path'
-import https from 'https'
-import http from 'http'
+import { list, put } from '@vercel/blob'
 import { unstable_cache } from 'next/cache'
 
 export interface AirtableRawRecord {
@@ -82,7 +80,10 @@ export function publishedFormula(
   return `AND({${publishFieldId}} = TRUE(), {${hideFieldId}} = FALSE())`
 }
 
-const CACHE_DIR = path.join(process.cwd(), 'public', 'images', 'airtable-cache')
+// Attachments are mirrored to Vercel Blob under this prefix. Airtable's own
+// attachment URLs are signed and expire within hours, so they must never end
+// up in cached pages or API responses; Blob URLs are permanent.
+const BLOB_PREFIX = 'airtable/'
 const CONCURRENCY = 20
 const DOWNLOAD_MAX_RETRIES = 3
 const DOWNLOAD_RETRY_DELAY_MS = 2000
@@ -107,9 +108,22 @@ const ALLOWED_EXTENSIONS = [
   '.webp',
   '.gif',
   '.avif',
+  // Comb falls back to a site's favicon when no logo is available.
+  '.ico',
 ]
 
-function getExtension(url: string, filename: string): string {
+const MIME_EXTENSIONS: Record<string, string> = {
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/svg+xml': '.svg',
+  'image/webp': '.webp',
+  'image/gif': '.gif',
+  'image/avif': '.avif',
+  'image/x-icon': '.ico',
+  'image/vnd.microsoft.icon': '.ico',
+}
+
+function getExtension({ url, filename, type }: AirtableAttachment): string {
   const filenameExt = path.extname(filename).toLowerCase()
   if (filenameExt && ALLOWED_EXTENSIONS.includes(filenameExt)) {
     return filenameExt
@@ -119,6 +133,10 @@ function getExtension(url: string, filename: string): string {
   const urlExt = path.extname(urlPath).toLowerCase()
   if (urlExt && ALLOWED_EXTENSIONS.includes(urlExt)) {
     return urlExt
+  }
+
+  if (type && MIME_EXTENSIONS[type]) {
+    return MIME_EXTENSIONS[type]
   }
 
   throw new Error(
@@ -135,6 +153,11 @@ function parseHttpStatus(message: string): number {
 function isRetryableError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
   if (RETRYABLE_STATUS_CODES.has(parseHttpStatus(message))) return true
+  // fetch wraps network errors: the useful code lives in error.cause.
+  const cause =
+    error instanceof Error && error.cause instanceof Error
+      ? error.cause.message
+      : ''
   const networkErrors = [
     'ECONNRESET',
     'ETIMEDOUT',
@@ -142,56 +165,19 @@ function isRetryableError(error: unknown): boolean {
     'EPIPE',
     'EAI_AGAIN',
     'socket hang up',
+    'fetch failed',
   ]
-  return networkErrors.some(e => message.includes(e))
+  return networkErrors.some(e => message.includes(e) || cause.includes(e))
 }
 
-function downloadFileOnce(url: string, dest: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(dest)
-    file.on('error', err => {
-      reject(err)
-    })
-    const protocol = url.startsWith('https') ? https : http
-
-    protocol
-      .get(url, response => {
-        if (response.statusCode === 301 || response.statusCode === 302) {
-          const redirectUrl = response.headers.location
-          if (redirectUrl) {
-            file.close()
-            fs.unlinkSync(dest)
-            downloadFileOnce(redirectUrl, dest).then(resolve).catch(reject)
-            return
-          }
-        }
-
-        if (response.statusCode !== 200) {
-          file.close()
-          fs.unlinkSync(dest)
-          reject(new Error(`HTTP ${response.statusCode}`))
-          return
-        }
-
-        response.pipe(file)
-        file.on('finish', () => {
-          file.close()
-          resolve()
-        })
-      })
-      .on('error', err => {
-        file.close()
-        fs.unlink(dest, () => {})
-        reject(err)
-      })
-  })
-}
-
-async function downloadFile(url: string, dest: string): Promise<void> {
+async function fetchAttachmentBody(url: string): Promise<ArrayBuffer> {
   for (let attempt = 0; attempt <= DOWNLOAD_MAX_RETRIES; attempt++) {
     try {
-      await downloadFileOnce(url, dest)
-      return
+      const response = await fetch(url, { cache: 'no-store' })
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+      return await response.arrayBuffer()
     } catch (error) {
       if (!isRetryableError(error) || attempt === DOWNLOAD_MAX_RETRIES) {
         throw error
@@ -204,89 +190,129 @@ async function downloadFile(url: string, dest: string): Promise<void> {
       await new Promise(r => setTimeout(r, delay))
     }
   }
+  // Unreachable — the loop returns or throws on the final attempt.
+  throw new Error('fetchAttachmentBody exhausted retries without returning')
 }
 
-interface DownloadTask {
+interface MirrorTask {
   recordId: string
   fieldName: string
-  attachment: AirtableAttachment
-  localPath: string
-  localUrl: string
+  /** The record's attachment array; index 0 is rewritten in place. */
+  holder: AirtableAttachment[]
+  pathname: string
 }
 
-async function downloadAttachments(
-  records: AirtableRawRecord[]
-): Promise<void> {
-  // The cache lives under public/ so it can be served as static assets.
-  // That works at build time (writable filesystem) but not at request time
-  // on Vercel serverless (read-only). When the cache dir isn't writable,
-  // skip caching and leave the original Airtable signed URLs in place —
-  // they're valid long enough for an interactive request.
-  try {
-    if (!fs.existsSync(CACHE_DIR)) {
-      fs.mkdirSync(CACHE_DIR, { recursive: true })
-    }
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code
-    if (code === 'EROFS' || code === 'EACCES' || code === 'ENOENT') {
-      return
-    }
-    throw err
+// Rewrites every record's first attachment URL to a permanent copy in Vercel
+// Blob, uploading any attachment not yet mirrored. Unlike the filesystem, Blob
+// is writable at request time too, so the same path runs at build time and at
+// runtime (ISR revalidation, the assistant catalog) and expiring signed URLs
+// never end up in cached data or rendered pages.
+async function mirrorAttachments(records: AirtableRawRecord[]): Promise<void> {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    // No Blob store configured (e.g. running from a fork without Vercel
+    // access). Signed URLs work for a couple of hours — enough for local dev.
+    console.warn(
+      'BLOB_READ_WRITE_TOKEN not set — images will use expiring Airtable URLs'
+    )
+    return
   }
 
-  const tasks: DownloadTask[] = []
-
+  // Collect every mirrorable attachment first: several tables (e.g. the
+  // per-table counts) carry no attachments at all, and those fetches should
+  // not pay for a Blob listing.
+  const candidates: MirrorTask[] = []
   for (const record of records) {
     for (const [fieldName, value] of Object.entries(record.fields)) {
       if (!isAttachmentArray(value)) continue
 
       const attachment = value[0]
-      const ext = getExtension(attachment.url, attachment.filename)
-      // Use attachment.id in filename so cache auto-invalidates when image is replaced in Airtable
-      const localFilename = `${attachment.id}${ext}`
-      const localPath = path.join(CACHE_DIR, localFilename)
-      const localUrl = `/images/airtable-cache/${localFilename}`
-
-      if (fs.existsSync(localPath)) {
-        // Already cached, just update the URL
-        value[0] = { ...attachment, url: localUrl }
+      let ext: string
+      try {
+        ext = getExtension(attachment)
+      } catch (error) {
+        // One odd attachment must not block deploys or crash consumers of the
+        // shared data cache; its record keeps the signed URL (works ~2h) and
+        // the warning names it so it can be fixed in Airtable.
+        console.warn(`Cannot mirror ${fieldName} for ${record.id}: ${error}`)
         continue
       }
-
-      tasks.push({
+      candidates.push({
         recordId: record.id,
         fieldName,
-        attachment,
-        localPath,
-        localUrl,
+        holder: value,
+        pathname: `${BLOB_PREFIX}${attachment.id}${ext}`,
       })
     }
   }
+  if (candidates.length === 0) return
 
-  if (tasks.length === 0) return
+  // One listing covers every already-mirrored attachment. Pathnames embed the
+  // attachment id, so replacing an image in Airtable changes the pathname and
+  // the new file is uploaded on the next fetch.
+  const existing = new Map<string, string>()
+  try {
+    let cursor: string | undefined
+    do {
+      const page = await list({ prefix: BLOB_PREFIX, cursor })
+      for (const blob of page.blobs) {
+        existing.set(blob.pathname, blob.url)
+      }
+      cursor = page.cursor
+    } while (cursor)
+  } catch (error) {
+    // A Blob outage (or revoked token) must not take down every consumer of
+    // the shared data cache — degrade to signed URLs at runtime, but fail the
+    // build loudly: deploying pages with expiring URLs defeats the mirror.
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      throw error
+    }
+    console.warn(
+      `Blob listing failed — images will use expiring Airtable URLs: ${error}`
+    )
+    return
+  }
 
-  console.log(`Downloading ${tasks.length} attachments...`)
-
+  const tasks: MirrorTask[] = []
   const failures: string[] = []
 
-  // Download in parallel with concurrency limit
+  for (const candidate of candidates) {
+    const mirroredUrl = existing.get(candidate.pathname)
+    if (mirroredUrl) {
+      candidate.holder[0] = { ...candidate.holder[0], url: mirroredUrl }
+    } else {
+      tasks.push(candidate)
+    }
+  }
+
+  if (tasks.length > 0) {
+    console.log(`Mirroring ${tasks.length} attachments to Blob...`)
+  }
+
+  // Upload in parallel with concurrency limit
   for (let i = 0; i < tasks.length; i += CONCURRENCY) {
     const batch = tasks.slice(i, i + CONCURRENCY)
     const results = await Promise.allSettled(
-      batch.map(task => downloadFile(task.attachment.url, task.localPath))
+      batch.map(async task => {
+        const body = await fetchAttachmentBody(task.holder[0].url)
+        return put(task.pathname, body, {
+          access: 'public',
+          addRandomSuffix: false,
+          // Concurrent revalidations can race to upload the same attachment;
+          // both write identical bytes, so overwriting is harmless.
+          allowOverwrite: true,
+          contentType: task.holder[0].type,
+          cacheControlMaxAge: 31536000,
+        })
+      })
     )
 
     for (let j = 0; j < results.length; j++) {
       const task = batch[j]
       const result = results[j]
-      const record = records.find(r => r.id === task.recordId)
 
-      if (result.status === 'fulfilled' && record) {
-        const field = record.fields[task.fieldName]
-        if (isAttachmentArray(field)) {
-          field[0] = { ...field[0], url: task.localUrl }
-        }
-      } else if (result.status === 'rejected') {
+      if (result.status === 'fulfilled') {
+        task.holder[0] = { ...task.holder[0], url: result.value.url }
+      } else {
         failures.push(
           `${task.fieldName} for ${task.recordId}: ${result.reason}`
         )
@@ -295,9 +321,14 @@ async function downloadAttachments(
   }
 
   if (failures.length > 0) {
-    throw new Error(
-      `Failed to download ${failures.length} attachments:\n${failures.join('\n')}`
-    )
+    const message = `Failed to mirror ${failures.length} attachments to Blob (their records keep expiring Airtable URLs):\n${failures.join('\n')}`
+    // A broken image must fail the build, but at request time it would take
+    // down every consumer of the shared data cache (assistant, search, ISR
+    // revalidation) over a single logo — warn and degrade there instead.
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      throw new Error(message)
+    }
+    console.warn(message)
   }
 }
 
@@ -419,7 +450,7 @@ async function fetchAirtableRecordsImpl(
     offset = data.offset || null
   } while (offset)
 
-  await downloadAttachments(allRecords)
+  await mirrorAttachments(allRecords)
 
   return allRecords
 }
@@ -431,7 +462,8 @@ async function fetchAirtableRecordsImpl(
 // records under the old field shape can't be served to new code.
 export const fetchAirtableRecords = unstable_cache(
   fetchAirtableRecordsImpl,
-  ['airtable-records', 'v2'],
+  // v3: attachment URLs moved from local paths to Vercel Blob.
+  ['airtable-records', 'v3'],
   // The tag lets /api/check-rebuild invalidate these entries the minute an
   // Airtable change is detected, so runtime consumers (assistant catalog,
   // search index) don't wait out the hourly revalidate that static pages


### PR DESCRIPTION
Fixes the intermittent all-images-broken state on /events, /training, and the other resource pages: Airtable attachment URLs expire every ~2 hours, and pages regenerated at runtime (where Vercel's filesystem is read-only) served those expiring links directly.

- Mirror Airtable attachments to Vercel Blob (store `site-images`), which is writable at build time and at request time, so every data refresh produces permanent image URLs
- Pathnames embed the attachment id, so a replaced image in Airtable is uploaded under a new name automatically
- Degrade gracefully at runtime: if Blob is unreachable or a single attachment cannot be mirrored, warn and keep the signed URL rather than failing the chatbot, search, API, and ISR revalidation; builds still fail loudly on mirror errors
- Accept `.ico` attachments (Comb's favicon fallback)
- Remove `absolutizeAssets` from the v1 API — image fields are now absolute Blob URLs; docs/api.md updated
- New `CardLogo` client component hides a logo that fails to load, so featured cards degrade like listing cards instead of showing the browser's broken-image icon
- Bump the shared data-cache key (v2 → v3) so cached records holding signed URLs are not served by the new code

Verified locally on a production build: all resource pages contain zero `airtableusercontent` URLs (events 81/81 Blob, map 1032/1032), the v1 API returns Blob URLs on its always-dynamic path, and every rendered logo loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)