### PR TITLE
Chatbot: answer project questions from the long description

### DIFF
--- a/src/app/api/v1/projects/route.ts
+++ b/src/app/api/v1/projects/route.ts
@@ -5,11 +5,15 @@ export const dynamic = 'force-dynamic'
 
 // `email` is a personal contact address. The site page still shows it to human
 // visitors, but strip it from the API so it can't be bulk-harvested.
+// `descriptionLong` is internal background never displayed on the site, and it
+// can name people who never agreed to appear in a public dump — strip it too.
+const PRIVATE_KEYS = ['email', 'descriptionLong']
+
 export const GET = createCollectionHandler('projects', async () => {
   const projects = await getProjects()
   return projects.map(project =>
     Object.fromEntries(
-      Object.entries(project).filter(([key]) => key !== 'email')
+      Object.entries(project).filter(([key]) => !PRIVATE_KEYS.includes(key))
     )
   )
 })

--- a/src/lib/assistant/catalog.ts
+++ b/src/lib/assistant/catalog.ts
@@ -253,6 +253,7 @@ export async function buildCatalog(): Promise<Catalog> {
       type: 'project',
       name: p.name,
       description: clamp(p.description, 280),
+      details: p.descriptionLong?.trim() || undefined,
       url: p.email ? `mailto:${p.email}` : '#',
       pageUrl: '/projects',
       dateAdded: p.dateAdded ?? undefined,

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES, greetingFor } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-08-07-01'
+export const PROMPT_VERSION = '2026-08-12-01'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -159,6 +159,7 @@ Filter keys + complete value lists per type. Values are exact catalog labels:
 
 - **project**:
   - \`status\`: "Active", "Paused", "Seeking owner"
+  - \`get_listing\` on a project returns a \`details\` field – fuller background on what the project involves. Fetch it before answering questions about a specific project (projects have no external webpage, so it's the only extra detail available). \`details\` is internal background NOT displayed anywhere on the site: never tell the user they can read it on the [Volunteer projects](/projects) page, and never quote it as public site content – relay what's relevant in your own words. **NEVER repeat any person's name or personal email address that appears in \`details\`** – people named there haven't agreed to be surfaced through this chat; refer to them by role if needed ("the project's founder", "a researcher who suggested it") and, as always, send the user to the [Volunteer projects](/projects) listing for how to get in touch.
 
 - **media-channel**:
   - \`type\`: "Article", "Blog", "Book", "Forum", "Newsletter", "Podcast", "Twitter/X list", "YouTube channel"

--- a/src/lib/assistant/search.ts
+++ b/src/lib/assistant/search.ts
@@ -55,7 +55,9 @@ function precompute(listing: Listing): ScoreInputs {
     nameTokens: new Set(tokenize(listing.name)),
     orgTokens: new Set(tokenize(listing.organization ?? '')),
     metaTokens: new Set(tokenize(Object.values(listing.meta).join(' '))),
-    descTokens: new Set(tokenize(listing.description)),
+    descTokens: new Set(
+      tokenize(listing.description + ' ' + (listing.details ?? ''))
+    ),
   }
 }
 

--- a/src/lib/assistant/tools.ts
+++ b/src/lib/assistant/tools.ts
@@ -117,7 +117,7 @@ EXAMPLES:
   {
     name: 'get_listing',
     description:
-      'Fetch full details on a single listing by id (e.g. "job:rec123ABC"). Use after search_listings when you need fields not in the summary, or when the user names a specific entry. The result includes dateAdded (when the listing was added to the site) and lastModified (when any part of its record last changed, including routine upkeep by the site\'s team) — use these for "how current is this listing" questions; jobs have neither, but carry datePublished in meta.',
+      'Fetch full details on a single listing by id (e.g. "job:rec123ABC"). Use after search_listings when you need fields not in the summary, or when the user names a specific entry. The result includes dateAdded (when the listing was added to the site) and lastModified (when any part of its record last changed, including routine upkeep by the site\'s team) — use these for "how current is this listing" questions; jobs have neither, but carry datePublished in meta. For PROJECT listings the result also carries a `details` field with fuller background than the search summary — always fetch it before answering questions about what a specific project involves (projects have no external webpage to read, so this is the only extra detail you can get).',
     input_schema: {
       type: 'object',
       properties: {
@@ -240,7 +240,12 @@ function summariseListing(
   distanceKm?: number,
   // Dates ride along only where they answer the question (recency-sorted
   // searches, get_listing) — regular search results stay lean.
-  includeDates?: boolean
+  includeDates?: boolean,
+  // `details` (currently only projects) rides along only on get_listing:
+  // it is served in full and can run to thousands of chars, so a browse-all
+  // search must not carry it for every match. The note travels with the data
+  // so the model sees the handling rules at the moment it reads the text.
+  includeDetails?: boolean
 ): object {
   const eventStatus =
     l.type === 'event' || l.type === 'training'
@@ -256,6 +261,13 @@ function summariseListing(
     ...(eventStatus ?? {}),
     ...(includeDates && l.dateAdded ? { dateAdded: l.dateAdded } : {}),
     ...(includeDates && l.lastModified ? { lastModified: l.lastModified } : {}),
+    ...(includeDetails && l.details
+      ? {
+          details: l.details,
+          detailsNote:
+            "Internal background — NOT displayed anywhere on the site, so never tell the user to read it on the listing page or present it as public site content; relay what is relevant in your own words. NEVER repeat any person's name or personal email that appears in it.",
+        }
+      : {}),
     url: l.url,
     pageUrl: l.pageUrl,
     ...(l.featured ? { featured: true } : {}),
@@ -330,7 +342,9 @@ function executeGetListing(
   const today = new Date().toISOString().slice(0, 10)
   return {
     ok: true,
-    content: JSON.stringify(summariseListing(listing, today, undefined, true)),
+    content: JSON.stringify(
+      summariseListing(listing, today, undefined, true, true)
+    ),
     listings: [listing],
   }
 }

--- a/src/lib/assistant/types.ts
+++ b/src/lib/assistant/types.ts
@@ -32,6 +32,11 @@ export interface Listing {
   /** YYYY-MM-DD any field of the record last changed (edits of any kind,
    *  including routine maintenance). Same visibility rules as dateAdded. */
   lastModified?: string
+  /** Fuller background reaching the model only via get_listing — search
+   *  results stay lean. Currently only projects have it (Airtable's
+   *  "Description (long)"). NOT displayed anywhere on the site, so the
+   *  prompt forbids citing it as on-page content or repeating names from it. */
+  details?: string
 }
 
 export interface Catalog {

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -16,6 +16,7 @@ const VIEW_ID = 'viwVgPN3hgpGa8dRE'
 const FIELD = {
   projectName: 'fldtfqsPSKc5ubNs4', // Project Name
   descriptionShort: 'fldbeRqlUCLsgOcCT', // Description (short)
+  descriptionLong: 'fldmSMJIiJukmgoEU', // Description (long)
   status: 'fld57KJsNvSKFLoHT', // Status
   contactName: 'fldejiM6qWUfXAeqO', // Contact name
   contactEmail: 'fldNhMihsnXhsHMnc', // Contact email
@@ -33,6 +34,11 @@ export interface Project {
   lastModified: string | null
   name: string
   description: string
+  /** Fuller background from Airtable's "Description (long)". Not displayed
+   *  anywhere on the site — it feeds only the chatbot's get_listing detail
+   *  view, and is stripped from the public Data API (it can name people who
+   *  never agreed to appear in a public dump). */
+  descriptionLong: string | null
   logo: string | null
   contact: string
   email: string | null
@@ -63,6 +69,7 @@ export async function getProjects(): Promise<Project[]> {
       lastModified: fieldDateOnly(f[FIELD.lastModified]),
       name,
       description: fieldString(f[FIELD.descriptionShort]) || '',
+      descriptionLong: fieldString(f[FIELD.descriptionLong]),
       logo: null,
       contact: fieldString(f[FIELD.contactName]) || '',
       email: fieldString(f[FIELD.contactEmail]),


### PR DESCRIPTION
- The chatbot can now read the Projects table's "Description (long)" field, which is not displayed anywhere on the site. It arrives as a `details` field on `get_listing` only, so bulk search results stay lean; the text is also indexed for search matching. Served in full, untrimmed.
- The bot is instructed (system prompt + a note that travels with the data) that this content is not on the site — so it never presents it as on-page content — and that it must never repeat a person's name or personal email found in it, referring to people by role instead.
- The field is stripped from the public Data API (`/api/v1/projects`) alongside `email`, since long descriptions can name people who never agreed to appear in a public dump. Contributor mode simply lacks it, like `featured`.
- Prompt version bumped to 2026-08-12-01.

Verified locally: the bot fetches details before answering project questions, draws on content deep in the longest record (PAIS, ~7k chars), and under a direct "who suggested this project, give me their email" ask it answered by role and declined to share the address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)