### PR TITLE
Analytics: preset ranges clear custom dates + Total row shows % of visitors who clicked any listing

### DIFF
--- a/src/app/admin/analytics/DateRangePicker.tsx
+++ b/src/app/admin/analytics/DateRangePicker.tsx
@@ -39,6 +39,8 @@ export default function DateRangePicker({
   }
 
   const setPreset = (key: string) => {
+    setCustomFrom('')
+    setCustomTo('')
     const params = carryOver()
     params.set('range', key)
     router.push(`${pathname}?${params.toString()}`)

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -843,12 +843,15 @@ export default async function AnalyticsPage({
                     rankFor={name => positionByName.get(name)}
                     shareFor={name => listingShare.get(name)}
                     total={listingTotal}
+                    totalShare={data.anyListingShare ?? undefined}
                   />
                   <p className={styles.caption}>
                     Slot = where each listing was clicked this period (F1/F2 =
                     featured cards). Blank for clicks logged before slot
                     tracking. % of visitors = the share of this page&apos;s
-                    visitors who clicked the listing.
+                    visitors who clicked the listing; the Total row is the share
+                    who clicked any listing at all (each visitor counted once,
+                    so it&apos;s less than the column&apos;s sum).
                   </p>
                 </Panel>
                 <Panel title="Clicks by position">
@@ -1436,6 +1439,7 @@ function CountTable({
   pageFor,
   shareFor,
   total,
+  totalShare,
 }: {
   rows: Counted[]
   labelHead: string
@@ -1460,6 +1464,11 @@ function CountTable({
    *  footer row. The total is the denominator, so for a sliced "top N" table it
    *  can exceed the sum of the visible rows. */
   total?: number
+  /** The Total row's "% of visitors" cell: the share of visitors who did the
+   *  thing at least once, counted across the whole table. Computed from
+   *  distinct visitors, not by summing the rows — a visitor who did several
+   *  things counts once. Blank when unset. */
+  totalShare?: VisitorShare
 }) {
   if (allRows.length === 0) return <p className={styles.dim}>No data yet.</p>
   const rows = allRows.slice(0, MAX_TABLE_ROWS)
@@ -1512,7 +1521,18 @@ function CountTable({
               {showPct && (
                 <td className={styles.pctCol}>{pct1(total, total)}</td>
               )}
-              {shareFor && <td className={styles.pctCol} />}
+              {shareFor && (
+                <td className={styles.pctCol}>
+                  {/* active 0 means the range's clicks predate visitor ids
+                      (or all came from private browsing) — that's unknown,
+                      not a true 0%, so it gets the same dash as the rows. */}
+                  {totalShare
+                    ? totalShare.active > 0
+                      ? shareCell(totalShare)
+                      : '—'
+                    : null}
+                </td>
+              )}
             </tr>
           ) : undefined
         }

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -480,6 +480,12 @@ export interface DashboardData {
    *  each against the page's distinct visitors. Keyed by the same row names
    *  the corresponding tables use. */
   listingShare: VisitorShare[]
+  /** The Top listings footer's "% of visitors": distinct visitors who clicked
+   *  ANY listing on `selectedPage` vs the page's distinct visitors. Not the
+   *  sum of the `listingShare` rows — a visitor who clicked three listings
+   *  counts once here. Narrowed by `selectedSource` like the rows above it.
+   *  Null when no page is selected. */
+  anyListingShare: VisitorShare | null
   positionShare: VisitorShare[]
   filterGroupShare: VisitorShare[]
   filterValueShare: VisitorShare[]
@@ -554,6 +560,7 @@ const EMPTY: Omit<DashboardData, 'source'> = {
   newsletterByPage: [],
   newsletterShareByPage: [],
   listingShare: [],
+  anyListingShare: null,
   positionShare: [],
   filterGroupShare: [],
   filterValueShare: [],
@@ -930,6 +937,19 @@ function aggregate(
     }))
   }
   const listingShare = shareOnPage(pageClicks, listingMember)
+  // The footer's "any listing" share: one Set across every listing click on
+  // the page, so a visitor who clicked several listings still counts once —
+  // deliberately NOT the sum of the per-listing rows.
+  const anyListingVids = new Set<string>()
+  for (const e of pageClicks) if (e.vid) anyListingVids.add(e.vid)
+  const anyListingShare: VisitorShare | null =
+    selectedPage != null
+      ? {
+          name: 'Any listing',
+          active: anyListingVids.size,
+          visitors: pageVisitorCount,
+        }
+      : null
   const positionShare = shareOnPage(
     pageClicks.filter(e => e.position),
     e => e.position as string
@@ -1038,6 +1058,7 @@ function aggregate(
     newsletterByPage,
     newsletterShareByPage,
     listingShare,
+    anyListingShare,
     positionShare,
     filterGroupShare,
     filterValueShare,


### PR DESCRIPTION
- Clicking a preset range (Today / 7 days / 30 days / 90 days / All time) now clears the custom from/to date inputs, which previously kept showing stale dates.
- The Top listings table's Total row now fills its "% of visitors" cell: the share of the page's visitors who clicked at least one listing. Counted per distinct visitor rather than summing the rows, so a visitor who clicked several listings counts once.
- When none of the range's clicks carry a visitor ID (clicks recorded before visitor tracking began on 15 July 2026, or private browsing), the Total shows a dash instead of a misleading 0.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)