### PR TITLE
Events: In person pill first, Online gets the ?view URL

### DIFF
--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -365,16 +365,16 @@ function CitySearch({
   )
 }
 
-// Keeps the historical URLs: "In person" writes ?view=in-person (so old
-// shared links keep working) and "Online" keeps the bare URL, exactly as
-// when online was the default. The online set therefore has no URL of its
-// own — a bare link always opens the in-person default. replaceState (not
-// push) so toggling never stacks history entries; history.state is passed
-// through untouched because Next.js keeps its routing internals there.
+// "Online" writes ?view=online so the online set has a shareable URL;
+// "In person" is the default and keeps the bare URL. Old ?view=in-person
+// links still resolve to the in-person set via applyViewParam's fallback.
+// replaceState (not push) so toggling never stacks history entries;
+// history.state is passed through untouched because Next.js keeps its
+// routing internals there.
 function syncViewParam(next: Mode) {
   const url = new URL(window.location.href)
-  if (next === 'online') url.searchParams.delete('view')
-  else url.searchParams.set('view', next)
+  if (next === 'online') url.searchParams.set('view', next)
+  else url.searchParams.delete('view')
   window.history.replaceState(window.history.state, '', url)
 }
 
@@ -402,14 +402,13 @@ export default function EventsClient({ events }: EventsClientProps) {
 
   const toggleAnchorRef = useRef<HTMLDivElement>(null)
 
-  // URL -> state, fed by ViewParamSync below. A bare URL keeps the current
-  // set: switching to Online clears the param, so null can mean "online,
-  // just toggled" as well as "fresh load" (where state already holds the
-  // in-person default). Unknown values fall through to the default; a deep
-  // link doesn't auto-scroll the way a click does. Landing on online drops
-  // the city filter, mirroring switchMode.
+  // URL -> state, fed by ViewParamSync below. Only ?view=online selects the
+  // online set; anything else — the bare URL (the default, also what
+  // switching back to In person leaves behind), legacy ?view=in-person
+  // links, unknown values — resolves to in person. A deep link doesn't
+  // auto-scroll the way a click does. Landing on online drops the city
+  // filter, mirroring switchMode.
   const applyViewParam = useCallback((view: string | null) => {
-    if (view === null) return
     const next: Mode = view === 'online' ? 'online' : 'in-person'
     if (next === 'online') setSelectedCities([])
     setMode(next)
@@ -563,14 +562,14 @@ export default function EventsClient({ events }: EventsClientProps) {
           ariaLabel="Event format"
           tabs={[
             {
-              value: 'online',
-              icon: '/images/icons/computer.svg',
-              label: 'Online',
-            },
-            {
               value: 'in-person',
               icon: '/images/icons/pin.svg',
               label: 'In person',
+            },
+            {
+              value: 'online',
+              icon: '/images/icons/computer.svg',
+              label: 'Online',
             },
           ]}
         />


### PR DESCRIPTION
- The In person pill now comes first in the toggle and is the default view at the bare /events URL.
- Switching to Online writes ?view=online, so the online set has a shareable URL of its own; switching back to In person returns to the bare URL.
- Legacy ?view=in-person links still resolve to the in-person set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)