### PR TITLE
Admin: analytics-only password that hides the chatbot areas

### DIFF
--- a/src/app/admin/analytics/layout.tsx
+++ b/src/app/admin/analytics/layout.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation'
-import { canViewAnalytics, isAdmin } from '@/lib/admin/auth'
+import { canViewAnalytics, canViewChatbot } from '@/lib/admin/auth'
 import AdminHeader from '../AdminHeader'
-import { adminTabs } from '../nav'
+import { adminTabs, adminHomeHref } from '../nav'
 import styles from '../admin.module.css'
 
 export const metadata = {
@@ -14,16 +14,18 @@ export default async function AnalyticsLayout({
 }: {
   children: React.ReactNode
 }) {
-  // Owner and volunteers only. A signed-in partner holding the Successif
-  // password is sent to the chat area they're allowed to use; everyone else to
-  // the login page.
+  const chatbot = await canViewChatbot()
+  // A signed-in partner holding the Successif password is sent to the chat area
+  // they're allowed to use; everyone else to the login page.
   if (!(await canViewAnalytics())) {
-    redirect((await isAdmin()) ? '/admin/chatbot/playground' : '/admin/login')
+    redirect(chatbot ? '/admin/chatbot/playground' : '/admin/login')
   }
-  // analytics access is guaranteed here, so the Analytics tab is always present.
+  // Analytics access is guaranteed here, so the Analytics tab is always present;
+  // the chatbot tabs drop out for an analytics-only session.
+  const access = { chatbot, analytics: true }
   return (
     <>
-      <AdminHeader tabs={adminTabs(true)} />
+      <AdminHeader tabs={adminTabs(access)} brandHref={adminHomeHref(access)} />
       <main className={styles.consoleWrap}>{children}</main>
     </>
   )

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -20,6 +20,7 @@ import {
   type TopQuestion,
 } from '@/lib/analytics/conversations'
 import { readQuestionThemes, type ThemeSummary } from '@/lib/analytics/themes'
+import { canViewChatbot } from '@/lib/admin/auth'
 import {
   buildSearchIndex,
   type SearchEntry,
@@ -460,6 +461,13 @@ export default async function AnalyticsPage({
   const tabReq = tabRaw === 'funnel' ? 'chatbot' : tabRaw
   const onResourceTab = tabReq != null && !OVERVIEW_KEYS.has(tabReq)
 
+  // The Chatbot tab is transcript-derived — visitor funnel plus verbatim first
+  // messages — so an analytics-only volunteer doesn't get it: hidden from the
+  // tab bar below, data left unfetched here, and a bookmarked ?tab=chatbot
+  // falls back to the default tab rather than rendering an empty panel.
+  const showChatbotTab = await canViewChatbot()
+  const onChatbotTab = tabReq === 'chatbot' && showChatbotTab
+
   const [data, funders, convStats, themes, searchIndex] = await Promise.all([
     readDashboard(
       range,
@@ -470,8 +478,8 @@ export default async function AnalyticsPage({
     getFunders().catch(() => []),
     // The transcript-derived stats only render on the Chatbot tab, so only
     // fetch the (ever-growing) conversation log when it's the active tab.
-    tabReq === 'chatbot' ? readConversationStats(range) : null,
-    tabReq === 'chatbot' ? readQuestionThemes() : null,
+    onChatbotTab ? readConversationStats(range) : null,
+    onChatbotTab ? readQuestionThemes() : null,
     // Resolves clicked search results to their resource page; only the Search
     // tab reads it. On error the page icons resolve from recorded types alone.
     tabReq === 'search'
@@ -498,7 +506,13 @@ export default async function AnalyticsPage({
 
   // Resolve the active tab: the requested one if it's a real tab, else the
   // default overview ('pages'). onResourceView gates the per-page panels.
-  const tabKeys = new Set<string>([...OVERVIEW_KEYS, ...resourceNames])
+  const overviewTabs = showChatbotTab
+    ? OVERVIEW_TABS
+    : OVERVIEW_TABS.filter(t => t.key !== 'chatbot')
+  const tabKeys = new Set<string>([
+    ...overviewTabs.map(t => t.key),
+    ...resourceNames,
+  ])
   const activeTab = tabReq && tabKeys.has(tabReq) ? tabReq : 'pages'
   const onResourceView = !OVERVIEW_KEYS.has(activeTab)
 
@@ -705,7 +719,7 @@ export default async function AnalyticsPage({
       ) : (
         <>
           <DashboardTabs
-            overview={OVERVIEW_TABS}
+            overview={overviewTabs}
             pages={resourceTabs}
             active={activeTab}
             params={sp}

--- a/src/app/admin/chatbot/layout.tsx
+++ b/src/app/admin/chatbot/layout.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation'
-import { canViewAnalytics, isAdmin } from '@/lib/admin/auth'
+import { canViewAnalytics, canViewChatbot } from '@/lib/admin/auth'
 import AdminHeader from '../AdminHeader'
-import { adminTabs } from '../nav'
+import { adminTabs, adminHomeHref } from '../nav'
 import styles from '../admin.module.css'
 
 export default async function ChatbotAdminLayout({
@@ -9,14 +9,18 @@ export default async function ChatbotAdminLayout({
 }: {
   children: React.ReactNode
 }) {
-  if (!(await isAdmin())) {
-    redirect('/admin/login')
+  const analytics = await canViewAnalytics()
+  // A signed-in analytics-only volunteer is sent to the dashboard they're
+  // allowed to use; everyone else to the login page.
+  if (!(await canViewChatbot())) {
+    redirect(analytics ? '/admin/analytics' : '/admin/login')
   }
-  // adminTabs() hides the Analytics tab from sessions that can't reach it
-  // (e.g. Successif; owner and volunteers see it).
+  // Chatbot access is guaranteed here; adminTabs() still hides the Analytics tab
+  // from sessions that can't reach it (e.g. Successif).
+  const access = { chatbot: true, analytics }
   return (
     <>
-      <AdminHeader tabs={adminTabs(await canViewAnalytics())} />
+      <AdminHeader tabs={adminTabs(access)} brandHref={adminHomeHref(access)} />
       <main className={styles.consoleWrap}>{children}</main>
     </>
   )

--- a/src/app/admin/login/LoginForm.tsx
+++ b/src/app/admin/login/LoginForm.tsx
@@ -26,7 +26,9 @@ export default function LoginForm() {
         setBusy(false)
         return
       }
-      router.push('/admin/chatbot/playground')
+      // /admin bounces to the first area this password opens — the playground
+      // for most, the dashboard for an analytics-only volunteer.
+      router.push('/admin')
       router.refresh()
     } catch {
       setError('Network error')

--- a/src/app/admin/nav.ts
+++ b/src/app/admin/nav.ts
@@ -9,18 +9,32 @@ export interface AdminNavTab {
   group: 'chatbot' | 'analytics'
 }
 
-/** Tabs shown in the admin header. Playground and Conversation Log always show;
- *  the Analytics tab is only included when the session may reach
- *  /admin/analytics (owner and volunteer passwords; the shared Successif
- *  password can't). */
-export function adminTabs(analytics: boolean): AdminNavTab[] {
+export interface AdminAccess {
+  /** Session may reach /admin/chatbot/* (every password but analytics-only). */
+  chatbot: boolean
+  /** Session may reach /admin/analytics (every password but Successif). */
+  analytics: boolean
+}
+
+/** Tabs shown in the admin header, limited to the areas this session can
+ *  actually open — a tab the session would only be bounced out of is worse than
+ *  no tab at all. */
+export function adminTabs({ chatbot, analytics }: AdminAccess): AdminNavTab[] {
   return [
-    {
-      href: '/admin/chatbot/playground',
-      label: 'Playground',
-      group: 'chatbot',
-    },
-    { href: '/admin/chatbot/log', label: 'Conversation Log', group: 'chatbot' },
+    ...(chatbot
+      ? [
+          {
+            href: '/admin/chatbot/playground',
+            label: 'Playground',
+            group: 'chatbot' as const,
+          },
+          {
+            href: '/admin/chatbot/log',
+            label: 'Conversation Log',
+            group: 'chatbot' as const,
+          },
+        ]
+      : []),
     ...(analytics
       ? [
           {
@@ -31,4 +45,13 @@ export function adminTabs(analytics: boolean): AdminNavTab[] {
         ]
       : []),
   ]
+}
+
+/** Where a session should land when it has no particular destination: the
+ *  first area it can open. Used for the header brand link and the post-login
+ *  bounce so nobody is sent somewhere they'll be redirected out of. */
+export function adminHomeHref({ chatbot, analytics }: AdminAccess): string {
+  if (chatbot) return '/admin/chatbot/playground'
+  if (analytics) return '/admin/analytics'
+  return '/admin/login'
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,11 +1,14 @@
 import { redirect } from 'next/navigation'
-import { isAdmin } from '@/lib/admin/auth'
+import { canViewAnalytics, canViewChatbot } from '@/lib/admin/auth'
+import { adminHomeHref } from './nav'
 
-// /admin is an index that bounces to the right place: the playground when
-// already authenticated, otherwise the login page.
+// /admin is an index that bounces to the right place: the first area this
+// session can open, or the login page when it can't open any.
 export default async function AdminIndexPage() {
-  if (await isAdmin()) {
-    redirect('/admin/chatbot/playground')
-  }
-  redirect('/admin/login')
+  redirect(
+    adminHomeHref({
+      chatbot: await canViewChatbot(),
+      analytics: await canViewAnalytics(),
+    })
+  )
 }

--- a/src/app/api/admin/auth/route.ts
+++ b/src/app/api/admin/auth/route.ts
@@ -21,7 +21,8 @@ export async function POST(req: NextRequest) {
     })
   }
   // checkAdminPassword has confirmed this is one of the accepted passwords;
-  // mint the cookie derived from it so isAdmin() recognises the session.
+  // mint the cookie derived from it so the capability checks recognise the
+  // session and grant exactly the areas this password opens.
   await setAdminCookie(body.password as string)
   return new Response(JSON.stringify({ ok: true }), {
     headers: { 'Content-Type': 'application/json' },

--- a/src/app/api/admin/conversations/route.ts
+++ b/src/app/api/admin/conversations/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server'
-import { isAdmin } from '@/lib/admin/auth'
+import { canViewChatbot } from '@/lib/admin/auth'
 import {
   isConversationsTableConfigured,
   listConversationsPage,
@@ -23,7 +23,7 @@ function collectCardIds(text: string, into: Set<string>): void {
 const REC_RE = /rec[A-Za-z0-9]+/
 
 async function ensureAuth(): Promise<Response | null> {
-  if (!(await isAdmin())) {
+  if (!(await canViewChatbot())) {
     return new Response(JSON.stringify({ error: 'unauthorized' }), {
       status: 401,
       headers: { 'Content-Type': 'application/json' },

--- a/src/app/api/admin/test-run/route.ts
+++ b/src/app/api/admin/test-run/route.ts
@@ -1,6 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { NextRequest } from 'next/server'
-import { isAdmin } from '@/lib/admin/auth'
+import { canViewChatbot } from '@/lib/admin/auth'
 import { getCatalog } from '@/lib/assistant/catalog'
 import {
   PAGES_BLOCK,
@@ -22,7 +22,7 @@ export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: NextRequest) {
-  if (!(await isAdmin())) {
+  if (!(await canViewChatbot())) {
     return new Response(JSON.stringify({ error: 'unauthorized' }), {
       status: 401,
       headers: { 'Content-Type': 'application/json' },

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -5,18 +5,40 @@ const COOKIE_NAME = 'aisafety_admin'
 // 30 days. Re-auth when expired.
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 30
 
-/** Passwords that grant admin access: the primary owner password plus optional
- *  shareable ones (a "successif…" password for the partner reviewing chat logs,
- *  a "volunteer…" password for site volunteers). Each lives in its own env var,
- *  so any one can be revoked on its own — drop the env var and that password
- *  (and any cookie derived from it) stops working immediately, while the others
- *  are untouched. */
+interface PasswordRole {
+  /** Env var holding the password. Unset or empty means this role is disabled. */
+  env: string
+  /** May open the playground and conversation log, and read chat transcripts. */
+  chatbot: boolean
+  /** May open the analytics dashboard. */
+  analytics: boolean
+}
+
+/** Every password that grants admin access, and the areas each one opens. Each
+ *  lives in its own env var, so any one can be revoked on its own — drop the env
+ *  var and that password (and any cookie derived from it) stops working
+ *  immediately, while the others are untouched. */
+const PASSWORD_ROLES: PasswordRole[] = [
+  // Primary owner password: the whole admin.
+  { env: 'ADMIN_PASSWORD', chatbot: true, analytics: true },
+  // Partner reviewing chat logs: chat areas only, no analytics.
+  { env: 'ADMIN_PASSWORD_SUCCESSIF', chatbot: true, analytics: false },
+  // Site volunteers: the whole admin.
+  { env: 'ADMIN_PASSWORD_VOLUNTEER', chatbot: true, analytics: true },
+  // Analytics-only volunteers: the dashboard, with the chat areas out of reach.
+  { env: 'ADMIN_PASSWORD_ANALYTICS', chatbot: false, analytics: true },
+]
+
+/** Configured passwords whose role satisfies `grants`. Roles left unconfigured
+ *  drop out, so every caller fails closed on an empty list. */
+function passwordsWhere(grants: (role: PasswordRole) => boolean): string[] {
+  return PASSWORD_ROLES.filter(grants)
+    .map(role => process.env[role.env])
+    .filter((p): p is string => typeof p === 'string' && p.length > 0)
+}
+
 function validPasswords(): string[] {
-  return [
-    process.env.ADMIN_PASSWORD,
-    process.env.ADMIN_PASSWORD_SUCCESSIF,
-    process.env.ADMIN_PASSWORD_VOLUNTEER,
-  ].filter((p): p is string => typeof p === 'string' && p.length > 0)
+  return passwordsWhere(() => true)
 }
 
 /** Cookie value derived from a password. Forging the cookie therefore requires
@@ -28,29 +50,33 @@ function cookieValueFor(password: string): string {
     .digest('hex')
 }
 
-export async function isAdmin(): Promise<boolean> {
-  const accepted = validPasswords().map(cookieValueFor)
+/** True when the session's cookie was derived from one of `passwords`. */
+async function sessionHolds(passwords: string[]): Promise<boolean> {
+  const accepted = passwords.map(cookieValueFor)
   if (accepted.length === 0) return false
   const c = await cookies()
   const got = c.get(COOKIE_NAME)?.value
   return got != null && accepted.includes(got)
 }
 
-/** True when the session was authenticated with a password allowed into the
- *  analytics dashboard: the primary owner password or the shared volunteer
- *  password. The Successif password is deliberately excluded — that partner
- *  reviews chat logs only. Fails closed if neither password is configured. */
+/** Signed in with any accepted password. Use this only to tell "signed in" from
+ *  "signed out" — for anything gating a section of the admin, ask the specific
+ *  capability instead, since not every password reaches every area. */
+export async function isAdmin(): Promise<boolean> {
+  return sessionHolds(validPasswords())
+}
+
+/** True when the session may use the playground and conversation log, and read
+ *  chat transcripts. The analytics-only password is deliberately excluded — that
+ *  volunteer sees the dashboard and nothing else. */
+export async function canViewChatbot(): Promise<boolean> {
+  return sessionHolds(passwordsWhere(role => role.chatbot))
+}
+
+/** True when the session may open the analytics dashboard. The Successif
+ *  password is deliberately excluded — that partner reviews chat logs only. */
 export async function canViewAnalytics(): Promise<boolean> {
-  const accepted = [
-    process.env.ADMIN_PASSWORD,
-    process.env.ADMIN_PASSWORD_VOLUNTEER,
-  ]
-    .filter((p): p is string => typeof p === 'string' && p.length > 0)
-    .map(cookieValueFor)
-  if (accepted.length === 0) return false
-  const c = await cookies()
-  const got = c.get(COOKIE_NAME)?.value
-  return got != null && accepted.includes(got)
+  return sessionHolds(passwordsWhere(role => role.analytics))
 }
 
 export async function setAdminCookie(password: string): Promise<void> {


### PR DESCRIPTION
- Adds `ADMIN_PASSWORD_ANALYTICS`, a fourth admin password that opens the analytics dashboard only — for volunteers who help with analytics but shouldn't be reading visitor conversations. Set in Vercel across Production, Preview and Development.
- Replaces the flat password list in `src/lib/admin/auth.ts` with a `PASSWORD_ROLES` table declaring each password's reach, so adding a tier is one row rather than edits in several places.
- Splits `canViewChatbot()` out of `isAdmin()`. `isAdmin()` had been doing double duty as both "signed in" and "may use the chatbot area", which was safe only while every password opened everything; without the split the new password would have been able to read chat transcripts through `/api/admin/conversations`. The playground, conversation log, and the conversations and test-run APIs now gate on the capability rather than on being signed in. `isAdmin()` remains as the signed-in-or-not primitive.
- Hides the analytics dashboard's own **Chatbot** tab from analytics-only sessions. That tab is transcript-derived — visitor funnel plus verbatim first messages typed to the bot — so leaving it visible would have defeated the point. Its data is left unfetched, and a bookmarked `?tab=chatbot` or the legacy `?tab=funnel` falls back to the default tab.
- After login, and from the header brand link, each session now goes to the first area it can actually open instead of assuming the playground.

Verified locally against all four passwords: header tabs, redirects for every `/admin` route, dashboard tab filtering, and API responses. Owner and volunteer keep full access; Successif is unchanged (chat areas, no analytics); the new password reaches only the dashboard and gets 401 from the conversations API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)