### PR TITLE
Analytics: show the Chatbot tab to analytics-only sessions

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -20,7 +20,6 @@ import {
   type TopQuestion,
 } from '@/lib/analytics/conversations'
 import { readQuestionThemes, type ThemeSummary } from '@/lib/analytics/themes'
-import { canViewChatbot } from '@/lib/admin/auth'
 import {
   buildSearchIndex,
   type SearchEntry,
@@ -461,13 +460,6 @@ export default async function AnalyticsPage({
   const tabReq = tabRaw === 'funnel' ? 'chatbot' : tabRaw
   const onResourceTab = tabReq != null && !OVERVIEW_KEYS.has(tabReq)
 
-  // The Chatbot tab is transcript-derived — visitor funnel plus verbatim first
-  // messages — so an analytics-only volunteer doesn't get it: hidden from the
-  // tab bar below, data left unfetched here, and a bookmarked ?tab=chatbot
-  // falls back to the default tab rather than rendering an empty panel.
-  const showChatbotTab = await canViewChatbot()
-  const onChatbotTab = tabReq === 'chatbot' && showChatbotTab
-
   const [data, funders, convStats, themes, searchIndex] = await Promise.all([
     readDashboard(
       range,
@@ -478,8 +470,8 @@ export default async function AnalyticsPage({
     getFunders().catch(() => []),
     // The transcript-derived stats only render on the Chatbot tab, so only
     // fetch the (ever-growing) conversation log when it's the active tab.
-    onChatbotTab ? readConversationStats(range) : null,
-    onChatbotTab ? readQuestionThemes() : null,
+    tabReq === 'chatbot' ? readConversationStats(range) : null,
+    tabReq === 'chatbot' ? readQuestionThemes() : null,
     // Resolves clicked search results to their resource page; only the Search
     // tab reads it. On error the page icons resolve from recorded types alone.
     tabReq === 'search'
@@ -506,13 +498,7 @@ export default async function AnalyticsPage({
 
   // Resolve the active tab: the requested one if it's a real tab, else the
   // default overview ('pages'). onResourceView gates the per-page panels.
-  const overviewTabs = showChatbotTab
-    ? OVERVIEW_TABS
-    : OVERVIEW_TABS.filter(t => t.key !== 'chatbot')
-  const tabKeys = new Set<string>([
-    ...overviewTabs.map(t => t.key),
-    ...resourceNames,
-  ])
+  const tabKeys = new Set<string>([...OVERVIEW_KEYS, ...resourceNames])
   const activeTab = tabReq && tabKeys.has(tabReq) ? tabReq : 'pages'
   const onResourceView = !OVERVIEW_KEYS.has(activeTab)
 
@@ -713,7 +699,7 @@ export default async function AnalyticsPage({
       ) : (
         <>
           <DashboardTabs
-            overview={overviewTabs}
+            overview={OVERVIEW_TABS}
             pages={resourceTabs}
             active={activeTab}
             params={sp}


### PR DESCRIPTION
- The analytics dashboard's **Chatbot** tab is aggregate — funnel, conversation counts, length buckets, languages, suggested-chip usage, clicked-from-replies. The only visitor-typed content on it is up to three short first-message snippets per theme in "What people ask about". No transcripts, no follow-up messages.
- On that basis it's fine for an analytics-only volunteer to see, so this reverts the tab gating added in #527.
- The chatbot admin areas themselves are unchanged: `/admin/chatbot/playground` and `/admin/chatbot/log` still redirect analytics-only sessions to the dashboard, and the conversations and test-run APIs still refuse them.

Verified locally across all four passwords: the analytics-only password now sees the Chatbot tab and its panels while still being redirected away from the playground and conversation log and still getting 401 from `/api/admin/conversations`. Owner and Successif behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)