### PR TITLE
Events: pass over closed-applications events in the featured row

### DIFF
--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -433,7 +433,13 @@ export default function EventsClient({ events }: EventsClientProps) {
     [events, mode]
   )
 
-  const featuredEvents = useMemo(() => selectFeatured(modeEvents), [modeEvents])
+  // Events whose applications/registrations closed (competitions can run for
+  // months after their deadline) are passed over when an open backup is
+  // queued behind them, matching /training.
+  const featuredEvents = useMemo(
+    () => selectFeatured(modeEvents, e => e.applicationStatus === 'Open'),
+    [modeEvents]
+  )
 
   // Each event's slot in the full (unfiltered) order of the active mode, so a
   // click is tagged with the rank the visitor saw — not its position within an

--- a/src/lib/assistant/catalog.ts
+++ b/src/lib/assistant/catalog.ts
@@ -307,7 +307,9 @@ export async function buildCatalog(): Promise<Catalog> {
     })
   }
 
-  const featuredEventIds = displayedIds(selectFeatured(events))
+  const featuredEventIds = displayedIds(
+    selectFeatured(events, e => e.applicationStatus === 'Open')
+  )
   const featuredTrainingIds = displayedIds(
     selectFeatured(trainingPrograms, p => p.applicationStatus === 'Open')
   )


### PR DESCRIPTION
- The /events featured row now passes over events whose applications/registrations have closed when an open backup is queued behind them – the same rule /training already used. A closed entry still fills a slot when nothing better is queued, so the row keeps two cards for as long as the queue allows.
- The assistant catalog's `featured` flag for events uses the same selection, so the chatbot's curated top picks stay in sync with the page.
- Why: on 13 August the queue keeper auto-promoted the Lie Detection Competition (apply by 31 March, running until 31 August) into a live featured slot – nothing on the events side checked application status, so the page showed a featured card reading "Apply by 31 Mar 2026".
- Verified on localhost against live data: with an open backup temporarily benched at rank 3, the featured row showed ranks 1 and 3 and skipped the closed rank 2; with no backup queued, the row is unchanged. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)