### PR TITLE
Events: feature hybrid events under Online only

### DIFF
--- a/src/app/events/EventsClient.tsx
+++ b/src/app/events/EventsClient.tsx
@@ -435,10 +435,18 @@ export default function EventsClient({ events }: EventsClientProps) {
 
   // Events whose applications/registrations closed (competitions can run for
   // months after their deadline) are passed over when an open backup is
-  // queued behind them, matching /training.
+  // queued behind them, matching /training. Hybrid events are featured under
+  // Online only — in the In person view they appear in the grid but never in
+  // the featured row.
   const featuredEvents = useMemo(
-    () => selectFeatured(modeEvents, e => e.applicationStatus === 'Open'),
-    [modeEvents]
+    () =>
+      selectFeatured(
+        mode === 'online'
+          ? modeEvents
+          : modeEvents.filter(e => e.mode !== 'Hybrid'),
+        e => e.applicationStatus === 'Open'
+      ),
+    [modeEvents, mode]
   )
 
   // Each event's slot in the full (unfiltered) order of the active mode, so a


### PR DESCRIPTION
- Hybrid events appear on both the Online and In person views of /events, and the featured row was picked from each view's full set — so a featured hybrid event (currently the AI Incident Response Sprint) took a featured slot on both sides.
- The featured row now treats hybrid events as Online only: the In person view skips them when selecting its two featured cards.
- Hybrid events still appear in the In person grid as before — they just can't occupy that view's featured slots.
- Follow-up after deploy: matching update to the local featured-queue keeper, which currently counts hybrid records in both view queues for rank compaction and bench warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)