### PR TITLE
Homepage: BlueDot button links to /courses, "two main tracks"

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -239,11 +239,11 @@ export default async function Home() {
             </div>
             <p className="padding-bottom-24px">
               Learn key concepts and research perspectives in AI safety, split
-              into two tracks.
+              into two main tracks.
             </p>
             <div className="block">
               <TrackedLink
-                href="https://bluedot.org/"
+                href="https://bluedot.org/courses"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="button-secondary"


### PR DESCRIPTION
- "View curricula" button on the homepage BlueDot Impact card now links to https://bluedot.org/courses (was https://bluedot.org/)
- Card description now reads "…split into two main tracks."

🤖 Generated with [Claude Code](https://claude.com/claude-code)