### PR TITLE
Hackathon: applications closed, late applications still considered

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,5 +24,5 @@ The site does not publish articles or research. It is a directory and discovery 
 ## Other Pages
 
 - [About](https://aisafety.com/about): Information about the team, mission, and how to get involved
-- [Hackathon 2026](https://aisafety.com/hackathon): The annual AISafety.com hackathon – event details and signup
+- [Hackathon 2026](https://aisafety.com/hackathon): The annual AISafety.com hackathon – event details and application form (applications closed 14 August 2026; late applications from very strong candidates may still be considered)
 - [AISafety.info](https://aisafety.info): Sister site explaining what AI safety is, why it matters, and what you can do to help

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -73,8 +73,9 @@ export default function ApplicationForm() {
       <div className="padding-bottom-56px">
         <h3 className="padding-bottom-16px">Thanks!</h3>
         <p className="color-teal-300">
-          We&apos;ve emailed you a confirmation. Application results will be
-          announced by 21 August.
+          We&apos;ve emailed you a confirmation. Since applications have
+          officially closed, we can&apos;t promise a decision, but we&apos;ll be
+          in touch if we&apos;re able to offer you a place.
         </p>
       </div>
     )
@@ -85,6 +86,17 @@ export default function ApplicationForm() {
       className={`${styles.fields} padding-bottom-56px`}
       onSubmit={handleSubmit}
     >
+      {/* Applications closed 14 August 2026; the form stays up for late
+          applications from very strong candidates. */}
+      <div className={`${styles.full} padding-bottom-8px`}>
+        <h3 className="padding-bottom-16px">Applications have closed</h3>
+        <p className="color-teal-300">
+          The deadline was 14 August, but if you think you&apos;d be a very
+          strong fit, you&apos;re welcome to submit a late application below and
+          we may still consider it.
+        </p>
+      </div>
+
       <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="name">
           Name

--- a/src/app/hackathon/ApplicationForm.tsx
+++ b/src/app/hackathon/ApplicationForm.tsx
@@ -88,14 +88,9 @@ export default function ApplicationForm() {
     >
       {/* Applications closed 14 August 2026; the form stays up for late
           applications from very strong candidates. */}
-      <div className={`${styles.full} padding-bottom-8px`}>
-        <h3 className="padding-bottom-16px">Applications have closed</h3>
-        <p className="color-teal-300">
-          The deadline was 14 August, but if you think you&apos;d be a very
-          strong fit, you&apos;re welcome to submit a late application below and
-          we may still consider it.
-        </p>
-      </div>
+      <h3 className={`${styles.full} padding-bottom-8px`}>
+        Applications have closed
+      </h3>
 
       <div className={`${styles.field} ${styles.full}`}>
         <label className="paragraph-small color-teal-300" htmlFor="name">

--- a/src/app/hackathon/page.tsx
+++ b/src/app/hackathon/page.tsx
@@ -6,7 +6,7 @@ const OG_DESCRIPTION = 'A four-day, in-person hackathon to improve the site.'
 export const metadata = {
   title: 'Hackathon 2026 – AISafety.com',
   description:
-    'Join the AISafety.com team at CEEALAR in Blackpool, England, 17–20 September 2026, for a four-day hackathon to improve the site. Free to attend – applications close 14 August.',
+    'Join the AISafety.com team at CEEALAR in Blackpool, England, 17–20 September 2026, for a four-day hackathon to improve the site. Free to attend – applications closed 14 August 2026.',
   alternates: { canonical: '/hackathon' },
   openGraph: {
     title: 'AISafety.com Hackathon 2026',
@@ -63,9 +63,10 @@ export default function HackathonPage() {
             Free, including accommodation and all meals
           </p>
           <p className="padding-bottom-40px">
-            <strong>Applications close</strong>
+            <strong>Applications closed</strong>
             <br />
-            14 August 2026 (decisions by 21 August)
+            14 August 2026 (decisions by 21 August). We may still consider late
+            applications from very strong candidates.
           </p>
 
           <p className="color-teal-300 padding-bottom-40px">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -57,7 +57,7 @@ export default function Footer() {
               <FooterLink
                 href="/hackathon"
                 section="Help us out"
-                label="Join the hackathon"
+                label="Hackathon 2026"
               />
             </div>
           </div>

--- a/src/lib/assistant/pages.ts
+++ b/src/lib/assistant/pages.ts
@@ -201,7 +201,7 @@ export const PAGES: PageInfo[] = [
   When: Thursday 17th September – Sunday 20th September 2026.
   Where: CEEALAR (the EA Hotel) in Blackpool, England.
   Cost: Free, including accommodation and all meals. Travel in general isn't covered, but for very strong applicants it may be considered.
-  Applications close: 14 August 2026 (decisions by 21 August), via the form on this page (asks for name, email, skills/experience, personal links, anything else).
+  Applications: CLOSED on 14 August 2026 (decisions by 21 August). We may still consider late applications from very strong candidates – the form on this page (asks for name, email, skills/experience, personal links, anything else) still accepts late applications, but no decision or decision date is promised. Don't tell people applications are open or encourage everyone to apply; do say that someone who thinks they'd be a very strong fit is welcome to submit a late application.
   Once a year, the core AISafety.com team gets together with a group of amazing volunteers and spends an extended weekend getting a bunch of stuff done to improve the site. We also do some relaxed fun activities between work sessions.
   Who we're looking for: Product managers and designers – to execute the vision for new projects, build out design mockups, conduct user research, offer consulting, and brainstorm product solutions. Project managers – to lead and organize project efforts and run sprints. Developers – to work with product managers, designers, and AI tools to bring some amazing new things to life. Connectors, people with an audience, and subject-matter experts – to help us with targeted community outreach, general outreach, social media, and to give takes to product managers and designers. Promotion people – to help us spread awareness of the site and each resource page in various ways, maybe including SEO. Anything else – just tell us how you can help!
   On the first day of the hackathon we will divide everyone into small teams by project (the project list: https://app.notion.com/p/15aaef8c3f9640018d6b256d39b4ee8a?pvs=21). Participants will get to decide which projects they work on and in what way they contribute. We're also open to new project suggestions.
@@ -210,11 +210,11 @@ export const PAGES: PageInfo[] = [
     audience:
       'Volunteers who want to spend a long weekend improving AISafety.com in person.',
     greeting:
-      'Curious about the hackathon? Ask me anything about the event – and if you want in, the application form is right on this page.',
+      'Curious about the hackathon? Ask me anything about the event. Applications closed on 14 August, but very strong late applicants may still be considered.',
     chips: [
       'What happens at the hackathon?',
       'Who is the hackathon looking for?',
-      'When do applications close?',
+      'Can I still apply?',
     ],
   },
   {

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -2,7 +2,7 @@ import { PAGES, greetingFor } from './pages'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-08-12-01'
+export const PROMPT_VERSION = '2026-08-16-01'
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset


### PR DESCRIPTION
- /hackathon: "Applications close" → "Applications closed – 14 August 2026 (decisions by 21 August). We may still consider late applications from very strong candidates."
- Form stays live for late applications, with just an "Applications have closed" heading above the fields (no extra paragraph)
- Thank-you message no longer promises a decision by 21 August
- Meta description says applications closed 14 August 2026
- Chatbot /hackathon context, greeting, and chip updated ("Can I still apply?"); PROMPT_VERSION bumped to 2026-08-16-01
- llms.txt line updated
- Footer link relabelled "Join the hackathon" → "Hackathon 2026"

🤖 Generated with [Claude Code](https://claude.com/claude-code)