### PR TITLE
Show chatbot reply ratings on the analytics dashboard

### DIFF
--- a/src/app/admin/analytics/analytics.module.css
+++ b/src/app/admin/analytics/analytics.module.css
@@ -690,6 +690,11 @@
   gap: 8px;
 }
 
+/* A table sitting under a row of stat tiles in the same panel. */
+.tileTable {
+  margin-top: 16px;
+}
+
 .funnelStage {
   flex: 1;
   min-width: 120px;

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import {
   readDashboard,
   sourceSlug,
+  PAGE_NAME_BY_PATH,
   type Counted,
   type DateRange,
   type ChatbotFunnel,
@@ -17,6 +18,7 @@ import {
 import {
   readConversationStats,
   type ConversationStats,
+  type RatedReply,
   type TopQuestion,
 } from '@/lib/analytics/conversations'
 import { readQuestionThemes, type ThemeSummary } from '@/lib/analytics/themes'
@@ -399,6 +401,9 @@ function labelFor(e: {
     return e.query ? `Searched for “${e.query}”` : 'Searched'
   if (e.type === 'filter_apply')
     return `Filtered by ${e.source ?? '?'}: ${e.label ?? '?'}`
+  // A rating's label is the bare value ('up' | 'down'), so spell it out.
+  if (e.type === 'chatbot_rating')
+    return e.label === 'up' ? 'Rated a reply 👍' : 'Rated a reply 👎'
   // search_click carries the result's title as its label, like listing clicks.
   return e.label ?? EVENT_LABELS[e.type] ?? e.type
 }
@@ -1798,6 +1803,38 @@ function ChatbotView({
 
       {conv?.available && (
         <>
+          <Panel title="Reply ratings">
+            <div className={styles.funnel}>
+              <Stat
+                label="replies rated 👍"
+                value={conv.ratedUp.toLocaleString()}
+              />
+              <Stat
+                label="replies rated 👎"
+                value={conv.ratedDown.toLocaleString()}
+              />
+              <Stat
+                label="of rated replies got a thumbs up"
+                value={share(conv.thumbsUpShare)}
+              />
+              <Stat
+                label="of conversations included a rating"
+                value={share(conv.ratedConversationShare)}
+              />
+            </div>
+            <div className={styles.tileTable}>
+              <RatedRepliesTable rows={conv.ratedReplies} />
+            </div>
+            <p className={styles.caption}>
+              Thumbs ratings visitors gave the chatbot&apos;s replies, from the
+              conversation log, for conversations started in the selected date
+              range. Each reply counts once, under its latest rating (switching
+              thumbs overwrites). The table lists every rated reply, newest
+              first; a reply that has scrolled out of a long conversation&apos;s
+              stored transcript keeps its rating but not its text.
+            </p>
+          </Panel>
+
           <div className={styles.grid}>
             <Panel title="Conversation length">
               <CountTable
@@ -2026,6 +2063,67 @@ function QuestionsTable({
             </td>
             <td className={styles.numCol}>{r.count.toLocaleString()}</td>
             <td className={styles.pctCol}>{pct1(r.count, total)}</td>
+          </tr>
+        ))}
+      </SortableTable>
+      {allRows.length > rows.length && (
+        <TruncationNote shown={rows.length} of={allRows.length} />
+      )}
+    </>
+  )
+}
+
+/** Longest a question or reply snippet gets in the rated-replies table. */
+const SNIPPET_CHARS = 220
+
+function snippet(text: string): string {
+  return text.length > SNIPPET_CHARS
+    ? `${text.slice(0, SNIPPET_CHARS - 1).trimEnd()}…`
+    : text
+}
+
+/** Every rated reply in the range, newest first: when, which thumb, the
+ *  visitor's question with the reply beneath it, and the page the chat was
+ *  on. Sortable by time, rating and page. */
+function RatedRepliesTable({ rows: allRows }: { rows: RatedReply[] }) {
+  if (allRows.length === 0)
+    return <p className={styles.dim}>No ratings in this range yet.</p>
+  const rows = allRows.slice(0, MAX_TABLE_ROWS)
+  return (
+    <>
+      <SortableTable
+        columns={[
+          { label: 'Visitor asked → chatbot replied' },
+          { label: 'Rating', className: styles.numCol, sort: 'text' },
+          { label: 'Page', className: styles.numCol, sort: 'text' },
+          { label: 'When', className: styles.numCol, sort: 'text' },
+        ]}
+        values={rows.map(r => [null, r.rating, r.page, r.at])}
+      >
+        {rows.map((r, i) => (
+          <tr key={i}>
+            <td>
+              {r.question != null && r.reply != null ? (
+                <>
+                  <div>{snippet(r.question)}</div>
+                  <div className={styles.dim}>{snippet(r.reply)}</div>
+                </>
+              ) : (
+                <div className={styles.dim}>
+                  Reply text not in the stored transcript
+                </div>
+              )}
+            </td>
+            <td
+              className={styles.numCol}
+              title={r.rating === 'up' ? 'Thumbs up' : 'Thumbs down'}
+            >
+              {r.rating === 'up' ? '👍' : '👎'}
+            </td>
+            <td className={styles.numCol}>
+              {r.page ? (PAGE_NAME_BY_PATH[r.page] ?? r.page) : '—'}
+            </td>
+            <td className={styles.numCol}>{formatTime(r.at)}</td>
           </tr>
         ))}
       </SortableTable>

--- a/src/lib/admin/airtable.ts
+++ b/src/lib/admin/airtable.ts
@@ -334,8 +334,8 @@ export async function listConversationsPage(opts: {
 
 /** Every conversation created inside the given window (epoch-ms bounds, either
  *  side open), fetched with only the fields the analytics dashboard's chatbot
- *  panels read — Data (the transcript) and Clicked — so the payload stays as
- *  small as the ever-growing log allows. */
+ *  panels read — Data (the transcript), Clicked and Ratings — so the payload
+ *  stays as small as the ever-growing log allows. */
 export async function listConversationsForStats(range: {
   startMs: number | null
   endMs: number | null
@@ -362,6 +362,7 @@ export async function listConversationsForStats(range: {
   params.set('returnFieldsByFieldId', 'true')
   params.append('fields[]', FIELD.data)
   params.append('fields[]', FIELD.clicked)
+  params.append('fields[]', FIELD.ratings)
   const rows = await listAll<ConversationFields>(CONVERSATIONS_TABLE, params)
   return rows.map(rowToConversation)
 }

--- a/src/lib/analytics/conversations.ts
+++ b/src/lib/analytics/conversations.ts
@@ -5,11 +5,12 @@
 
 import { franc } from 'franc-min'
 import { PAGES, DEFAULT_CHIPS } from '@/lib/assistant/pages'
-import { extractChips } from '@/lib/assistant/tokens'
+import { extractChips, stripChipTokens } from '@/lib/assistant/tokens'
 import {
   isConversationsTableConfigured,
   listConversationsForStats,
   type ConversationRow,
+  type HistoryTurn,
 } from '@/lib/admin/airtable'
 import type { Counted, DateRange } from './events'
 
@@ -20,6 +21,22 @@ export interface TopQuestion {
   count: number
   /** True when it matches one of the chatbot's suggested-question chips. */
   suggested: boolean
+}
+
+/** One thumbs-rated bot reply, for the dashboard's rated-replies table. */
+export interface RatedReply {
+  /** When the visitor sent the message this reply answered (ISO). Falls back
+   *  to the conversation's creation time for rows without per-turn times. */
+  at: string
+  rating: 'up' | 'down'
+  /** The visitor's message the reply answered, or null when that turn has
+   *  fallen out of the stored (windowed) history. */
+  question: string | null
+  /** The reply itself as plain text (card/chip markers stripped), or null
+   *  when it's fallen out of the stored history. */
+  reply: string | null
+  /** Page the chat was open on for that turn ('/funding', …), when stored. */
+  page: string | null
 }
 
 export interface ConversationStats {
@@ -43,6 +60,18 @@ export interface ConversationStats {
   /** Share (0–1) of conversations where the visitor clicked a listing card or
    *  link out of a reply, or null with no data. */
   clickedShare: number | null
+  /** Bot replies the visitor rated thumbs up / thumbs down (each reply counts
+   *  once, under its final rating — a switched thumb overwrites). */
+  ratedUp: number
+  ratedDown: number
+  /** Share (0–1) of rated replies that got a thumbs up, or null when nothing
+   *  in the range was rated. */
+  thumbsUpShare: number | null
+  /** Share (0–1) of conversations where the visitor rated at least one reply,
+   *  or null with no data. */
+  ratedConversationShare: number | null
+  /** Every rated reply in the range, newest first. */
+  ratedReplies: RatedReply[]
   /** Conversations bucketed by how many messages the visitor sent. */
   lengthBuckets: Counted[]
   /** Conversations bucketed by auto-detected language, busiest first. */
@@ -58,6 +87,11 @@ const EMPTY_STATS: ConversationStats = {
   suggestedShare: null,
   followUpMessageShare: null,
   clickedShare: null,
+  ratedUp: 0,
+  ratedDown: 0,
+  thumbsUpShare: null,
+  ratedConversationShare: null,
+  ratedReplies: [],
   lengthBuckets: [],
   languages: [],
   topQuestions: [],
@@ -103,6 +137,79 @@ function conversationLength(row: ConversationRow): number {
     return d.turnTimes.length
   if (Array.isArray(d.tools) && d.tools.length > 0) return d.tools.length
   return userMessages(row).length
+}
+
+/** `[[card:ID|note]]` and `[[suggest:type]]` markers in a reply — dropped for
+ *  the plain-text snippet. */
+const CARD_OR_SUGGEST_TOKEN = /\[\[\s*(?:card|suggest)\s*:[^\]\n]*\]\]/gi
+/** End of the model's reasoning; the answer is what follows the LAST one
+ *  (same rule as the transcript viewer and the live renderer). */
+const THINKING_DONE = /\[\[\s*\/\s*thinking\s*\]\]/gi
+
+/** A stored reply as the readable answer: reasoning before the final
+ *  thinking marker dropped, card/suggest/chip markers removed, whitespace
+ *  collapsed. */
+function replyText(raw: string): string {
+  let answer = raw
+  let last: RegExpExecArray | null = null
+  THINKING_DONE.lastIndex = 0
+  for (let m = THINKING_DONE.exec(raw); m; m = THINKING_DONE.exec(raw)) {
+    last = m
+  }
+  if (last) answer = raw.slice(last.index + last[0].length)
+  return stripChipTokens(answer.replace(CARD_OR_SUGGEST_TOKEN, ''))
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** The per-turn entry (turn time, page) behind the message at history index
+ *  `msgIdx`. The per-turn arrays hold one entry per logged turn since the
+ *  conversation began while the history is a sliding window, so the two are
+ *  aligned from the END: the window's last user message belongs to the last
+ *  entry, and so on backwards. Same rule the Conversation Log viewer uses. */
+function turnEntryFor(
+  history: HistoryTurn[],
+  entries: unknown[],
+  msgIdx: number
+): unknown {
+  const totalUsers = history.filter(t => t.role === 'user').length
+  const usersUpToHere = history
+    .slice(0, msgIdx)
+    .filter(t => t.role === 'user').length
+  return entries[entries.length - 1 - (totalUsers - usersUpToHere)]
+}
+
+/** The rated replies on one conversation row. The rating's turn index is the
+ *  reply's position in the message list, which matches the stored history
+ *  unless the conversation outgrew the history window (or an errored turn
+ *  left the two out of step) — then the reply text can't be recovered and
+ *  the entry keeps only its rating and time. */
+function ratedRepliesOf(row: ConversationRow): RatedReply[] {
+  const out: RatedReply[] = []
+  const d = row.data
+  for (const [key, rating] of Object.entries(row.ratings)) {
+    const idx = Number(key)
+    if (!Number.isInteger(idx) || idx < 0) continue
+    const reply = d?.history[idx]
+    const question = idx > 0 ? d?.history[idx - 1] : undefined
+    const aligned = reply?.role === 'assistant' && question?.role === 'user'
+    // Look the turn up by the user message that started it (index idx - 1;
+    // the slice bound idx includes it), so the time/page belong to this reply.
+    const at = aligned
+      ? turnEntryFor(d!.history, d!.turnTimes ?? [], idx)
+      : undefined
+    const page = aligned
+      ? turnEntryFor(d!.history, d!.pages ?? [], idx)
+      : undefined
+    out.push({
+      at: typeof at === 'string' ? at : row.createdAt,
+      rating,
+      question: aligned ? question!.content : null,
+      reply: aligned ? replyText(reply!.content) : null,
+      page: typeof page === 'string' ? page : null,
+    })
+  }
+  return out
 }
 
 /** ISO 639-3 codes franc may return here, mapped to display names. Detection
@@ -309,6 +416,10 @@ export async function readConversationStats(
   let clicked = 0
   let totalMessages = 0
   let pillMessages = 0
+  let ratedUp = 0
+  let ratedDown = 0
+  let ratedConversations = 0
+  const ratedReplies: RatedReply[] = []
 
   for (const row of rows) {
     const messages = userMessages(row)
@@ -318,6 +429,13 @@ export async function readConversationStats(
       languages.push(detectLanguage(messages))
     }
     if (row.clickedCitations.length > 0) clicked += 1
+    const rated = ratedRepliesOf(row)
+    if (rated.length > 0) ratedConversations += 1
+    for (const r of rated) {
+      if (r.rating === 'up') ratedUp += 1
+      else ratedDown += 1
+      ratedReplies.push(r)
+    }
     const pills = countFollowUpMessages(row)
     totalMessages += pills.messages
     pillMessages += pills.followUps
@@ -350,6 +468,14 @@ export async function readConversationStats(
     followUpMessageShare:
       totalMessages > 0 ? pillMessages / totalMessages : null,
     clickedShare: rows.length > 0 ? clicked / rows.length : null,
+    ratedUp,
+    ratedDown,
+    thumbsUpShare:
+      ratedUp + ratedDown > 0 ? ratedUp / (ratedUp + ratedDown) : null,
+    ratedConversationShare:
+      rows.length > 0 ? ratedConversations / rows.length : null,
+    // ISO timestamps compare chronologically as strings.
+    ratedReplies: ratedReplies.sort((a, b) => (a.at < b.at ? 1 : -1)),
     // Buckets in display order (1 → 11+), only the non-empty ones.
     lengthBuckets: LENGTH_BUCKETS.map(b => ({
       name: b.label,

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1159,7 +1159,7 @@ function aggregate(
 /** Page paths as their resource-page analytics names, so page views line up
  *  with the names listing clicks already use ('/funding' and 'Funding' are the
  *  same interest). Unknown paths pass through as-is. */
-const PAGE_NAME_BY_PATH: Record<string, string> = {
+export const PAGE_NAME_BY_PATH: Record<string, string> = {
   '/': 'Home',
   '/map': 'Map',
   '/communities': 'Communities',


### PR DESCRIPTION
Admin dashboard only. Follows up #530 by surfacing the new chatbot reply ratings on the analytics Chatbot tab.

- New **Reply ratings** panel: tiles for replies rated 👍 / 👎, share of rated replies that were thumbs up, and share of conversations that included a rating.
- Beneath the tiles, a sortable table of every rated reply in the date range, newest first – the visitor's question with the bot's answer under it (reasoning and card/chip/suggest markers stripped), the thumb, the page the chat was on, and when. Show‑more past 50 rows like the other tables.
- Counted from the conversation log's `Ratings` field, so each reply counts once under its final rating and the panel is date‑range aware like its neighbours. Turn index → history/turnTimes/pages alignment mirrors the Conversation Log viewer; a rating whose reply has scrolled out of the windowed history keeps its rating and time but shows no text.
- `listConversationsForStats` now fetches `Ratings`; `readConversationStats` returns `ratedUp` / `ratedDown` / `thumbsUpShare` / `ratedConversationShare` / `ratedReplies`. `PAGE_NAME_BY_PATH` exported so the table names pages like the tab's other tables.
- Recent‑activity feed spells out `chatbot_rating` events as "Rated a reply 👍/👎" instead of the bare "up"/"down" label.

Verified on localhost with two rated test conversations (👍 on `/`, 👎 on `/funding`); type‑check, lint and build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
