### PR TITLE
Keep the last 50 messages of a chat in the conversation log

### DIFF
--- a/src/app/admin/chatbot/ConversationList.tsx
+++ b/src/app/admin/chatbot/ConversationList.tsx
@@ -493,11 +493,23 @@ function ConversationRow({
   const [notes, setNotes] = useState(conv.notes)
   const [saveStatus, setSaveStatus] = useState('')
   const data = conv.data
-  const turnCount = data?.history.filter(t => t.role === 'user').length ?? 0
+  // Visitor messages actually stored in the (windowed) history — what the
+  // transcript below can show.
+  const storedTurns = data?.history.filter(t => t.role === 'user').length ?? 0
+  // True length of the conversation: the per-turn arrays get one entry per
+  // logged turn and are never windowed, unlike history. turnTimes is the
+  // newest of them; tools counts too when it has the per-turn shape (one
+  // array per turn). Rows predating both fall back to the stored history.
+  const loggedTurns =
+    data?.turnTimes?.length ||
+    (data?.tools?.every(t => Array.isArray(t)) ? data.tools.length : 0)
+  const turnCount = loggedTurns > 0 ? loggedTurns : storedTurns
+  const missingTurns = Math.max(0, turnCount - storedTurns)
   const geo = data ? geoString(data.geo) : ''
   // Collapsed row previews the visitor's OPENING message (how they first
-  // arrived), not the most recent turn. Fall back to the latest-turn field
-  // for old rows that have no stored history.
+  // arrived), not the most recent turn — or the oldest still stored, when a
+  // long chat has outgrown the history window. Fall back to the latest-turn
+  // field for old rows that have no stored history.
   const firstUser =
     data?.history.find(t => t.role === 'user')?.content ?? data?.user ?? ''
   // Cards and links the visitor clicked. New clicks are stored turn-scoped as
@@ -688,6 +700,20 @@ function ConversationRow({
                     )
                   })}
                 </div>
+                {/* The stored history is a window (the last 50 messages; 14
+                    on rows logged before 17 Aug 2026), so a long chat's
+                    opening turns are gone from the transcript even though
+                    the per-turn arrays still count them. Say so, rather than
+                    letting the visible start read as the real one. */}
+                {missingTurns > 0 && data.history.length > 0 && (
+                  <div
+                    className={styles.convNavDivider}
+                    title="The log keeps only the most recent messages of a conversation; earlier turns were not stored"
+                  >
+                    {missingTurns} earlier turn{missingTurns === 1 ? '' : 's'}{' '}
+                    not stored
+                  </div>
+                )}
                 {data.history.length > 0 ? (
                   data.history.map((t, i) => {
                     const reads =

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -13,6 +13,7 @@ import {
   buildApiMessages,
   runAssistantStream,
   sseResponse,
+  validateLogHistory,
   validateMessages,
   type AssistantRunResult,
 } from '@/lib/assistant/stream'
@@ -86,9 +87,13 @@ export async function POST(req: NextRequest) {
     })
   }
 
+  // `messages` is the window the model sees; `logHistory` is the wider window
+  // the conversation log stores (same cleaned list, longer tail).
   let messages: ChatMessage[]
+  let logHistory: ChatMessage[]
   try {
     messages = validateMessages(body.messages)
+    logHistory = validateLogHistory(body.messages)
   } catch (err) {
     return new Response(
       JSON.stringify({
@@ -175,10 +180,13 @@ export async function POST(req: NextRequest) {
           geo: ctx.geo ?? null,
           utm: ctx.utm ?? null,
           user: userQuery,
-          // Full conversation including the assistant's just-finished reply
+          // The log's history window plus the assistant's just-finished reply
           // (empty when generation produced nothing), so the upsert persists
           // the up-to-date History in one row.
-          history: [...messages, { role: 'assistant', content: assistantText }],
+          history: [
+            ...logHistory,
+            { role: 'assistant', content: assistantText },
+          ],
           toolCalls,
           response: assistantText,
           fallbackCards: result?.fallbackCardIds ?? [],

--- a/src/lib/admin/airtable.ts
+++ b/src/lib/admin/airtable.ts
@@ -4,12 +4,14 @@
   ─── assistant_conversations ───
   ID env var: ADMIN_CONVERSATIONS_TABLE_ID
   One row per CONVERSATION (keyed by Session). Each turn updates the row
-  in place: refresh the latest fields, extend Data.history, accumulate
-  Data.tools/citations.
+  in place: refresh the latest fields, replace Data.history with the
+  latest turn's window (the widget resends the whole conversation each
+  turn; the route windows it to the last 50 messages before logging),
+  accumulate Data.tools/citations.
 
   Fields:
     Session         (single line text)  — natural key
-    Page            (single line text)  — page of the latest turn
+    Page            (single line text)  — page the conversation started on
     Latency ms      (number)            — latest turn's latency
     Prompt version  (single line text)  — latest, e.g. "2026-05-07-1"
     Notes           (long text)         — admin annotations
@@ -30,6 +32,9 @@
 const TOKEN = process.env.AIRTABLE_TOKEN
 const BASE = process.env.AIRTABLE_BASE_ID
 const CONVERSATIONS_TABLE = process.env.ADMIN_CONVERSATIONS_TABLE_ID
+// Ceiling for the serialized Data JSON, under Airtable's 100,000-character
+// long-text limit with margin. See upsertConversation.
+const MAX_DATA_CHARS = 90_000
 
 // Permanent Airtable field IDs for the conversations table. All reads set
 // returnFieldsByFieldId and all writes key fields by ID, so renaming a
@@ -127,6 +132,12 @@ export interface StoredCitation {
 export interface ConversationData {
   user: string
   response: string
+  /** The conversation as of the latest turn, WINDOWED: the last 50 messages
+   *  (25 exchanges; rows written before 17 Aug 2026 kept only the model's
+   *  14-message window), then trimmed further if the row would overflow
+   *  Airtable's long-text limit. Per-turn arrays (`tools`, `turnTimes`,
+   *  `pages`) are never windowed, so their length is the true turn count and
+   *  they align with `history` from the END. */
   history: HistoryTurn[]
   tools: unknown[]
   /** One entry per logged turn (aligned with `tools`): card ids in that
@@ -474,6 +485,19 @@ export async function upsertConversation(input: {
     ...(input.status ? { status: input.status } : {}),
   }
 
+  // Airtable rejects long-text values over 100,000 characters, and a rejected
+  // write loses the whole turn. The route already windows history to 50
+  // messages, which fits comfortably at typical message sizes; this is the
+  // backstop for the rare chat of very long replies. Drop the oldest messages
+  // until the serialized row fits — the transcript viewer already handles a
+  // window that opens mid-exchange, and the per-turn arrays keep the true
+  // turn count.
+  let serialized = JSON.stringify(data)
+  while (serialized.length > MAX_DATA_CHARS && data.history.length > 2) {
+    data.history = data.history.slice(1)
+    serialized = JSON.stringify(data)
+  }
+
   const fields: ConversationFields = {
     [FIELD.session]: input.session ?? '',
     // The page where the conversation STARTED — written on create, never
@@ -484,7 +508,7 @@ export async function upsertConversation(input: {
     ...(existing ? {} : { [FIELD.page]: input.page }),
     [FIELD.latencyMs]: input.latencyMs,
     [FIELD.promptVersion]: input.promptVersion,
-    [FIELD.data]: JSON.stringify(data),
+    [FIELD.data]: serialized,
   }
 
   const res = existing

--- a/src/lib/assistant/stream.ts
+++ b/src/lib/assistant/stream.ts
@@ -13,7 +13,15 @@ import type { Catalog, ChatMessage, CitationRef, Listing } from './types'
 // requires this parameter, so it can't be "unlimited" — pick a value well
 // above any realistic response size.
 const MAX_TOKENS = 4096
+// Messages the MODEL sees each turn (7 exchanges) — bounds prompt size and
+// keeps old tool results from crowding out the current question.
 const MAX_HISTORY = 14
+// Messages the conversation LOG keeps (25 exchanges). Wider than the model's
+// window so long chats stay readable in the admin transcript, but bounded so
+// the serialized row stays well inside Airtable's 100,000-character long-text
+// limit (a typical message is ~1,000 chars; upsertConversation also trims
+// further if a row would still overflow).
+const LOG_HISTORY = 50
 const MAX_TOOL_ITERATIONS = 10
 // Hard server-side budget matching the prompt's "at most 5 page reads per
 // turn" rule — each read is a multi-second external fetch, so a runaway model
@@ -183,9 +191,23 @@ export function sseResponse(
   return new Response(stream, { headers: SSE_HEADERS })
 }
 
-/** Validates and normalises the incoming messages array. Throws on bad input
- *  so the route can return a 400 with a useful message. */
+/** Validates and normalises the incoming messages array, then windows it to
+ *  the last MAX_HISTORY messages — the slice the MODEL sees. Throws on bad
+ *  input so the route can return a 400 with a useful message. */
 export function validateMessages(messages: unknown): ChatMessage[] {
+  return cleanMessages(messages).slice(-MAX_HISTORY)
+}
+
+/** The same cleaned messages, windowed to the last LOG_HISTORY — the slice
+ *  the conversation LOG stores. The widget sends the whole conversation every
+ *  turn, so long chats keep their earlier turns in the admin transcript even
+ *  though the model only ever sees the last MAX_HISTORY. Always a superset of
+ *  validateMessages() for the same input (both are tails of one list). */
+export function validateLogHistory(messages: unknown): ChatMessage[] {
+  return cleanMessages(messages).slice(-LOG_HISTORY)
+}
+
+function cleanMessages(messages: unknown): ChatMessage[] {
   if (!Array.isArray(messages)) throw new Error('messages must be an array')
   const out: ChatMessage[] = []
   for (const m of messages) {
@@ -205,7 +227,7 @@ export function validateMessages(messages: unknown): ChatMessage[] {
   if (out[out.length - 1].role !== 'user') {
     throw new Error('last message must be from user')
   }
-  return out.slice(-MAX_HISTORY)
+  return out
 }
 
 /** Builds the Anthropic message list, prepending the context line to the


### PR DESCRIPTION
- The conversation log stored the same 14-message window the model sees, so any chat longer than seven exchanges lost its opening turns from the admin transcript. A 29-turn /training conversation (14–17 August 2026) showed only its last seven, starting mid-exchange with a Chatbot message.
- The widget already resends the whole conversation every turn, so the route now windows it twice: the last 14 messages for the model (unchanged) and the last 50 for the log (`validateLogHistory` / `LOG_HISTORY` in `stream.ts`).
- `upsertConversation` drops the oldest history messages if a row's serialized Data would exceed 90,000 characters, keeping it inside Airtable's 100,000-character long-text limit so a turn can't fail to save.
- Admin log: the turn count now comes from the never-windowed per-turn arrays (`turnTimes`, else per-turn `tools`) instead of the windowed history, and the transcript shows an "N earlier turns not stored" divider when the stored history is shorter than the conversation.
- Rows logged before this change keep their 14-message window; the earlier text was never stored, so it can't be recovered.
- Verified: build, type-check and lint pass; a 61-message input yields a 14-message model window and a 50-message log window; an end-to-end 20-message test conversation against the local API stored all 21 messages in Airtable (test record deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)