### PR TITLE
Chatbot: place orgs on the Field map by first category only

### DIFF
--- a/src/lib/assistant/catalog.ts
+++ b/src/lib/assistant/catalog.ts
@@ -7,6 +7,7 @@ import { getFounderResources } from '@/lib/data/founders'
 import { getProjects } from '@/lib/data/projects'
 import { getMediaChannels } from '@/lib/data/media-channels'
 import { getMapData } from '@/lib/data/map'
+import { mapAreaFor } from '@/lib/data/map-areas'
 import { getEvents } from '@/lib/data/events'
 import { getTrainingPrograms, getRecurringPrograms } from '@/lib/data/training'
 import { selectFeatured } from '@/lib/featured'
@@ -298,6 +299,10 @@ export async function buildCatalog(): Promise<Catalog> {
       lastModified: o.lastModified ?? undefined,
       meta: compact({
         category: o.category,
+        // Named region the org's logo sits in on /map — decided by its FIRST
+        // category only. Lets the model answer "what's in Advocacy Anchorage"
+        // without mistaking every org tagged Advocacy for one drawn there.
+        mapArea: mapAreaFor(o.category),
         status: o.status,
         scale: o.scale,
         // Acronym/short name (e.g. "AED", "MIRI") so users can search the org

--- a/src/lib/assistant/prompt.ts
+++ b/src/lib/assistant/prompt.ts
@@ -1,8 +1,18 @@
 import { PAGES, greetingFor } from './pages'
+import { MAP_AREA_BY_CATEGORY } from '@/lib/data/map-areas'
 
 /** Stamp on every conversation log row. Bump manually when you ship a
  *  meaningful prompt change so historical conversations stay attributable. */
-export const PROMPT_VERSION = '2026-08-16-01'
+export const PROMPT_VERSION = '2026-08-17-01'
+
+/** "Category → **Area**" lines for the Field map section, generated from the
+ *  same table the catalog uses to compute each org's \`mapArea\`, so the prompt
+ *  can't drift from the data. Gone Graveyard is deliberately left off the
+ *  list – the prompt tells the model never to name it. */
+const MAP_AREA_LIST = Object.entries(MAP_AREA_BY_CATEGORY)
+  .filter(([category]) => category !== 'No longer active')
+  .map(([category, area]) => `- ${category} → **${area}**`)
+  .join('\n')
 
 /** The production system prompt. Edited only via code (not via the admin
  *  panel). Exported so the admin "use production prompt as draft" reset
@@ -358,24 +368,11 @@ When the user asks about fellowships or programs in ANY form (research fellowshi
 - This applies even if you are mid-way through a multi-step pipeline answer. There is no exception for "but it's part of a bigger response."
 
 # Field map areas
-The Field map (/map) is laid out as named regions, one per org \`category\`. When you point the user to /map, name the specific area they should look at – e.g. "see Governance Grove on the [Field map](/map)" not just "see the [Field map](/map)". Mapping:
+The Field map (/map) is laid out as named regions, one per org category. When you point the user to /map, name the specific area they should look at – e.g. "see Governance Grove on the [Field map](/map)" not just "see the [Field map](/map)". Mapping:
 
-- Advocacy → **Advocacy Anchorage**
-- Blog → **Blog Beach**
-- Capabilities research → **Capabilities Cove**
-- Career support → **Career Castle**
-- Conceptual research → **Conceptual Cliffs**
-- Empirical research → **Empirical Escarpment**
-- Forecasting → **Forecasting Falls**
-- Funding → **Funding Forest**
-- Governance → **Governance Grove**
-- Newsletter → **Newsletter Nook**
-- Podcast → **Podcast Port**
-- Research support → **Support Shoreline**
-- Resource → **Resource Rock**
-- Strategy → **Strategy Summit**
-- Training and education → **Training Town**
-- Video → **Video Vista**
+${MAP_AREA_LIST}
+
+**An org sits in exactly ONE area – the one for its FIRST category.** Orgs often carry several categories ("Governance, Advocacy, Conceptual research"), but only the first one places the logo; the rest are secondary tags. So an org tagged Advocacy second or third is NOT in Advocacy Anchorage – it's drawn in the area of its first category. Every org result carries a \`mapArea\` field that already resolves this for you – trust it. Whenever you talk about an area itself – "Advocacy Anchorage holds N orgs", "you'll find X in Governance Grove", "the rest are in the same area" – go by \`mapArea\` (search with \`filters: { mapArea: 'Advocacy Anchorage' }\`), never by \`category\`. A \`category\` search ("orgs that do advocacy") returns the wider set of every org tagged with it anywhere in its list – fine for "which orgs work on X", but never present that count or those orgs as what's *in* the area, and don't tell a user to look for an org in an area it isn't drawn in. (The card view's Category filter on /map does match any tag – so "the card view with Category set to Advocacy" is the right pointer for the wider set.)
 
 (Inactive orgs sit in **Gone Graveyard** – never refer to that area to users; per the inactive-listing rule, drop them silently.)
 

--- a/src/lib/assistant/tools.ts
+++ b/src/lib/assistant/tools.ts
@@ -26,7 +26,9 @@ ARGUMENTS:
     advisor: focus, status
     founder-resource: type
     media-channel: type ("Podcast"|"Newsletter"|"Blog"|"Video"|"Forum")
-    org: category, status
+    org: category, mapArea, status
+      – \`category\` is EVERY category the org is tagged with (comma-separated, e.g. "Governance, Advocacy, Conceptual research"). Filter on it for "orgs that do X" (any tag counts).
+      – \`mapArea\` is the ONE named region the org's logo is drawn in on the Field map (e.g. "Advocacy Anchorage", "Governance Grove"), decided by its FIRST category only. Filter on it when the user asks what's in an area, or whenever you're about to describe an area ("X area holds…", "see it in X area"). An org tagged Advocacy as a second or third category is NOT in Advocacy Anchorage.
     event: type ("Competition"|"Conference"|"Hackathon"|"Meetup"|"Talk"|"Workshop"|"Other"), mode ("Online"|"In person"|"Hybrid"), location (free text, usually "City, Country" like "Berkeley, USA" — or "Online"), cost ("Free"|"Free (assistance available)"|"Free (cash prize available)"|"Pay to attend"|"Pay to attend (assistance available)" — substring match means cost: "Free" catches all three Free variants and cost: "Pay to attend" both paid ones. "(assistance available)" = the organizer offers financial support: needs-based travel/accommodation support on free events, ticket discounts/aid on paid ones)
     training: type ("Fellowship"|"Course"|"Bootcamp"|"Immersive workshop"|"Other"), mode ("Online"|"In person"|"Hybrid"|"Online or in person"), location (free text like events), focus ("General"|"Technical"|"Governance" — multi-select, a program can carry both "Technical" and "Governance"; filtering on one value matches programs that carry it among others), entryBar ("Low"|"Mid"|"High"), timeCommitment ("Full-time"|"Part-time"), stipend ("No stipend"|"Expenses covered"|"Stipend included"), length ("Under 1 month"|"1–3 months"|"3+ months" — how long the program runs), recurring ("Yes" — only evergreen programs carry it)
 
@@ -61,6 +63,12 @@ EXAMPLES:
 
   // Browse all advisors
   search_listings({ type: 'advisor' })
+
+  // Every org drawn in one Field map region (first category only)
+  search_listings({ type: 'org', filters: { mapArea: 'Advocacy Anchorage' } })
+
+  // Every org tagged Advocacy anywhere in its category list (wider set)
+  search_listings({ type: 'org', filters: { category: 'Advocacy' } })
 
   // Upcoming fellowships (dated rounds and evergreen programs together)
   search_listings({ type: 'training', filters: { type: 'Fellowship' } })

--- a/src/lib/data/map-areas.ts
+++ b/src/lib/data/map-areas.ts
@@ -1,0 +1,46 @@
+// Named regions on the Field map (/map), keyed by org category.
+//
+// An org's logo is drawn in the region for its FIRST category only:
+// "Governance, Advocacy, Conceptual research" → Governance Grove, not Advocacy
+// Anchorage. Later categories are secondary tags and don't place the org
+// anywhere. This file has no dependencies so both the chatbot catalog (server)
+// and the system prompt can import it without pulling in the Airtable client.
+export const MAP_AREA_BY_CATEGORY: Record<string, string> = {
+  Advocacy: 'Advocacy Anchorage',
+  Blog: 'Blog Beach',
+  'Capabilities research': 'Capabilities Cove',
+  'Career support': 'Career Castle',
+  'Conceptual research': 'Conceptual Cliffs',
+  'Empirical research': 'Empirical Escarpment',
+  Forecasting: 'Forecasting Falls',
+  Funding: 'Funding Forest',
+  Governance: 'Governance Grove',
+  Newsletter: 'Newsletter Nook',
+  Podcast: 'Podcast Port',
+  'Research support': 'Support Shoreline',
+  Resource: 'Resource Rock',
+  Strategy: 'Strategy Summit',
+  'Training and education': 'Training Town',
+  Video: 'Video Vista',
+  'No longer active': 'Gone Graveyard',
+}
+
+/** First entry of an org's comma-joined category list, or null. */
+export function primaryCategory(category: string): string | null {
+  const first = category.split(',')[0]?.trim()
+  return first || null
+}
+
+/** Field map region an org is drawn in — decided by its first category. */
+export function mapAreaFor(category: string): string | null {
+  const primary = primaryCategory(category)
+  if (!primary) return null
+  const area = MAP_AREA_BY_CATEGORY[primary]
+  if (!area) {
+    console.warn(
+      `[map-areas] No Field map area for category "${primary}" — add it to MAP_AREA_BY_CATEGORY`
+    )
+    return null
+  }
+  return area
+}


### PR DESCRIPTION
- The chatbot told a user "Advocacy Anchorage holds 27 active listings" and carded MIRI and CAIS as being there. It had filtered on `category`, which holds every tag an org carries – but on the map an org sits only in the region for its **first** category (MIRI: "Governance, Advocacy, Conceptual research" → Governance Grove). The drawn map has 17 in Advocacy Anchorage.
- New `src/lib/data/map-areas.ts` holds the category → area table plus `mapAreaFor()`, which resolves the first category. Computed at catalog build time from live Airtable data, so reordering categories flows through on its own.
- Every org listing the chatbot sees now carries a `mapArea` meta field alongside the full `category` list.
- `search_listings` docs and the system prompt explain when to use which: talking about an area → `mapArea`; "orgs that do X" → `category`, never presented as what's *in* the area. The prompt's area list is generated from the shared table so the two can't drift. `PROMPT_VERSION` → `2026-08-17-01`.
- Verified against the real chatbot locally: "Advocacy organizations" on /map now searches `mapArea: Advocacy Anchorage` (17) and says so, noting the wider tagged set is in the card view; "Is MIRI in Advocacy Anchorage?" → "No – it's drawn in Governance Grove."

🤖 Generated with [Claude Code](https://claude.com/claude-code)