### PR TITLE
Admin map editor: drag logos on the Field map, saved to Airtable

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,6 +158,21 @@ src/app/
         └── events/route.ts
 ```
 
+## Admin map editor
+
+`/admin/map` (owner password only, `mapEditor` capability in
+`src/lib/admin/auth.ts`) lets the owner drag logos on the Field map and writes
+the record's `x`/`y` to Airtable via `/api/admin/map` (GET live records,
+PATCH one move). It is deliberately a **copy** of the public map's rendering,
+not a shared component: `src/lib/admin/map-geometry.ts` mirrors the constants
+in `src/app/map/D3Map.tsx` and `map-geometry.test.ts` fails if they drift.
+The editor reads Airtable directly with `cache: 'no-store'` (unpublished rows
+included, `Hide?` rows excluded) – never through `fetchAirtableRecords` /
+`unstable_cache` – and never revalidates anything, so `/map`'s data path,
+cache and bundle are untouched. The only Airtable fields it can write are `x`
+and `y` (`buildPositionFields` in `map-editor-core.ts`; any other key in the
+request body is rejected). Publish?/Hide?/Scale stay in Airtable.
+
 ## Deployment
 
 - **Platform**: Vercel (recommended for Next.js)
@@ -177,10 +192,10 @@ As more pages are built, consider extracting:
 
 ### Testing
 
-Currently no tests. When adding:
-
-- Use Vitest or Jest for unit tests
-- Playwright for E2E (especially the D3 map)
+Unit tests run with Vitest (`npm test`, files `src/**/*.test.ts`, node
+environment, `@` alias resolves to `src`). Pure modules only – nothing that
+imports Next, d3 or the DOM. E2E is still manual (Playwright headless against a
+local server, especially for the D3 map).
 
 ### Performance
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "lint-staged": "^16.2.7",
         "prettier": "^3.7.4",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -364,6 +365,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1091,6 +1534,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1296,6 +1756,356 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1307,6 +2117,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1600,6 +2417,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -1853,10 +2681,17 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2553,6 +3388,119 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2854,6 +3802,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3081,6 +4039,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4045,6 +5013,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4103,6 +5078,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -4561,6 +5578,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4630,6 +5657,16 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4789,6 +5826,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6694,6 +7746,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -6831,6 +7897,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7178,6 +8251,52 @@
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
       "license": "Unlicense"
     },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7495,6 +8614,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7554,6 +8680,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -7563,6 +8696,13 @@
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7848,6 +8988,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7894,6 +9051,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8213,6 +9380,215 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -8337,6 +9713,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.0",
@@ -40,7 +41,8 @@
     "lint-staged": "^16.2.7",
     "prettier": "^3.7.4",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.10"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/src/app/admin/analytics/layout.tsx
+++ b/src/app/admin/analytics/layout.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { canViewAnalytics, canViewChatbot } from '@/lib/admin/auth'
+import { canEditMap, canViewAnalytics, canViewChatbot } from '@/lib/admin/auth'
 import AdminHeader from '../AdminHeader'
 import { adminTabs, adminHomeHref } from '../nav'
 import styles from '../admin.module.css'
@@ -22,7 +22,7 @@ export default async function AnalyticsLayout({
   }
   // Analytics access is guaranteed here, so the Analytics tab is always present;
   // the chatbot tabs drop out for an analytics-only session.
-  const access = { chatbot, analytics: true }
+  const access = { chatbot, analytics: true, mapEditor: await canEditMap() }
   return (
     <>
       <AdminHeader tabs={adminTabs(access)} brandHref={adminHomeHref(access)} />

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -591,57 +591,61 @@ export default function MapEditor() {
         </span>
       </div>
 
-      {placing && (
-        <div className={`${adminStyles.notice} ${styles.placeNotice}`}>
-          Click on the map to place <strong>{placing.title}</strong>
-          {placing.area ? ` (its region is ${placing.area})` : ''}. Press Esc to
-          cancel.
-        </div>
-      )}
-
-      {errorBanner && (
-        <div className={`${adminStyles.notice} ${styles.errorBanner}`}>
-          <span>{errorBanner.text}</span>
-          <span className={styles.errorActions}>
-            {errorBanner.retry && (
-              <button
-                type="button"
-                className={adminStyles.editorButtonPrimary}
-                onClick={() => {
-                  const m = errorBanner.retry!
-                  setErrorBanner(null)
-                  moveRecord(m.id, m.x, m.y, { kind: m.kind, entry: m.entry })
-                }}
-              >
-                Retry
-              </button>
-            )}
-            <button
-              type="button"
-              className={adminStyles.editorButton}
-              onClick={() => setErrorBanner(null)}
-            >
-              Dismiss
-            </button>
-          </span>
-        </div>
-      )}
-
-      {loadError && (
-        <div className={`${adminStyles.notice} ${styles.errorBanner}`}>
-          <span>{loadError}</span>
-          <button
-            type="button"
-            className={adminStyles.editorButtonPrimary}
-            onClick={() => void load()}
-          >
-            Retry
-          </button>
-        </div>
-      )}
-
       <div className={styles.split}>
         <div className={styles.canvasWrap}>
+          {/* Notices float over the map so they never push it around. */}
+          <div className={styles.overlays}>
+            {placing && (
+              <div className={`${adminStyles.notice} ${styles.placeNotice}`}>
+                Click on the map to place <strong>{placing.title}</strong>.
+                Press Esc to cancel.
+              </div>
+            )}
+
+            {errorBanner && (
+              <div className={`${adminStyles.notice} ${styles.errorBanner}`}>
+                <span>{errorBanner.text}</span>
+                <span className={styles.errorActions}>
+                  {errorBanner.retry && (
+                    <button
+                      type="button"
+                      className={adminStyles.editorButtonPrimary}
+                      onClick={() => {
+                        const m = errorBanner.retry!
+                        setErrorBanner(null)
+                        moveRecord(m.id, m.x, m.y, {
+                          kind: m.kind,
+                          entry: m.entry,
+                        })
+                      }}
+                    >
+                      Retry
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className={adminStyles.editorButton}
+                    onClick={() => setErrorBanner(null)}
+                  >
+                    Dismiss
+                  </button>
+                </span>
+              </div>
+            )}
+
+            {loadError && (
+              <div className={`${adminStyles.notice} ${styles.errorBanner}`}>
+                <span>{loadError}</span>
+                <button
+                  type="button"
+                  className={adminStyles.editorButtonPrimary}
+                  onClick={() => void load()}
+                >
+                  Retry
+                </button>
+              </div>
+            )}
+          </div>
           {records ? (
             <MapEditorCanvas
               records={visible}

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -534,7 +534,7 @@ export default function MapEditor() {
                 fetchedAt ? new Date(fetchedAt).toLocaleTimeString() : ''
               } · ${counts.total} records · ${counts.placed} placed · ${
                 counts.unplaced
-              } unplaced · ${counts.drafts} drafts`
+              } unplaced · ${counts.drafts} unpublished`
             : 'Loading…'}
         </span>
         <button
@@ -570,7 +570,7 @@ export default function MapEditor() {
             onChange={e => setShowDrafts(e.target.checked)}
             disabled={previewPublic}
           />
-          Show drafts
+          Show unpublished
         </label>
         <label className={styles.toggle}>
           <input

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -43,8 +43,12 @@ interface QueuedMove {
   id: string
   x: number
   y: number
-  /** True for undo writes, which must not push another undo entry. */
-  isUndo: boolean
+  /** 'user' moves push an undo entry when confirmed (and clear redo);
+   *  'undo' moves hand their entry to the redo stack; 'redo' moves hand it
+   *  back to the undo stack. */
+  kind: 'user' | 'undo' | 'redo'
+  /** The history entry an undo/redo write is replaying. */
+  entry?: UndoEntry
   /** When it was (last) queued — sends wait SETTLE_MS after this so a burst
    *  of nudges becomes one write. */
   at: number
@@ -81,6 +85,7 @@ export default function MapEditor() {
     retry: QueuedMove | null
   } | null>(null)
   const [undoStack, setUndoStack] = useState<UndoEntry[]>([])
+  const [redoStack, setRedoStack] = useState<UndoEntry[]>([])
   const [showDrafts, setShowDrafts] = useState(true)
   const [showFurniture, setShowFurniture] = useState(true)
   const [previewPublic, setPreviewPublic] = useState(false)
@@ -111,6 +116,8 @@ export default function MapEditor() {
   selectedRef.current = selectedId
   const undoRef = useRef<UndoEntry[]>([])
   undoRef.current = undoStack
+  const redoRef = useRef<UndoEntry[]>([])
+  redoRef.current = redoStack
   const lastLoadAt = useRef(0)
 
   // ── Loading ──────────────────────────────────────────────────────────────
@@ -277,13 +284,21 @@ export default function MapEditor() {
           record: { id: string; x: number; y: number }
         }
         const stored = data.record
-        if (!next.isUndo && expected.x !== null && expected.y !== null) {
-          pushUndo({
-            id: next.id,
-            from: { x: expected.x, y: expected.y },
-            to: { x: stored.x, y: stored.y },
-            at: Date.now(),
-          })
+        if (next.kind === 'user') {
+          if (expected.x !== null && expected.y !== null) {
+            pushUndo({
+              id: next.id,
+              from: { x: expected.x, y: expected.y },
+              to: { x: stored.x, y: stored.y },
+              at: Date.now(),
+            })
+          }
+        } else if (next.kind === 'undo' && next.entry) {
+          const entry = next.entry
+          setRedoStack(prev => [...prev.slice(-49), entry])
+        } else if (next.kind === 'redo' && next.entry) {
+          const entry = next.entry
+          setUndoStack(prev => [...prev.slice(-49), entry])
         }
         lastConfirmed.current.set(next.id, { x: stored.x, y: stored.y })
         if (!superseded()) setLocalPosition(next.id, stored.x, stored.y)
@@ -298,6 +313,14 @@ export default function MapEditor() {
       const back = lastConfirmed.current.get(next.id)
       if (!superseded() && back && back.x !== null && back.y !== null) {
         setLocalPosition(next.id, back.x, back.y)
+      }
+      // A failed undo/redo keeps its history entry where it came from.
+      if (next.kind === 'undo' && next.entry) {
+        const entry = next.entry
+        setUndoStack(prev => [...prev, entry])
+      } else if (next.kind === 'redo' && next.entry) {
+        const entry = next.entry
+        setRedoStack(prev => [...prev, entry])
       }
       setStatus({ kind: 'error', text: `Not saved: ${name}` })
       setErrorBanner({ text: message, retry: next })
@@ -323,26 +346,48 @@ export default function MapEditor() {
   )
 
   const moveRecord = useCallback(
-    (id: string, x: number, y: number, isUndo = false) => {
+    (
+      id: string,
+      x: number,
+      y: number,
+      history: { kind: QueuedMove['kind']; entry?: UndoEntry } = {
+        kind: 'user',
+      }
+    ) => {
       const c = clampGrid(roundGrid(x), roundGrid(y))
       setLocalPosition(id, c.x, c.y)
-      enqueue({ id, x: c.x, y: c.y, isUndo })
+      // A fresh move forks history: nothing to redo any more.
+      if (history.kind === 'user') setRedoStack([])
+      enqueue({ id, x: c.x, y: c.y, ...history })
     },
     [enqueue, setLocalPosition]
   )
 
-  const undo = useCallback(() => {
-    // The undo entry for a move only exists once Airtable confirms it, so
-    // undoing while a save is pending would revert the wrong thing.
+  /** History entries only exist once Airtable confirms a move, so replaying
+   *  one while a save is pending could revert the wrong thing. */
+  const historyBusy = useCallback(() => {
     if (inFlight.current || queue.current.length) {
       setStatus({ kind: 'saving', text: 'Finishing the current save first…' })
-      return
+      return true
     }
+    return false
+  }, [])
+
+  const undo = useCallback(() => {
+    if (historyBusy()) return
     const last = undoRef.current[undoRef.current.length - 1]
     if (!last) return
     setUndoStack(prev => prev.slice(0, -1))
-    moveRecord(last.id, last.from.x, last.from.y, true)
-  }, [moveRecord])
+    moveRecord(last.id, last.from.x, last.from.y, { kind: 'undo', entry: last })
+  }, [historyBusy, moveRecord])
+
+  const redo = useCallback(() => {
+    if (historyBusy()) return
+    const last = redoRef.current[redoRef.current.length - 1]
+    if (!last) return
+    setRedoStack(prev => prev.slice(0, -1))
+    moveRecord(last.id, last.to.x, last.to.y, { kind: 'redo', entry: last })
+  }, [historyBusy, moveRecord])
 
   // ── Canvas callbacks ─────────────────────────────────────────────────────
 
@@ -390,10 +435,23 @@ export default function MapEditor() {
           target.tagName === 'TEXTAREA' ||
           target.tagName === 'SELECT' ||
           target.isContentEditable)
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'z' && !typing) {
-        e.preventDefault()
-        undo()
-        return
+      if ((e.metaKey || e.ctrlKey) && !typing) {
+        const k = e.key.toLowerCase()
+        if (k === 'z' && e.shiftKey) {
+          e.preventDefault()
+          redo()
+          return
+        }
+        if (k === 'z') {
+          e.preventDefault()
+          undo()
+          return
+        }
+        if (k === 'y') {
+          e.preventDefault()
+          redo()
+          return
+        }
       }
       if (e.key === 'Escape') {
         if (typing) return
@@ -425,7 +483,7 @@ export default function MapEditor() {
     }
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
-  }, [moveRecord, undo])
+  }, [moveRecord, undo, redo])
 
   // ── Derived ──────────────────────────────────────────────────────────────
 
@@ -498,6 +556,15 @@ export default function MapEditor() {
         >
           Undo{undoStack.length ? ` (${undoStack.length})` : ''}
         </button>
+        <button
+          type="button"
+          className={adminStyles.editorButton}
+          onClick={redo}
+          disabled={redoStack.length === 0 || saving}
+          title="Cmd/Ctrl+Shift+Z"
+        >
+          Redo{redoStack.length ? ` (${redoStack.length})` : ''}
+        </button>
         <label className={styles.toggle}>
           <input
             type="checkbox"
@@ -554,7 +621,7 @@ export default function MapEditor() {
                 onClick={() => {
                   const m = errorBanner.retry!
                   setErrorBanner(null)
-                  moveRecord(m.id, m.x, m.y, m.isUndo)
+                  moveRecord(m.id, m.x, m.y, { kind: m.kind, entry: m.entry })
                 }}
               >
                 Retry
@@ -624,7 +691,7 @@ export default function MapEditor() {
 
       <p className={`${adminStyles.sectionHint} ${styles.footnote}`}>
         Only x and y are written – publishing, hiding and Scale stay in
-        Airtable. Undo is per tab and cleared on reload. Desktop only.
+        Airtable. Undo/Redo are per tab and cleared on reload. Desktop only.
       </p>
     </div>
   )

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -45,6 +45,11 @@ interface QueuedMove {
   y: number
   /** True for undo writes, which must not push another undo entry. */
   isUndo: boolean
+  /** When it was (last) queued — sends wait SETTLE_MS after this so a burst
+   *  of nudges becomes one write. */
+  at: number
+  /** Rate-limit retries so far. */
+  attempts: number
 }
 
 /** Consecutive nudges/drops of the same pin within this window collapse into
@@ -52,6 +57,13 @@ interface QueuedMove {
 const UNDO_MERGE_MS = 1500
 /** Re-read Airtable when the tab regains focus after this long away. */
 const REFRESH_ON_FOCUS_MS = 60_000
+/** Wait this long after the last move of a pin before writing it. Airtable
+ *  allows ~5 requests/s per base and each save is two; held arrow keys or
+ *  quick successive drops must not turn into a burst. */
+const SETTLE_MS = 400
+/** After a 429 Airtable refuses everything for ~30 s. Retry then. */
+const RATE_LIMIT_WAIT_MS = 31_000
+const RATE_LIMIT_MAX_ATTEMPTS = 3
 
 function fmt(n: number): string {
   return n.toFixed(1)
@@ -73,6 +85,8 @@ export default function MapEditor() {
   const [showFurniture, setShowFurniture] = useState(true)
   const [previewPublic, setPreviewPublic] = useState(false)
   const [dragging, setDragging] = useState(false)
+  // True while any save is queued or in flight (Undo waits for it).
+  const [saving, setSaving] = useState(false)
   const [panelTab, setPanelTab] = useState<PanelTab>('unplaced')
 
   const controlsRef = useRef<CanvasControls>({
@@ -85,6 +99,8 @@ export default function MapEditor() {
   const lastConfirmed = useRef<Map<string, Position>>(new Map())
   const queue = useRef<QueuedMove[]>([])
   const inFlight = useRef<QueuedMove | null>(null)
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const rateLimitedUntil = useRef(0)
   const recordsRef = useRef<EditorRecord[] | null>(null)
   recordsRef.current = records
   const draggingRef = useRef(false)
@@ -176,8 +192,31 @@ export default function MapEditor() {
   const processQueue = useCallback(async () => {
     if (inFlight.current) return
     const next = queue.current.shift()
-    if (!next) return
+    if (!next) {
+      setSaving(false)
+      return
+    }
+    setSaving(true)
+    // Let a burst of moves settle so we send one write, not one per keypress,
+    // and hold everything while Airtable's rate-limit lockout is running.
+    const wait = Math.max(
+      SETTLE_MS - (Date.now() - next.at),
+      rateLimitedUntil.current - Date.now()
+    )
+    if (wait > 0) {
+      queue.current.unshift(next)
+      if (!settleTimer.current) {
+        settleTimer.current = setTimeout(() => {
+          settleTimer.current = null
+          void processQueue()
+        }, wait)
+      }
+      return
+    }
     inFlight.current = next
+    // A newer move of the same pin waiting behind this one means the pin is
+    // already where the user wants it — don't drag it back to this result.
+    const superseded = () => queue.current.some(m => m.id === next.id)
     const expected = lastConfirmed.current.get(next.id) ?? { x: null, y: null }
     const name =
       recordsRef.current?.find(r => r.id === next.id)?.labelName ?? next.id
@@ -194,6 +233,9 @@ export default function MapEditor() {
       if (res.status === 409) {
         const data = (await res.json()) as { current: Position }
         lastConfirmed.current.set(next.id, data.current)
+        // Someone else moved it: show where it really is and drop any of our
+        // follow-up moves rather than silently overwriting theirs.
+        queue.current = queue.current.filter(m => m.id !== next.id)
         if (data.current.x !== null && data.current.y !== null) {
           setLocalPosition(next.id, data.current.x, data.current.y)
         }
@@ -202,6 +244,24 @@ export default function MapEditor() {
           text: `${name} was moved in Airtable since you loaded – shown at its current position (${
             data.current.x === null ? '–' : fmt(data.current.x)
           }, ${data.current.y === null ? '–' : fmt(data.current.y)}). Drag again if you still want to move it.`,
+        })
+      } else if (
+        res.status === 429 &&
+        next.attempts < RATE_LIMIT_MAX_ATTEMPTS
+      ) {
+        // Airtable rate limit: keep the move, wait out the lockout, retry.
+        // Nothing else is sent until then either (see the gate above).
+        if (!superseded()) {
+          queue.current.unshift({
+            ...next,
+            at: Date.now(),
+            attempts: next.attempts + 1,
+          })
+        }
+        rateLimitedUntil.current = Date.now() + RATE_LIMIT_WAIT_MS
+        setStatus({
+          kind: 'saving',
+          text: `Airtable is rate-limiting – ${name} will be saved automatically in about 30 seconds (attempt ${next.attempts + 1} of ${RATE_LIMIT_MAX_ATTEMPTS})…`,
         })
       } else if (!res.ok) {
         let message = `Save failed (${res.status})`
@@ -226,7 +286,7 @@ export default function MapEditor() {
           })
         }
         lastConfirmed.current.set(next.id, { x: stored.x, y: stored.y })
-        setLocalPosition(next.id, stored.x, stored.y)
+        if (!superseded()) setLocalPosition(next.id, stored.x, stored.y)
         setStatus({
           kind: 'ok',
           text: `Saved ${name} at (${fmt(stored.x)}, ${fmt(stored.y)}) · ${new Date().toLocaleTimeString()}`,
@@ -236,7 +296,7 @@ export default function MapEditor() {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       const back = lastConfirmed.current.get(next.id)
-      if (back && back.x !== null && back.y !== null) {
+      if (!superseded() && back && back.x !== null && back.y !== null) {
         setLocalPosition(next.id, back.x, back.y)
       }
       setStatus({ kind: 'error', text: `Not saved: ${name}` })
@@ -244,14 +304,19 @@ export default function MapEditor() {
     } finally {
       inFlight.current = null
       if (queue.current.length) void processQueue()
+      else setSaving(false)
     }
   }, [pushUndo, setLocalPosition])
 
   const enqueue = useCallback(
-    (move: QueuedMove) => {
+    (move: Omit<QueuedMove, 'at' | 'attempts'>) => {
       // A newer move of the same pin replaces the one still waiting.
       queue.current = queue.current.filter(m => m.id !== move.id)
-      queue.current.push(move)
+      queue.current.push({ ...move, at: Date.now(), attempts: 0 })
+      if (settleTimer.current) {
+        clearTimeout(settleTimer.current)
+        settleTimer.current = null
+      }
       void processQueue()
     },
     [processQueue]
@@ -267,6 +332,12 @@ export default function MapEditor() {
   )
 
   const undo = useCallback(() => {
+    // The undo entry for a move only exists once Airtable confirms it, so
+    // undoing while a save is pending would revert the wrong thing.
+    if (inFlight.current || queue.current.length) {
+      setStatus({ kind: 'saving', text: 'Finishing the current save first…' })
+      return
+    }
     const last = undoRef.current[undoRef.current.length - 1]
     if (!last) return
     setUndoStack(prev => prev.slice(0, -1))
@@ -386,6 +457,12 @@ export default function MapEditor() {
 
   return (
     <div className={styles.page}>
+      <div className={`${adminStyles.notice} ${styles.liveWarning}`}>
+        <strong>This edits the live site.</strong> Every move is saved to
+        Airtable straight away and appears on the public /map within a few
+        minutes. Please don&apos;t experiment here unless you mean it.
+      </div>
+
       <div className={adminStyles.pageHeading}>
         <h1 className={adminStyles.pageTitle}>Map editor</h1>
         <span className={adminStyles.pageMeta}>
@@ -416,7 +493,7 @@ export default function MapEditor() {
           type="button"
           className={adminStyles.editorButton}
           onClick={undo}
-          disabled={undoStack.length === 0}
+          disabled={undoStack.length === 0 || saving}
           title="Cmd/Ctrl+Z"
         >
           Undo{undoStack.length ? ` (${undoStack.length})` : ''}

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -1,0 +1,554 @@
+'use client'
+
+/*
+  Admin map editor controller: loads records live from /api/admin/map, keeps
+  the optimistic local positions, runs a one-at-a-time save queue (later moves
+  of the same record replace the queued one), holds the undo stack, and wires
+  keyboard shortcuts. The canvas (d3) and side panel are dumb views.
+*/
+
+import dynamic from 'next/dynamic'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { EditorRecord } from '@/lib/admin/map-editor-core'
+import { clampGrid, roundGrid } from '@/lib/admin/map-geometry'
+import type { CanvasControls } from './MapEditorCanvas'
+import SidePanel, { type PanelTab } from './SidePanel'
+import adminStyles from '../admin.module.css'
+import styles from './map-editor.module.css'
+
+const MapEditorCanvas = dynamic(() => import('./MapEditorCanvas'), {
+  ssr: false,
+  loading: () => (
+    <div className={`${styles.canvas} ${styles.canvasLoading}`}>
+      <p className="paragraph-small color-teal-300">Loading map…</p>
+    </div>
+  ),
+})
+
+type Position = { x: number | null; y: number | null }
+
+interface Status {
+  kind: 'idle' | 'saving' | 'ok' | 'stale' | 'error'
+  text: string
+}
+
+interface UndoEntry {
+  id: string
+  from: { x: number; y: number }
+  to: { x: number; y: number }
+  at: number
+}
+
+interface QueuedMove {
+  id: string
+  x: number
+  y: number
+  /** True for undo writes, which must not push another undo entry. */
+  isUndo: boolean
+}
+
+/** Consecutive nudges/drops of the same pin within this window collapse into
+ *  one undo step. */
+const UNDO_MERGE_MS = 1500
+/** Re-read Airtable when the tab regains focus after this long away. */
+const REFRESH_ON_FOCUS_MS = 60_000
+
+function fmt(n: number): string {
+  return n.toFixed(1)
+}
+
+export default function MapEditor() {
+  const [records, setRecords] = useState<EditorRecord[] | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [fetchedAt, setFetchedAt] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [placeModeId, setPlaceModeId] = useState<string | null>(null)
+  const [status, setStatus] = useState<Status>({ kind: 'idle', text: '' })
+  const [errorBanner, setErrorBanner] = useState<{
+    text: string
+    retry: QueuedMove | null
+  } | null>(null)
+  const [undoStack, setUndoStack] = useState<UndoEntry[]>([])
+  const [showDrafts, setShowDrafts] = useState(true)
+  const [showFurniture, setShowFurniture] = useState(true)
+  const [previewPublic, setPreviewPublic] = useState(false)
+  const [dragging, setDragging] = useState(false)
+  const [panelTab, setPanelTab] = useState<PanelTab>('unplaced')
+
+  const controlsRef = useRef<CanvasControls>({
+    zoomIn: () => {},
+    zoomOut: () => {},
+    reset: () => {},
+  })
+  // What Airtable last confirmed for each record — the `expected` value sent
+  // with every write, and where a pin goes back to when a save fails.
+  const lastConfirmed = useRef<Map<string, Position>>(new Map())
+  const queue = useRef<QueuedMove[]>([])
+  const inFlight = useRef<QueuedMove | null>(null)
+  const recordsRef = useRef<EditorRecord[] | null>(null)
+  recordsRef.current = records
+  const draggingRef = useRef(false)
+  draggingRef.current = dragging
+  const placeModeRef = useRef<string | null>(null)
+  placeModeRef.current = placeModeId
+  const selectedRef = useRef<string | null>(null)
+  selectedRef.current = selectedId
+  const undoRef = useRef<UndoEntry[]>([])
+  undoRef.current = undoStack
+  const lastLoadAt = useRef(0)
+
+  // ── Loading ──────────────────────────────────────────────────────────────
+
+  const load = useCallback(async () => {
+    setLoadError(null)
+    let res: Response
+    try {
+      res = await fetch('/api/admin/map', { cache: 'no-store' })
+    } catch (err) {
+      setLoadError(`Could not reach the server: ${String(err)}`)
+      return
+    }
+    if (!res.ok) {
+      const text = await res.text()
+      setLoadError(`Load failed (${res.status}): ${text}`)
+      return
+    }
+    const data = (await res.json()) as {
+      fetchedAt: string
+      records: EditorRecord[]
+    }
+    const busy = new Set<string>(queue.current.map(m => m.id))
+    if (inFlight.current) busy.add(inFlight.current.id)
+    setRecords(prev => {
+      // Keep the local position of anything still being saved.
+      if (!prev) return data.records
+      const local = new Map(prev.map(r => [r.id, r]))
+      return data.records.map(r =>
+        busy.has(r.id) && local.has(r.id)
+          ? { ...r, x: local.get(r.id)!.x, y: local.get(r.id)!.y }
+          : r
+      )
+    })
+    for (const r of data.records) {
+      if (!busy.has(r.id)) lastConfirmed.current.set(r.id, { x: r.x, y: r.y })
+    }
+    setFetchedAt(data.fetchedAt)
+    lastLoadAt.current = Date.now()
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  // Refresh when coming back to the tab after a while — but never in the
+  // middle of a drag, a save, or a placement.
+  useEffect(() => {
+    const onFocus = () => {
+      if (Date.now() - lastLoadAt.current < REFRESH_ON_FOCUS_MS) return
+      if (draggingRef.current || inFlight.current || queue.current.length)
+        return
+      if (placeModeRef.current) return
+      void load()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [load])
+
+  // ── Local mutation + save queue ──────────────────────────────────────────
+
+  const setLocalPosition = useCallback((id: string, x: number, y: number) => {
+    setRecords(prev =>
+      prev ? prev.map(r => (r.id === id ? { ...r, x, y } : r)) : prev
+    )
+  }, [])
+
+  const pushUndo = useCallback((entry: UndoEntry) => {
+    setUndoStack(prev => {
+      const last = prev[prev.length - 1]
+      if (last && last.id === entry.id && entry.at - last.at < UNDO_MERGE_MS) {
+        // Merge a burst of nudges into one step, keeping the original origin.
+        return [...prev.slice(0, -1), { ...entry, from: last.from }]
+      }
+      return [...prev.slice(-49), entry]
+    })
+  }, [])
+
+  const processQueue = useCallback(async () => {
+    if (inFlight.current) return
+    const next = queue.current.shift()
+    if (!next) return
+    inFlight.current = next
+    const expected = lastConfirmed.current.get(next.id) ?? { x: null, y: null }
+    const name =
+      recordsRef.current?.find(r => r.id === next.id)?.labelName ?? next.id
+    setStatus({
+      kind: 'saving',
+      text: `Saving ${name} → (${fmt(next.x)}, ${fmt(next.y)})…`,
+    })
+    try {
+      const res = await fetch('/api/admin/map', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: next.id, x: next.x, y: next.y, expected }),
+      })
+      if (res.status === 409) {
+        const data = (await res.json()) as { current: Position }
+        lastConfirmed.current.set(next.id, data.current)
+        if (data.current.x !== null && data.current.y !== null) {
+          setLocalPosition(next.id, data.current.x, data.current.y)
+        }
+        setStatus({
+          kind: 'stale',
+          text: `${name} was moved in Airtable since you loaded – shown at its current position (${
+            data.current.x === null ? '–' : fmt(data.current.x)
+          }, ${data.current.y === null ? '–' : fmt(data.current.y)}). Drag again if you still want to move it.`,
+        })
+      } else if (!res.ok) {
+        let message = `Save failed (${res.status})`
+        try {
+          const data = (await res.json()) as { error?: string }
+          if (data.error) message = `Save failed (${res.status}): ${data.error}`
+        } catch {
+          // non-JSON error body; keep the status text
+        }
+        throw new Error(message)
+      } else {
+        const data = (await res.json()) as {
+          record: { id: string; x: number; y: number }
+        }
+        const stored = data.record
+        if (!next.isUndo && expected.x !== null && expected.y !== null) {
+          pushUndo({
+            id: next.id,
+            from: { x: expected.x, y: expected.y },
+            to: { x: stored.x, y: stored.y },
+            at: Date.now(),
+          })
+        }
+        lastConfirmed.current.set(next.id, { x: stored.x, y: stored.y })
+        setLocalPosition(next.id, stored.x, stored.y)
+        setStatus({
+          kind: 'ok',
+          text: `Saved ${name} at (${fmt(stored.x)}, ${fmt(stored.y)}) · ${new Date().toLocaleTimeString()}`,
+        })
+        setErrorBanner(null)
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      const back = lastConfirmed.current.get(next.id)
+      if (back && back.x !== null && back.y !== null) {
+        setLocalPosition(next.id, back.x, back.y)
+      }
+      setStatus({ kind: 'error', text: `Not saved: ${name}` })
+      setErrorBanner({ text: message, retry: next })
+    } finally {
+      inFlight.current = null
+      if (queue.current.length) void processQueue()
+    }
+  }, [pushUndo, setLocalPosition])
+
+  const enqueue = useCallback(
+    (move: QueuedMove) => {
+      // A newer move of the same pin replaces the one still waiting.
+      queue.current = queue.current.filter(m => m.id !== move.id)
+      queue.current.push(move)
+      void processQueue()
+    },
+    [processQueue]
+  )
+
+  const moveRecord = useCallback(
+    (id: string, x: number, y: number, isUndo = false) => {
+      const c = clampGrid(roundGrid(x), roundGrid(y))
+      setLocalPosition(id, c.x, c.y)
+      enqueue({ id, x: c.x, y: c.y, isUndo })
+    },
+    [enqueue, setLocalPosition]
+  )
+
+  const undo = useCallback(() => {
+    const last = undoRef.current[undoRef.current.length - 1]
+    if (!last) return
+    setUndoStack(prev => prev.slice(0, -1))
+    moveRecord(last.id, last.from.x, last.from.y, true)
+  }, [moveRecord])
+
+  // ── Canvas callbacks ─────────────────────────────────────────────────────
+
+  const onDrop = useCallback(
+    (id: string, x: number, y: number, clamped: boolean) => {
+      moveRecord(id, x, y)
+      if (clamped) {
+        setStatus({
+          kind: 'saving',
+          text: 'Dropped past the edge – clamped to the map edge…',
+        })
+      }
+      setSelectedId(id)
+      setPanelTab('selected')
+    },
+    [moveRecord]
+  )
+
+  // Clicking a logo on the map opens its details in the side panel.
+  const onSelect = useCallback((id: string | null) => {
+    setSelectedId(id)
+    if (id) setPanelTab('selected')
+  }, [])
+
+  const onPlaceClick = useCallback(
+    (x: number, y: number) => {
+      const id = placeModeRef.current
+      if (!id) return
+      moveRecord(id, x, y)
+      setPlaceModeId(null)
+      setSelectedId(id)
+      setPanelTab('selected')
+    },
+    [moveRecord]
+  )
+
+  // ── Keyboard: Undo, Escape, arrow nudges ─────────────────────────────────
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null
+      const typing =
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable)
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'z' && !typing) {
+        e.preventDefault()
+        undo()
+        return
+      }
+      if (e.key === 'Escape') {
+        if (typing) return
+        if (placeModeRef.current) {
+          setPlaceModeId(null)
+          return
+        }
+        if (selectedRef.current) {
+          setSelectedId(null)
+          return
+        }
+        controlsRef.current.reset()
+        return
+      }
+      const selId = selectedRef.current
+      if (typing || !selId) return
+      const step = e.shiftKey ? 1 : 0.1
+      const rec = recordsRef.current?.find(r => r.id === selId)
+      if (!rec || rec.x === null || rec.y === null) return
+      let dx = 0
+      let dy = 0
+      if (e.key === 'ArrowLeft') dx = -step
+      else if (e.key === 'ArrowRight') dx = step
+      else if (e.key === 'ArrowUp') dy = -step
+      else if (e.key === 'ArrowDown') dy = step
+      else return
+      e.preventDefault()
+      moveRecord(rec.id, rec.x + dx, rec.y + dy)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [moveRecord, undo])
+
+  // ── Derived ──────────────────────────────────────────────────────────────
+
+  const visible = useMemo(() => {
+    if (!records) return []
+    return records.filter(r => {
+      if (previewPublic) return r.published
+      if (!showDrafts && !r.published) return false
+      if (!showFurniture && r.isMagic) return false
+      return true
+    })
+  }, [records, showDrafts, showFurniture, previewPublic])
+
+  const counts = useMemo(() => {
+    const all = records ?? []
+    const placed = all.filter(r => r.x !== null && r.y !== null).length
+    return {
+      total: all.length,
+      placed,
+      unplaced: all.length - placed,
+      drafts: all.filter(r => !r.published).length,
+    }
+  }, [records])
+
+  const selected = records?.find(r => r.id === selectedId) ?? null
+  const placing = records?.find(r => r.id === placeModeId) ?? null
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  return (
+    <div className={styles.page}>
+      <div className={adminStyles.pageHeading}>
+        <h1 className={adminStyles.pageTitle}>Map editor</h1>
+        <span className={adminStyles.pageMeta}>
+          Drag a logo to move it · click to select · saves to Airtable on drop ·{' '}
+          /map updates within a few minutes
+        </span>
+      </div>
+
+      <div className={`${adminStyles.editorToolbar} ${styles.toolbar}`}>
+        <span className={adminStyles.editorStatus}>
+          {records
+            ? `Live from Airtable · loaded ${
+                fetchedAt ? new Date(fetchedAt).toLocaleTimeString() : ''
+              } · ${counts.total} records · ${counts.placed} placed · ${
+                counts.unplaced
+              } unplaced · ${counts.drafts} drafts`
+            : 'Loading…'}
+        </span>
+        <button
+          type="button"
+          className={adminStyles.editorButton}
+          onClick={() => void load()}
+          disabled={dragging || !!inFlight.current}
+        >
+          Refresh
+        </button>
+        <button
+          type="button"
+          className={adminStyles.editorButton}
+          onClick={undo}
+          disabled={undoStack.length === 0}
+          title="Cmd/Ctrl+Z"
+        >
+          Undo{undoStack.length ? ` (${undoStack.length})` : ''}
+        </button>
+        <label className={styles.toggle}>
+          <input
+            type="checkbox"
+            checked={showDrafts}
+            onChange={e => setShowDrafts(e.target.checked)}
+            disabled={previewPublic}
+          />
+          Show drafts
+        </label>
+        <label className={styles.toggle}>
+          <input
+            type="checkbox"
+            checked={showFurniture}
+            onChange={e => setShowFurniture(e.target.checked)}
+            disabled={previewPublic}
+          />
+          Show furniture
+        </label>
+        <label className={styles.toggle}>
+          <input
+            type="checkbox"
+            checked={previewPublic}
+            onChange={e => setPreviewPublic(e.target.checked)}
+          />
+          Preview as public
+        </label>
+        <span
+          className={`${adminStyles.editorStatus} ${
+            status.kind === 'saving' ? adminStyles.editorStatusSaving : ''
+          } ${status.kind === 'error' ? adminStyles.convError : ''} ${
+            status.kind === 'stale' ? styles.statusStale : ''
+          }`}
+        >
+          {status.text}
+        </span>
+      </div>
+
+      {placing && (
+        <div className={`${adminStyles.notice} ${styles.placeNotice}`}>
+          Click on the map to place <strong>{placing.title}</strong>
+          {placing.area ? ` (its region is ${placing.area})` : ''}. Press Esc to
+          cancel.
+        </div>
+      )}
+
+      {errorBanner && (
+        <div className={`${adminStyles.notice} ${styles.errorBanner}`}>
+          <span>{errorBanner.text}</span>
+          <span className={styles.errorActions}>
+            {errorBanner.retry && (
+              <button
+                type="button"
+                className={adminStyles.editorButtonPrimary}
+                onClick={() => {
+                  const m = errorBanner.retry!
+                  setErrorBanner(null)
+                  moveRecord(m.id, m.x, m.y, m.isUndo)
+                }}
+              >
+                Retry
+              </button>
+            )}
+            <button
+              type="button"
+              className={adminStyles.editorButton}
+              onClick={() => setErrorBanner(null)}
+            >
+              Dismiss
+            </button>
+          </span>
+        </div>
+      )}
+
+      {loadError && (
+        <div className={`${adminStyles.notice} ${styles.errorBanner}`}>
+          <span>{loadError}</span>
+          <button
+            type="button"
+            className={adminStyles.editorButtonPrimary}
+            onClick={() => void load()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <div className={styles.split}>
+        <div className={styles.canvasWrap}>
+          {records ? (
+            <MapEditorCanvas
+              records={visible}
+              selectedId={selectedId}
+              placeModeId={placeModeId}
+              previewPublic={previewPublic}
+              onDrop={onDrop}
+              onSelect={onSelect}
+              onPlaceClick={onPlaceClick}
+              onDragStateChange={setDragging}
+              controlsRef={controlsRef}
+            />
+          ) : (
+            <div className={`${styles.canvas} ${styles.canvasLoading}`}>
+              <p className="paragraph-small color-teal-300">
+                {loadError ? 'Could not load the map.' : 'Loading map…'}
+              </p>
+            </div>
+          )}
+        </div>
+        {!previewPublic && (
+          <SidePanel
+            records={records ?? []}
+            selected={selected}
+            placeModeId={placeModeId}
+            tab={panelTab}
+            onTabChange={setPanelTab}
+            onPlace={id => {
+              setPlaceModeId(prev => (prev === id ? null : id))
+              setSelectedId(id)
+            }}
+            onSetPosition={(id, x, y) => moveRecord(id, x, y)}
+          />
+        )}
+      </div>
+
+      <p className={`${adminStyles.sectionHint} ${styles.footnote}`}>
+        Only x and y are written – publishing, hiding and Scale stay in
+        Airtable. Undo is per tab and cleared on reload. Desktop only.
+      </p>
+    </div>
+  )
+}

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -518,7 +518,7 @@ export default function MapEditor() {
       <div className={`${adminStyles.notice} ${styles.liveWarning}`}>
         <strong>This edits the live site.</strong> Every move is saved to
         Airtable straight away and appears on the public /map within a few
-        minutes. Please don&apos;t play with this :)
+        minutes.
       </div>
 
       <div className={adminStyles.pageHeading}>

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -87,7 +87,6 @@ export default function MapEditor() {
   const [undoStack, setUndoStack] = useState<UndoEntry[]>([])
   const [redoStack, setRedoStack] = useState<UndoEntry[]>([])
   const [showDrafts, setShowDrafts] = useState(true)
-  const [showFurniture, setShowFurniture] = useState(true)
   const [previewPublic, setPreviewPublic] = useState(false)
   const [dragging, setDragging] = useState(false)
   // True while any save is queued or in flight (Undo waits for it).
@@ -492,10 +491,9 @@ export default function MapEditor() {
     return records.filter(r => {
       if (previewPublic) return r.published
       if (!showDrafts && !r.published) return false
-      if (!showFurniture && r.isMagic) return false
       return true
     })
-  }, [records, showDrafts, showFurniture, previewPublic])
+  }, [records, showDrafts, previewPublic])
 
   const counts = useMemo(() => {
     const all = records ?? []
@@ -573,15 +571,6 @@ export default function MapEditor() {
             disabled={previewPublic}
           />
           Show drafts
-        </label>
-        <label className={styles.toggle}>
-          <input
-            type="checkbox"
-            checked={showFurniture}
-            onChange={e => setShowFurniture(e.target.checked)}
-            disabled={previewPublic}
-          />
-          Show furniture
         </label>
         <label className={styles.toggle}>
           <input

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -460,7 +460,7 @@ export default function MapEditor() {
       <div className={`${adminStyles.notice} ${styles.liveWarning}`}>
         <strong>This edits the live site.</strong> Every move is saved to
         Airtable straight away and appears on the public /map within a few
-        minutes. Please don&apos;t experiment here unless you mean it.
+        minutes. Please don&apos;t play with this :)
       </div>
 
       <div className={adminStyles.pageHeading}>

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -684,7 +684,7 @@ export default function MapEditor() {
 
       <p className={`${adminStyles.sectionHint} ${styles.footnote}`}>
         Only x and y are written – publishing, hiding and Scale stay in
-        Airtable. Undo/Redo are per tab and cleared on reload. Desktop only.
+        Airtable.
       </p>
     </div>
   )

--- a/src/app/admin/map/MapEditorCanvas.tsx
+++ b/src/app/admin/map/MapEditorCanvas.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useRef } from 'react'
 import * as d3 from 'd3'
 import MapControls from '@/components/MapControls'
+import { positionTooltip } from '@/lib/mapTooltip'
 import {
   AREA_LABELS,
   AREA_LABEL_STYLE,
@@ -186,6 +187,7 @@ export default function MapEditorCanvas({
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const hudRef = useRef<HTMLDivElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
   const pinsLayerRef = useRef<SVGGElement | null>(null)
   const svgRef = useRef<SVGSVGElement | null>(null)
   // Latest callbacks/state, read from inside d3 handlers without rebinding.
@@ -195,6 +197,13 @@ export default function MapEditorCanvas({
   placeModeRef.current = placeModeId
   const draggingRef = useRef(false)
   const movedRef = useRef(false)
+
+  const hideTooltip = () => {
+    const tt = tooltipRef.current
+    if (!tt) return
+    tt.style.visibility = 'hidden'
+    tt.style.opacity = '0'
+  }
 
   // ── Static scene: built once ─────────────────────────────────────────────
   useEffect(() => {
@@ -221,6 +230,7 @@ export default function MapEditorCanvas({
       .zoom<SVGSVGElement, unknown>()
       .scaleExtent(ZOOM_EXTENT)
       .on('zoom', event => {
+        hideTooltip()
         svgGroup.attr(
           'transform',
           `translate(${event.transform.x + MAP_OFFSET_X}, ${
@@ -304,15 +314,19 @@ export default function MapEditorCanvas({
     const pinsLayer = svgGroup.append('g').attr('class', 'pins')
     pinsLayerRef.current = pinsLayer.node()
 
-    // Place mode: a plain click (no pan) on the map drops the tray record.
+    // A plain click on empty map (a pan suppresses the click): in place mode
+    // it drops the tray record, otherwise it deselects. Pins stop propagation.
     svg.on('click', event => {
-      if (!placeModeRef.current) return
-      const [px, py] = d3.pointer(event, pinsLayer.node())
-      const { x, y } = clampGrid(
-        roundGrid(pxToGrid(px)),
-        roundGrid(pxToGrid(py))
-      )
-      cbRef.current.onPlaceClick(x, y)
+      if (placeModeRef.current) {
+        const [px, py] = d3.pointer(event, pinsLayer.node())
+        const { x, y } = clampGrid(
+          roundGrid(pxToGrid(px)),
+          roundGrid(pxToGrid(py))
+        )
+        cbRef.current.onPlaceClick(x, y)
+        return
+      }
+      cbRef.current.onSelect(null)
     })
 
     controlsRef.current = {
@@ -363,6 +377,7 @@ export default function MapEditorCanvas({
           // that selects a pin.
           d3.select(this).raise()
           if (hudRef.current) hudRef.current.style.display = 'block'
+          hideTooltip()
         }
         d3.select(this).attr('transform', `translate(${event.x}, ${event.y})`)
         if (hudRef.current) {
@@ -415,6 +430,27 @@ export default function MapEditorCanvas({
         event.stopPropagation()
         cbRef.current.onSelect(d.id)
       })
+      // Same hover as /map: the tooltip shows Long name + description.
+      .on('mouseenter', function (event, d) {
+        if (draggingRef.current) return
+        const tt = tooltipRef.current
+        const container = containerRef.current
+        if (!tt || !container) return
+        tt.querySelector('strong')!.textContent = d.tooltipTitle
+        tt.querySelector('span')!.textContent =
+          d.description ?? '(no description yet)'
+        tt.style.visibility = 'visible'
+        tt.style.opacity = '1'
+        positionTooltip(event.clientX, event.clientY, tt, container)
+      })
+      .on('mousemove', function (event) {
+        if (draggingRef.current) return
+        const tt = tooltipRef.current
+        const container = containerRef.current
+        if (!tt || !container) return
+        positionTooltip(event.clientX, event.clientY, tt, container)
+      })
+      .on('mouseleave', hideTooltip)
     entered.each(function () {
       drawGlyph(d3.select<SVGGElement, EditorRecord>(this))
     })
@@ -475,6 +511,15 @@ export default function MapEditorCanvas({
         onReset={() => controlsRef.current.reset()}
       />
       <div ref={hudRef} className={styles.hud} style={{ display: 'none' }} />
+      {/* Tooltip — always in the DOM for measuring, toggled via ref */}
+      <div
+        ref={tooltipRef}
+        className={styles.tooltip}
+        style={{ visibility: 'hidden', opacity: 0 }}
+      >
+        <strong></strong>
+        <span></span>
+      </div>
     </>
   )
 }

--- a/src/app/admin/map/MapEditorCanvas.tsx
+++ b/src/app/admin/map/MapEditorCanvas.tsx
@@ -1,0 +1,469 @@
+'use client'
+
+/*
+  The editor's map canvas. Draws the same scene as the public /map (same
+  background, title, area labels, logo sizes and label pills — see
+  src/lib/admin/map-geometry.ts, a guarded copy of D3Map's numbers) and adds
+  what the public map must never have: draggable pins, a place-mode click,
+  selection/draft rings, and a live x/y readout.
+
+  Kept deliberately separate from src/app/map/D3Map.tsx: nothing in here is
+  imported by the public map, and nothing here imports it. No analytics.
+*/
+
+import { useEffect, useRef } from 'react'
+import * as d3 from 'd3'
+import MapControls from '@/components/MapControls'
+import {
+  AREA_LABELS,
+  AREA_LABEL_STYLE,
+  BACKGROUND_IMAGE_URL,
+  MAP_HEIGHT,
+  MAP_OFFSET_X,
+  MAP_OFFSET_Y,
+  MAP_WIDTH,
+  PRESERVE_ASPECT_RATIO,
+  TITLE,
+  VIEWBOX,
+  ZOOM_EXTENT,
+  clampGrid,
+  gridToPx,
+  logoMetrics,
+  pxToGrid,
+  roundGrid,
+} from '@/lib/admin/map-geometry'
+import type { EditorRecord } from '@/lib/admin/map-editor-core'
+import styles from './map-editor.module.css'
+
+export interface CanvasControls {
+  zoomIn: () => void
+  zoomOut: () => void
+  reset: () => void
+}
+
+interface Props {
+  /** Records to draw (already filtered by the toolbar toggles). Records with
+   *  no x/y are skipped — they live in the side tray. */
+  records: EditorRecord[]
+  selectedId: string | null
+  /** Record currently being placed from the tray (click on the map drops it). */
+  placeModeId: string | null
+  /** Hide every editor-only decoration so the canvas matches /map. */
+  previewPublic: boolean
+  onDrop: (id: string, x: number, y: number, clamped: boolean) => void
+  onSelect: (id: string | null) => void
+  onPlaceClick: (x: number, y: number) => void
+  onDragStateChange: (dragging: boolean) => void
+  /** Filled in by the canvas so the parent (keyboard shortcuts) can zoom. */
+  controlsRef: React.MutableRefObject<CanvasControls>
+}
+
+const LOGO_CLIP_ID = 'editor-logo-circle-clip'
+const RING_GAP = 3
+
+type PinSel = d3.Selection<SVGGElement, EditorRecord, SVGGElement, unknown>
+
+function glyphSignature(r: EditorRecord): string {
+  return `${r.scale ?? ''}|${r.labelName}|${r.mapLogo ?? ''}`
+}
+
+/** Draws one pin's children (same element order and metrics as D3Map). */
+function drawGlyph(
+  g: d3.Selection<SVGGElement, EditorRecord, null, undefined>
+) {
+  g.selectAll('*').remove()
+  const r = g.datum()
+  const m = logoMetrics(r.scale)
+
+  // Editor-only rings sit underneath the glyph so they never cover it.
+  g.append('circle')
+    .attr('class', 'ring-draft')
+    .attr('r', m.iconSize / 2 + RING_GAP)
+    .attr('fill', 'none')
+    .attr('stroke', '#f5b942')
+    .attr('stroke-width', 2)
+    .attr('stroke-dasharray', '6 4')
+    .style('pointer-events', 'none')
+  g.append('circle')
+    .attr('class', 'ring-selected')
+    .attr('r', m.iconSize / 2 + RING_GAP)
+    .attr('fill', 'none')
+    .attr('stroke', '#a6dad9')
+    .attr('stroke-width', 3)
+    .style('pointer-events', 'none')
+
+  const glyph = g.append('g').attr('class', 'glyph')
+
+  // White circle background
+  glyph
+    .append('circle')
+    .attr('r', m.iconSize / 2)
+    .attr('cx', 0)
+    .attr('cy', 0)
+    .attr('fill', '#fff')
+
+  if (r.mapLogo) {
+    const logoImg = glyph
+      .append('image')
+      .attr('href', r.mapLogo)
+      .attr('width', m.contentSize)
+      .attr('height', m.contentSize)
+      .attr('x', -m.contentSize / 2)
+      .attr('y', -m.contentSize / 2)
+      .attr('preserveAspectRatio', 'xMidYMid meet')
+      .attr('clip-path', `url(#${LOGO_CLIP_ID})`)
+    logoImg.on('error', () => {
+      logoImg.remove()
+      glyph
+        .append('circle')
+        .attr('r', m.contentSize / 2)
+        .attr('cx', 0)
+        .attr('cy', 0)
+        .attr('fill', '#f70')
+    })
+  } else {
+    glyph
+      .append('circle')
+      .attr('r', m.contentSize / 2)
+      .attr('cx', 0)
+      .attr('cy', 0)
+      .attr('fill', 'red')
+  }
+
+  // Label below logo
+  const labelG = glyph
+    .append('g')
+    .attr('transform', `translate(0, ${m.labelY})`)
+  const textEl = labelG
+    .append('text')
+    .attr('text-anchor', 'middle')
+    .attr('font-family', 'Inter, sans-serif')
+    .attr('font-weight', 600)
+    .attr('font-size', m.fontSize)
+    .style('letter-spacing', '-0.02em')
+    .attr('fill', '#000')
+    .text(r.labelName)
+  const bbox = textEl.node()?.getBBox()
+  if (bbox) {
+    const rectW = bbox.width + m.padX * 2
+    const rectH = bbox.height + m.padY * 2
+    labelG
+      .insert('rect', 'text')
+      .attr('x', -rectW / 2)
+      .attr('y', -rectH / 2)
+      .attr('width', rectW)
+      .attr('height', rectH)
+      .attr('rx', rectH / 2)
+      .attr('ry', rectH / 2)
+      .attr('fill', '#fff')
+    textEl.attr('y', bbox.height * 0.35)
+
+    // Bridge rect between logo and label (a forgiving grab zone).
+    const bridgeW = Math.max(m.iconSize, rectW)
+    const bridgeH = (m.iconSize + rectH) / 2 + m.labelOffset
+    glyph
+      .append('rect')
+      .attr('x', -bridgeW / 2)
+      .attr('y', 0)
+      .attr('width', bridgeW)
+      .attr('height', bridgeH)
+      .attr('fill', 'transparent')
+      .lower()
+  }
+  g.attr('data-sig', glyphSignature(r))
+}
+
+export default function MapEditorCanvas({
+  records,
+  selectedId,
+  placeModeId,
+  previewPublic,
+  onDrop,
+  onSelect,
+  onPlaceClick,
+  onDragStateChange,
+  controlsRef,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const hudRef = useRef<HTMLDivElement>(null)
+  const pinsLayerRef = useRef<SVGGElement | null>(null)
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  // Latest callbacks/state, read from inside d3 handlers without rebinding.
+  const cbRef = useRef({ onDrop, onSelect, onPlaceClick, onDragStateChange })
+  cbRef.current = { onDrop, onSelect, onPlaceClick, onDragStateChange }
+  const placeModeRef = useRef(placeModeId)
+  placeModeRef.current = placeModeId
+  const draggingRef = useRef(false)
+
+  // ── Static scene: built once ─────────────────────────────────────────────
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    d3.select(container).select('svg').remove()
+
+    const svg = d3
+      .select(container)
+      .append('svg')
+      .attr('width', '100%')
+      .attr('height', '100%')
+      .attr('viewBox', VIEWBOX)
+      .attr('preserveAspectRatio', PRESERVE_ASPECT_RATIO)
+      .style('transform', 'translateZ(0)')
+      .style('backface-visibility', 'hidden')
+    svgRef.current = svg.node()
+
+    const svgGroup = svg
+      .append('g')
+      .attr('transform', `translate(${MAP_OFFSET_X}, ${MAP_OFFSET_Y})`)
+
+    const zoom = d3
+      .zoom<SVGSVGElement, unknown>()
+      .scaleExtent(ZOOM_EXTENT)
+      .on('zoom', event => {
+        svgGroup.attr(
+          'transform',
+          `translate(${event.transform.x + MAP_OFFSET_X}, ${
+            event.transform.y + MAP_OFFSET_Y
+          }) scale(${event.transform.k})`
+        )
+      })
+    svg.call(zoom)
+
+    const svgNode = svg.node()!
+    const preventPageZoom = (e: WheelEvent) => e.preventDefault()
+    svgNode.addEventListener('wheel', preventPageZoom, { passive: false })
+
+    svg
+      .append('defs')
+      .append('clipPath')
+      .attr('id', LOGO_CLIP_ID)
+      .attr('clipPathUnits', 'objectBoundingBox')
+      .append('circle')
+      .attr('cx', 0.5)
+      .attr('cy', 0.5)
+      .attr('r', 0.5)
+
+    svgGroup
+      .append('image')
+      .attr('xlink:href', BACKGROUND_IMAGE_URL)
+      .attr('width', MAP_WIDTH)
+      .attr('height', MAP_HEIGHT)
+      .attr('x', 0)
+      .attr('y', 0)
+
+    svgGroup
+      .append('text')
+      .attr('x', gridToPx(TITLE.gridX))
+      .attr('y', gridToPx(TITLE.gridY))
+      .attr('text-anchor', 'middle')
+      .attr('font-family', 'Inter, sans-serif')
+      .attr('font-weight', TITLE.fontWeight)
+      .attr('font-size', TITLE.fontSize)
+      .style('letter-spacing', TITLE.letterSpacing)
+      .attr('fill', '#fff')
+      .text(TITLE.text)
+
+    const s = AREA_LABEL_STYLE
+    const finalFontSize = s.baseFontSize * s.labelScale
+    const finalPadX = s.basePadX * s.labelScale
+    const finalPadY = s.basePadY * s.labelScale
+    AREA_LABELS.forEach(({ label, x, y }) => {
+      const labelGroup = svgGroup
+        .append('g')
+        .attr('class', 'area-label')
+        .attr('data-area', label)
+        .attr('transform', `translate(${gridToPx(x)}, ${gridToPx(y)})`)
+        .style('user-select', 'none')
+        .style('pointer-events', 'none')
+      const textEl = labelGroup
+        .append('text')
+        .attr('x', 0)
+        .attr('y', 0)
+        .attr('text-anchor', 'middle')
+        .attr('font-family', 'Inter, sans-serif')
+        .attr('font-weight', s.fontWeight)
+        .attr('font-size', finalFontSize)
+        .style('letter-spacing', s.letterSpacing)
+        .attr('fill', '#fff')
+        .text(label)
+      const bbox = textEl.node()?.getBBox()
+      if (bbox) {
+        labelGroup
+          .insert('rect', 'text')
+          .attr('x', bbox.x - finalPadX)
+          .attr('y', bbox.y - finalPadY)
+          .attr('width', bbox.width + finalPadX * 2)
+          .attr('height', bbox.height + finalPadY * 2)
+          .attr('rx', (bbox.height + finalPadY * 2) / 2)
+          .attr('ry', (bbox.height + finalPadY * 2) / 2)
+          .attr('fill', s.pillFill)
+      }
+    })
+
+    const pinsLayer = svgGroup.append('g').attr('class', 'pins')
+    pinsLayerRef.current = pinsLayer.node()
+
+    // Place mode: a plain click (no pan) on the map drops the tray record.
+    svg.on('click', event => {
+      if (!placeModeRef.current) return
+      const [px, py] = d3.pointer(event, pinsLayer.node())
+      const { x, y } = clampGrid(
+        roundGrid(pxToGrid(px)),
+        roundGrid(pxToGrid(py))
+      )
+      cbRef.current.onPlaceClick(x, y)
+    })
+
+    controlsRef.current = {
+      zoomIn: () => {
+        svg.transition().duration(300).call(zoom.scaleBy, 1.5)
+      },
+      zoomOut: () => {
+        svg.transition().duration(300).call(zoom.scaleBy, 0.75)
+      },
+      reset: () => {
+        svg.transition().duration(500).call(zoom.transform, d3.zoomIdentity)
+      },
+    }
+
+    return () => {
+      svgNode.removeEventListener('wheel', preventPageZoom)
+      d3.select(container).select('svg').remove()
+      pinsLayerRef.current = null
+      svgRef.current = null
+    }
+    // The scene is static; records are applied by the effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // ── Pins: keyed data join, never rebuilds the scene or resets zoom ───────
+  useEffect(() => {
+    const layerNode = pinsLayerRef.current
+    if (!layerNode) return
+    const layer = d3.select(layerNode)
+    const placed = records.filter(r => r.x !== null && r.y !== null)
+
+    const drag = d3
+      .drag<SVGGElement, EditorRecord>()
+      .container(layerNode)
+      .clickDistance(3)
+      .subject((_event, d) => ({ x: gridToPx(d.x!), y: gridToPx(d.y!) }))
+      .on('start', function () {
+        draggingRef.current = true
+        d3.select(this).raise().classed('dragging', true)
+        cbRef.current.onDragStateChange(true)
+        if (hudRef.current) hudRef.current.style.display = 'block'
+      })
+      .on('drag', function (event) {
+        d3.select(this).attr('transform', `translate(${event.x}, ${event.y})`)
+        if (hudRef.current) {
+          const gx = roundGrid(pxToGrid(event.x))
+          const gy = roundGrid(pxToGrid(event.y))
+          hudRef.current.textContent = `x ${gx.toFixed(1)} · y ${gy.toFixed(1)}`
+          hudRef.current.style.left = `${event.sourceEvent.clientX + 14}px`
+          hudRef.current.style.top = `${event.sourceEvent.clientY + 14}px`
+        }
+      })
+      .on('end', function (event, d) {
+        draggingRef.current = false
+        d3.select(this).classed('dragging', false)
+        if (hudRef.current) hudRef.current.style.display = 'none'
+        cbRef.current.onDragStateChange(false)
+        const rawX = roundGrid(pxToGrid(event.x))
+        const rawY = roundGrid(pxToGrid(event.y))
+        const { x, y } = clampGrid(rawX, rawY)
+        if (x !== d.x || y !== d.y) {
+          // Show it at the snapped/clamped spot straight away; the parent
+          // will confirm or revert once Airtable answers.
+          d3.select(this).attr(
+            'transform',
+            `translate(${gridToPx(x)}, ${gridToPx(y)})`
+          )
+          cbRef.current.onDrop(d.id, x, y, x !== rawX || y !== rawY)
+        } else {
+          d3.select(this).attr(
+            'transform',
+            `translate(${gridToPx(d.x!)}, ${gridToPx(d.y!)})`
+          )
+        }
+      })
+
+    const pins = layer
+      .selectAll<SVGGElement, EditorRecord>('g.pin')
+      .data(placed, d => d.id)
+
+    pins.exit().remove()
+
+    const entered = pins
+      .enter()
+      .append('g')
+      .attr('class', 'pin')
+      .attr('data-id', d => d.id)
+      .style('cursor', 'grab')
+      .on('click', function (event, d) {
+        event.stopPropagation()
+        cbRef.current.onSelect(d.id)
+      })
+    entered.each(function () {
+      drawGlyph(d3.select<SVGGElement, EditorRecord>(this))
+    })
+    entered.call(drag)
+
+    const all: PinSel = entered.merge(pins)
+    all.each(function (d) {
+      const g = d3.select<SVGGElement, EditorRecord>(this)
+      if (g.attr('data-sig') !== glyphSignature(d)) drawGlyph(g)
+    })
+    // Don't yank a pin out from under the cursor mid-drag.
+    all
+      .filter(function () {
+        return !d3.select(this).classed('dragging')
+      })
+      .attr('transform', d => `translate(${gridToPx(d.x!)}, ${gridToPx(d.y!)})`)
+
+    all
+      .select('.ring-draft')
+      .style('display', d => (!previewPublic && !d.published ? null : 'none'))
+    all
+      .select('.ring-selected')
+      .style('display', d =>
+        !previewPublic && d.id === selectedId ? null : 'none'
+      )
+
+    // Same stacking as /map: later records draw on top.
+    all.sort((a, b) => a.order - b.order)
+
+    // Highlight the selected/placing record's region label.
+    const focus =
+      records.find(r => r.id === (placeModeId ?? selectedId))?.area ?? null
+    d3.select(svgRef.current)
+      .selectAll<SVGGElement, unknown>('g.area-label')
+      .each(function () {
+        const area = this.getAttribute('data-area')
+        d3.select(this)
+          .select('rect')
+          .attr('stroke', !previewPublic && area === focus ? '#a6dad9' : null)
+          .attr('stroke-width', 3)
+      })
+  }, [records, selectedId, placeModeId, previewPublic])
+
+  // Crosshair while placing.
+  useEffect(() => {
+    if (svgRef.current) {
+      svgRef.current.style.cursor = placeModeId ? 'crosshair' : ''
+    }
+  }, [placeModeId])
+
+  return (
+    <>
+      <div ref={containerRef} className={styles.canvas} />
+      <MapControls
+        className={styles.controls}
+        onZoomIn={() => controlsRef.current.zoomIn()}
+        onZoomOut={() => controlsRef.current.zoomOut()}
+        onReset={() => controlsRef.current.reset()}
+      />
+      <div ref={hudRef} className={styles.hud} style={{ display: 'none' }} />
+    </>
+  )
+}

--- a/src/app/admin/map/MapEditorCanvas.tsx
+++ b/src/app/admin/map/MapEditorCanvas.tsx
@@ -378,6 +378,7 @@ export default function MapEditorCanvas({
           d3.select(this).raise()
           if (hudRef.current) hudRef.current.style.display = 'block'
           hideTooltip()
+          containerRef.current?.classList.add('is-dragging')
         }
         d3.select(this).attr('transform', `translate(${event.x}, ${event.y})`)
         if (hudRef.current) {
@@ -391,6 +392,7 @@ export default function MapEditorCanvas({
       .on('end', function (event, d) {
         draggingRef.current = false
         d3.select(this).classed('dragging', false)
+        containerRef.current?.classList.remove('is-dragging')
         if (hudRef.current) hudRef.current.style.display = 'none'
         cbRef.current.onDragStateChange(false)
         const rawX = roundGrid(pxToGrid(event.x))

--- a/src/app/admin/map/MapEditorCanvas.tsx
+++ b/src/app/admin/map/MapEditorCanvas.tsx
@@ -194,6 +194,7 @@ export default function MapEditorCanvas({
   const placeModeRef = useRef(placeModeId)
   placeModeRef.current = placeModeId
   const draggingRef = useRef(false)
+  const movedRef = useRef(false)
 
   // ── Static scene: built once ─────────────────────────────────────────────
   useEffect(() => {
@@ -349,12 +350,20 @@ export default function MapEditorCanvas({
       .clickDistance(3)
       .subject((_event, d) => ({ x: gridToPx(d.x!), y: gridToPx(d.y!) }))
       .on('start', function () {
+        movedRef.current = false
         draggingRef.current = true
-        d3.select(this).raise().classed('dragging', true)
+        d3.select(this).classed('dragging', true)
         cbRef.current.onDragStateChange(true)
-        if (hudRef.current) hudRef.current.style.display = 'block'
       })
       .on('drag', function (event) {
+        if (!movedRef.current) {
+          movedRef.current = true
+          // Lift the pin above its neighbours only once it actually moves.
+          // Moving the node in the DOM on mousedown would swallow the click
+          // that selects a pin.
+          d3.select(this).raise()
+          if (hudRef.current) hudRef.current.style.display = 'block'
+        }
         d3.select(this).attr('transform', `translate(${event.x}, ${event.y})`)
         if (hudRef.current) {
           const gx = roundGrid(pxToGrid(event.x))
@@ -372,7 +381,9 @@ export default function MapEditorCanvas({
         const rawX = roundGrid(pxToGrid(event.x))
         const rawY = roundGrid(pxToGrid(event.y))
         const { x, y } = clampGrid(rawX, rawY)
-        if (x !== d.x || y !== d.y) {
+        // A plain click (no movement) never writes, even if the stored value
+        // would round or clamp differently.
+        if (movedRef.current && (x !== d.x || y !== d.y)) {
           // Show it at the snapped/clamped spot straight away; the parent
           // will confirm or revert once Airtable answers.
           d3.select(this).attr(

--- a/src/app/admin/map/SidePanel.tsx
+++ b/src/app/admin/map/SidePanel.tsx
@@ -25,7 +25,7 @@ function Badges({ r }: { r: EditorRecord }) {
   return (
     <span className={styles.badges}>
       <span className={r.published ? styles.badgeLive : styles.badgeDraft}>
-        {r.published ? 'Published' : 'Draft'}
+        {r.published ? 'Published' : 'Unpublished'}
       </span>
       {r.isMagic && <span className={styles.badgeWarn}>furniture</span>}
       {!r.mapLogo && <span className={styles.badgeWarn}>no map logo</span>}

--- a/src/app/admin/map/SidePanel.tsx
+++ b/src/app/admin/map/SidePanel.tsx
@@ -151,7 +151,7 @@ export default function SidePanel({
                   <span className={styles.rowMain}>
                     <span className={styles.rowTitle}>{r.title}</span>
                     <span className={styles.rowMeta}>
-                      {r.area ?? r.category ?? '—'}
+                      {r.category || '—'}
                       {r.scale ? ` · ${r.scale}` : ''}
                     </span>
                     <Badges r={r} />
@@ -195,7 +195,6 @@ export default function SidePanel({
                   <span className={styles.rowTitle}>{selected.title}</span>
                   <span className={styles.rowMeta}>
                     {selected.category || '—'}
-                    {selected.area ? ` → ${selected.area}` : ''}
                   </span>
                   <Badges r={selected} />
                 </span>

--- a/src/app/admin/map/SidePanel.tsx
+++ b/src/app/admin/map/SidePanel.tsx
@@ -1,0 +1,285 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { EditorRecord } from '@/lib/admin/map-editor-core'
+import { MAP_TABLE_ID } from '@/lib/admin/map-editor-core'
+import { GRID_BOUNDS } from '@/lib/admin/map-geometry'
+import adminStyles from '../admin.module.css'
+import styles from './map-editor.module.css'
+
+const AIRTABLE_BASE_URL = 'https://airtable.com/appF8XfZUGXtfi40E'
+
+export type PanelTab = 'unplaced' | 'selected'
+
+interface Props {
+  records: EditorRecord[]
+  selected: EditorRecord | null
+  placeModeId: string | null
+  tab: PanelTab
+  onTabChange: (tab: PanelTab) => void
+  onPlace: (id: string) => void
+  onSetPosition: (id: string, x: number, y: number) => void
+}
+
+function Badges({ r }: { r: EditorRecord }) {
+  return (
+    <span className={styles.badges}>
+      <span className={r.published ? styles.badgeLive : styles.badgeDraft}>
+        {r.published ? 'Published' : 'Draft'}
+      </span>
+      {r.isMagic && <span className={styles.badgeWarn}>furniture</span>}
+      {!r.mapLogo && <span className={styles.badgeWarn}>no map logo</span>}
+      {!r.description && (
+        <span className={styles.badgeWarn}>no description</span>
+      )}
+      {!r.scale && (
+        <span className={styles.badgeWarn}>no Scale (drawn Medium)</span>
+      )}
+    </span>
+  )
+}
+
+function airtableUrl(id: string): string {
+  return `${AIRTABLE_BASE_URL}/${MAP_TABLE_ID}/${id}`
+}
+
+export default function SidePanel({
+  records,
+  selected,
+  placeModeId,
+  tab,
+  onTabChange,
+  onPlace,
+  onSetPosition,
+}: Props) {
+  const [search, setSearch] = useState('')
+  // Typed-but-not-yet-applied x/y for the selected record.
+  const [draft, setDraft] = useState<{
+    id: string
+    x: string
+    y: string
+  } | null>(null)
+
+  const unplaced = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return records
+      .filter(r => r.x === null || r.y === null)
+      .filter(r => !q || r.title.toLowerCase().includes(q))
+      .sort((a, b) => {
+        if (a.published !== b.published) return a.published ? 1 : -1
+        return a.title.localeCompare(b.title)
+      })
+  }, [records, search])
+
+  const shownTab = tab
+  const xValue =
+    draft && selected && draft.id === selected.id
+      ? draft.x
+      : selected?.x === null || selected?.x === undefined
+        ? ''
+        : selected.x.toFixed(1)
+  const yValue =
+    draft && selected && draft.id === selected.id
+      ? draft.y
+      : selected?.y === null || selected?.y === undefined
+        ? ''
+        : selected.y.toFixed(1)
+
+  const submitPosition = () => {
+    if (!selected) return
+    const x = Number(xValue)
+    const y = Number(yValue)
+    if (
+      xValue === '' ||
+      yValue === '' ||
+      !Number.isFinite(x) ||
+      !Number.isFinite(y)
+    )
+      return
+    setDraft(null)
+    onSetPosition(selected.id, x, y)
+  }
+
+  return (
+    <aside className={styles.panel}>
+      <div className={styles.tabs}>
+        <button
+          type="button"
+          className={`${styles.tab} ${shownTab === 'unplaced' ? styles.tabActive : ''}`}
+          onClick={() => onTabChange('unplaced')}
+        >
+          Unplaced ({records.filter(r => r.x === null || r.y === null).length})
+        </button>
+        <button
+          type="button"
+          className={`${styles.tab} ${shownTab === 'selected' ? styles.tabActive : ''}`}
+          onClick={() => onTabChange('selected')}
+        >
+          Selected
+        </button>
+      </div>
+
+      {shownTab === 'unplaced' && (
+        <div className={styles.panelBody}>
+          <input
+            className={`${adminStyles.editorInput} ${styles.search}`}
+            placeholder="Search unplaced…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+          {unplaced.length === 0 ? (
+            <p className={adminStyles.sectionHint}>
+              {search ? 'No matches.' : 'Everything has coordinates.'}
+            </p>
+          ) : (
+            <ul className={styles.list}>
+              {unplaced.map(r => (
+                <li
+                  key={r.id}
+                  className={`${styles.row} ${
+                    placeModeId === r.id ? styles.rowPlacing : ''
+                  }`}
+                >
+                  <span className={styles.rowLogo}>
+                    {r.mapLogo ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={r.mapLogo} alt="" />
+                    ) : (
+                      <span className={styles.rowLogoMissing} />
+                    )}
+                  </span>
+                  <span className={styles.rowMain}>
+                    <span className={styles.rowTitle}>{r.title}</span>
+                    <span className={styles.rowMeta}>
+                      {r.area ?? r.category ?? '—'}
+                      {r.scale ? ` · ${r.scale}` : ''}
+                    </span>
+                    <Badges r={r} />
+                  </span>
+                  <button
+                    type="button"
+                    className={
+                      placeModeId === r.id
+                        ? adminStyles.editorButtonPrimary
+                        : adminStyles.editorButton
+                    }
+                    onClick={() => onPlace(r.id)}
+                  >
+                    {placeModeId === r.id ? 'Placing…' : 'Place'}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {shownTab === 'selected' && (
+        <div className={styles.panelBody}>
+          {!selected ? (
+            <p className={adminStyles.sectionHint}>
+              Click a logo on the map to select it.
+            </p>
+          ) : (
+            <div className={styles.detail}>
+              <div className={styles.detailHead}>
+                <span className={styles.rowLogo}>
+                  {selected.mapLogo ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={selected.mapLogo} alt="" />
+                  ) : (
+                    <span className={styles.rowLogoMissing} />
+                  )}
+                </span>
+                <span className={styles.rowMain}>
+                  <span className={styles.rowTitle}>{selected.title}</span>
+                  <span className={styles.rowMeta}>
+                    {selected.category || '—'}
+                    {selected.area ? ` → ${selected.area}` : ''}
+                  </span>
+                  <Badges r={selected} />
+                </span>
+              </div>
+              <dl className={styles.dl}>
+                <dt>Status</dt>
+                <dd>{selected.status}</dd>
+                <dt>Scale</dt>
+                <dd>{selected.scale ?? 'not set – drawn as Medium'}</dd>
+                <dt>Label</dt>
+                <dd>{selected.labelName}</dd>
+              </dl>
+              <div className={styles.coords}>
+                <label>
+                  x
+                  <input
+                    className={adminStyles.editorInput}
+                    type="number"
+                    step="0.1"
+                    min={GRID_BOUNDS.x[0]}
+                    max={GRID_BOUNDS.x[1]}
+                    value={xValue}
+                    onChange={e =>
+                      setDraft({
+                        id: selected.id,
+                        x: e.target.value,
+                        y: yValue,
+                      })
+                    }
+                    onKeyDown={e => e.key === 'Enter' && submitPosition()}
+                  />
+                </label>
+                <label>
+                  y
+                  <input
+                    className={adminStyles.editorInput}
+                    type="number"
+                    step="0.1"
+                    min={GRID_BOUNDS.y[0]}
+                    max={GRID_BOUNDS.y[1]}
+                    value={yValue}
+                    onChange={e =>
+                      setDraft({
+                        id: selected.id,
+                        x: xValue,
+                        y: e.target.value,
+                      })
+                    }
+                    onKeyDown={e => e.key === 'Enter' && submitPosition()}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className={adminStyles.editorButton}
+                  onClick={submitPosition}
+                >
+                  Set
+                </button>
+              </div>
+              <p className={adminStyles.sectionHint}>
+                Arrow keys nudge the selected logo by 0.1 (Shift: 1.0). Map is
+                0–{GRID_BOUNDS.x[1]} wide, 0–{GRID_BOUNDS.y[1]} tall.
+              </p>
+              {(selected.x === null || selected.y === null) && (
+                <button
+                  type="button"
+                  className={adminStyles.editorButtonPrimary}
+                  onClick={() => onPlace(selected.id)}
+                >
+                  {placeModeId === selected.id ? 'Placing…' : 'Place on map'}
+                </button>
+              )}
+              <a
+                className={styles.airtableLink}
+                href={airtableUrl(selected.id)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open in Airtable ↗
+              </a>
+            </div>
+          )}
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/src/app/admin/map/SidePanel.tsx
+++ b/src/app/admin/map/SidePanel.tsx
@@ -62,13 +62,17 @@ export default function SidePanel({
 
   const unplaced = useMemo(() => {
     const q = search.trim().toLowerCase()
-    return records
-      .filter(r => r.x === null || r.y === null)
-      .filter(r => !q || r.title.toLowerCase().includes(q))
-      .sort((a, b) => {
-        if (a.published !== b.published) return a.published ? 1 : -1
-        return a.title.localeCompare(b.title)
-      })
+    return (
+      records
+        .filter(r => r.x === null || r.y === null)
+        .filter(r => !q || r.title.toLowerCase().includes(q))
+        // Newest additions to Airtable first (same order as the Incoming
+        // suggestions view), then by name.
+        .sort((a, b) => {
+          const t = (b.createdTime ?? '').localeCompare(a.createdTime ?? '')
+          return t !== 0 ? t : a.title.localeCompare(b.title)
+        })
+    )
   }, [records, search])
 
   const shownTab = tab

--- a/src/app/admin/map/SidePanel.tsx
+++ b/src/app/admin/map/SidePanel.tsx
@@ -141,8 +141,8 @@ export default function SidePanel({
                 <li
                   key={r.id}
                   className={`${styles.row} ${
-                    placeModeId === r.id ? styles.rowPlacing : ''
-                  }`}
+                    r.published ? styles.rowLiveUnplaced : ''
+                  } ${placeModeId === r.id ? styles.rowPlacing : ''}`}
                 >
                   <span className={styles.rowLogo}>
                     {r.mapLogo ? (
@@ -158,6 +158,11 @@ export default function SidePanel({
                       {r.category || '—'}
                       {r.scale ? ` · ${r.scale}` : ''}
                     </span>
+                    {r.published && (
+                      <span className={styles.missingNote}>
+                        Published but not on the map yet
+                      </span>
+                    )}
                     <Badges r={r} />
                   </span>
                   <button

--- a/src/app/admin/map/layout.tsx
+++ b/src/app/admin/map/layout.tsx
@@ -4,20 +4,24 @@ import AdminHeader from '../AdminHeader'
 import { adminTabs, adminHomeHref } from '../nav'
 import styles from '../admin.module.css'
 
-export default async function ChatbotAdminLayout({
+export const metadata = {
+  title: 'Map editor – AISafety.com',
+  robots: { index: false, follow: false },
+}
+
+export default async function MapEditorLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const chatbot = await canViewChatbot()
   const analytics = await canViewAnalytics()
-  // A signed-in analytics-only volunteer is sent to the dashboard they're
-  // allowed to use; everyone else to the login page.
-  if (!(await canViewChatbot())) {
-    redirect(analytics ? '/admin/analytics' : '/admin/login')
+  // Only the owner password may move logos on the live map. Anyone else who
+  // is signed in goes to the area they can use; signed-out sessions to login.
+  if (!(await canEditMap())) {
+    redirect(adminHomeHref({ chatbot, analytics, mapEditor: false }))
   }
-  // Chatbot access is guaranteed here; adminTabs() still hides the Analytics tab
-  // from sessions that can't reach it (e.g. Successif).
-  const access = { chatbot: true, analytics, mapEditor: await canEditMap() }
+  const access = { chatbot, analytics, mapEditor: true }
   return (
     <>
       <AdminHeader tabs={adminTabs(access)} brandHref={adminHomeHref(access)} />

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -324,17 +324,13 @@
   font-size: 13px;
   font-weight: 500;
   color: var(--white);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .rowMeta {
   font-size: 11px;
   color: var(--teal-400);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .badges {

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -28,6 +28,17 @@
   accent-color: var(--bright-teal-300);
 }
 
+.liveWarning {
+  border-color: #f5b942;
+  color: #f5b942;
+  font-size: 13px;
+}
+
+.liveWarning strong {
+  color: #f5b942;
+  font-weight: 600;
+}
+
 .statusStale {
   color: #f5b942;
 }

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -1,0 +1,344 @@
+/* Admin map editor. Layout and editor-only chrome; colours use the site's
+   existing tokens. Buttons/inputs/status reuse admin.module.css classes. */
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.toolbar {
+  padding: 10px 12px;
+  background-color: var(--teal-850);
+  border: 1px solid var(--teal-800);
+  border-radius: 8px;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--teal-300);
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle input {
+  accent-color: var(--bright-teal-300);
+}
+
+.statusStale {
+  color: #f5b942;
+}
+
+.placeNotice {
+  border-color: var(--bright-teal-500);
+  color: var(--white);
+}
+
+.errorBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-color: #ff8b8b;
+  color: #ff8b8b;
+}
+
+.errorActions {
+  display: inline-flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 16px;
+  align-items: stretch;
+}
+
+.canvasWrap {
+  position: relative;
+  min-width: 0;
+}
+
+.canvas {
+  width: 100%;
+  height: calc(100vh - 260px);
+  min-height: 560px;
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid var(--teal-800);
+  background-color: var(--teal-900);
+}
+
+.canvas svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.canvas :global(g.pin.dragging) {
+  cursor: grabbing;
+}
+
+.canvasLoading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.controls {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 5;
+}
+
+.hud {
+  position: fixed;
+  z-index: 50;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background-color: var(--teal-850);
+  border: 1px solid var(--teal-700);
+  color: var(--white);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+/* ─── Side panel ─────────────────────────────────────────────────────── */
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: calc(100vh - 260px);
+  min-height: 560px;
+  background-color: var(--teal-850);
+  border: 1px solid var(--teal-800);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.tabs {
+  display: flex;
+  border-bottom: 1px solid var(--teal-800);
+}
+
+.tab {
+  flex: 1;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--teal-300);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.tab:hover {
+  color: var(--white);
+}
+
+.tabActive {
+  color: var(--white);
+  border-bottom-color: var(--bright-teal-300);
+}
+
+.panelBody {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.search {
+  width: 100%;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid var(--teal-800);
+  background-color: var(--teal-900);
+}
+
+.rowPlacing {
+  border-color: var(--bright-teal-300);
+}
+
+.rowLogo {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: var(--white);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.rowLogo img {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+}
+
+.rowLogoMissing {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background-color: red;
+}
+
+.rowMain {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.rowTitle {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--white);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rowMeta {
+  font-size: 11px;
+  color: var(--teal-400);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.badgeLive,
+.badgeDraft,
+.badgeWarn {
+  font-size: 10px;
+  line-height: 1;
+  padding: 3px 6px;
+  border-radius: 999px;
+  border: 1px solid;
+}
+
+.badgeLive {
+  color: var(--bright-teal-300);
+  border-color: var(--bright-teal-500);
+}
+
+.badgeDraft {
+  color: #f5b942;
+  border-color: #f5b942;
+}
+
+.badgeWarn {
+  color: var(--teal-300);
+  border-color: var(--teal-700);
+}
+
+.detail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.detailHead {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 12px;
+  margin: 0;
+  font-size: 12px;
+}
+
+.dl dt {
+  color: var(--teal-400);
+}
+
+.dl dd {
+  margin: 0;
+  color: var(--white);
+}
+
+.coords {
+  display: flex;
+  align-items: end;
+  gap: 8px;
+}
+
+.coords label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--teal-400);
+}
+
+.coords input {
+  width: 84px;
+}
+
+.airtableLink {
+  font-size: 12px;
+  color: var(--bright-teal-300);
+  text-decoration: none;
+}
+
+.airtableLink:hover {
+  text-decoration: underline;
+}
+
+.footnote {
+  margin-top: 4px;
+}
+
+@media (max-width: 991px) {
+  .split {
+    grid-template-columns: 1fr;
+  }
+  .panel {
+    height: auto;
+    min-height: 0;
+  }
+}

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -75,6 +75,25 @@
   min-width: 0;
 }
 
+/* Place-mode and error notices sit on top of the map, clear of the zoom
+   controls on the right, and take no layout space. */
+.overlays {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  right: 76px;
+  z-index: 6;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.overlays > * {
+  pointer-events: auto;
+  box-shadow: 0 8px 20px rgba(0, 25, 27, 0.5);
+}
+
 .canvas {
   width: 100%;
   height: calc(100vh - 260px);

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -96,6 +96,48 @@
   cursor: grabbing;
 }
 
+/* Same hover as /map's .mapItem: the glyph grows 1.2× around the logo centre. */
+.canvas :global(g.pin .glyph) {
+  transition: transform 0.3s;
+}
+
+.canvas :global(g.pin:hover .glyph) {
+  transform: scale(1.2);
+}
+
+/* Tooltip — mirrors /map's .map-tooltip */
+.tooltip {
+  position: fixed;
+  pointer-events: none;
+  background-color: var(--teal-850);
+  border: 1px solid var(--teal-700);
+  border-radius: 8px;
+  padding: 12px 16px;
+  max-width: 300px;
+  box-shadow: 0 12px 24px rgba(0, 25, 27, 0.5);
+  z-index: 1000;
+  transition: opacity 0.15s;
+}
+
+.tooltip strong {
+  display: block;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 165%;
+  letter-spacing: -0.3px;
+  color: var(--white);
+  margin-bottom: 4px;
+}
+
+.tooltip span {
+  display: block;
+  font-size: 13px;
+  font-weight: 300;
+  line-height: 167.5%;
+  letter-spacing: -0.2px;
+  color: var(--teal-300);
+}
+
 .canvasLoading {
   display: flex;
   align-items: center;

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -96,13 +96,21 @@
   cursor: grabbing;
 }
 
-/* Same hover as /map's .mapItem: the glyph grows 1.2× around the logo centre. */
+/* Same hover as /map's .mapItem: the glyph grows 1.2× around the logo centre.
+   Not while a pin is being dragged — the pin should follow the cursor at its
+   real size so it lands where it looks. */
 .canvas :global(g.pin .glyph) {
   transition: transform 0.3s;
 }
 
 .canvas :global(g.pin:hover .glyph) {
   transform: scale(1.2);
+}
+
+.canvas :global(g.pin.dragging .glyph),
+.canvas:global(.is-dragging) :global(g.pin:hover .glyph) {
+  transform: none;
+  transition: none;
 }
 
 /* Tooltip — mirrors /map's .map-tooltip */

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -277,6 +277,17 @@
   border-color: var(--bright-teal-300);
 }
 
+/* Published records with no coordinates are invisible on /map — flag them. */
+.rowLiveUnplaced {
+  border-color: #ff8b8b;
+  background-color: rgba(255, 139, 139, 0.06);
+}
+
+.missingNote {
+  font-size: 11px;
+  color: #ff8b8b;
+}
+
 .rowLogo {
   width: 32px;
   height: 32px;

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -223,8 +223,15 @@
   min-height: 0;
 }
 
+/* The body scrolls; its children keep their natural size (a long list must
+   not squash the search box). */
+.panelBody > * {
+  flex-shrink: 0;
+}
+
 .search {
   width: 100%;
+  height: 36px;
 }
 
 .list {

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -323,12 +323,14 @@
 .rowTitle {
   font-size: 13px;
   font-weight: 500;
+  line-height: 1.3;
   color: var(--white);
   overflow-wrap: anywhere;
 }
 
 .rowMeta {
   font-size: 11px;
+  line-height: 1.4;
   color: var(--teal-400);
   overflow-wrap: anywhere;
 }

--- a/src/app/admin/map/page.tsx
+++ b/src/app/admin/map/page.tsx
@@ -1,0 +1,10 @@
+import MapEditor from './MapEditor'
+
+// Nothing here is prerendered: the editor reads Airtable live in the browser
+// via /api/admin/map, so a build never touches the Map table for this page.
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export default function MapEditorPage() {
+  return <MapEditor />
+}

--- a/src/app/admin/nav.ts
+++ b/src/app/admin/nav.ts
@@ -6,7 +6,7 @@ export interface AdminNavTab {
   label: string
   /** Tabs are grouped in the header; a divider is drawn where the group changes
    *  (so the two chatbot tabs read as a pair, separate from Analytics). */
-  group: 'chatbot' | 'analytics'
+  group: 'chatbot' | 'analytics' | 'map'
 }
 
 export interface AdminAccess {
@@ -14,12 +14,18 @@ export interface AdminAccess {
   chatbot: boolean
   /** Session may reach /admin/analytics (every password but Successif). */
   analytics: boolean
+  /** Session may reach /admin/map (owner password only). */
+  mapEditor: boolean
 }
 
 /** Tabs shown in the admin header, limited to the areas this session can
  *  actually open — a tab the session would only be bounced out of is worse than
  *  no tab at all. */
-export function adminTabs({ chatbot, analytics }: AdminAccess): AdminNavTab[] {
+export function adminTabs({
+  chatbot,
+  analytics,
+  mapEditor,
+}: AdminAccess): AdminNavTab[] {
   return [
     ...(chatbot
       ? [
@@ -44,14 +50,28 @@ export function adminTabs({ chatbot, analytics }: AdminAccess): AdminNavTab[] {
           },
         ]
       : []),
+    ...(mapEditor
+      ? [
+          {
+            href: '/admin/map',
+            label: 'Map editor',
+            group: 'map' as const,
+          },
+        ]
+      : []),
   ]
 }
 
 /** Where a session should land when it has no particular destination: the
  *  first area it can open. Used for the header brand link and the post-login
  *  bounce so nobody is sent somewhere they'll be redirected out of. */
-export function adminHomeHref({ chatbot, analytics }: AdminAccess): string {
+export function adminHomeHref({
+  chatbot,
+  analytics,
+  mapEditor,
+}: AdminAccess): string {
   if (chatbot) return '/admin/chatbot/playground'
   if (analytics) return '/admin/analytics'
+  if (mapEditor) return '/admin/map'
   return '/admin/login'
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { canViewAnalytics, canViewChatbot } from '@/lib/admin/auth'
+import { canEditMap, canViewAnalytics, canViewChatbot } from '@/lib/admin/auth'
 import { adminHomeHref } from './nav'
 
 // /admin is an index that bounces to the right place: the first area this
@@ -9,6 +9,7 @@ export default async function AdminIndexPage() {
     adminHomeHref({
       chatbot: await canViewChatbot(),
       analytics: await canViewAnalytics(),
+      mapEditor: await canEditMap(),
     })
   )
 }

--- a/src/app/api/admin/map/route.ts
+++ b/src/app/api/admin/map/route.ts
@@ -48,8 +48,14 @@ async function ensureAuth(): Promise<Response | null> {
 export async function GET() {
   const auth = await ensureAuth()
   if (auth) return auth
-  const records = await listMapRecordsLive()
-  return json({ fetchedAt: new Date().toISOString(), records })
+  try {
+    const records = await listMapRecordsLive()
+    return json({ fetchedAt: new Date().toISOString(), records })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[map-editor] list failed: ${message}`)
+    return json({ error: message }, 502)
+  }
 }
 
 export async function PATCH(req: NextRequest) {
@@ -89,6 +95,9 @@ export async function PATCH(req: NextRequest) {
     // error (never swallowed); the details go to the server log too.
     const message = err instanceof Error ? err.message : String(err)
     console.error(`[map-editor] move failed for ${move.id}: ${message}`)
-    return json({ error: message }, 502)
+    // Airtable's rate limit (5 req/s per base, then a ~30 s lockout) comes
+    // back as 429 so the editor can wait and retry rather than give up.
+    const rateLimited = /\b429\b/.test(message) && /RATE_LIMIT/.test(message)
+    return json({ error: message }, rateLimited ? 429 : 502)
   }
 }

--- a/src/app/api/admin/map/route.ts
+++ b/src/app/api/admin/map/route.ts
@@ -1,0 +1,94 @@
+/*
+  Admin map editor API.
+
+  GET  /api/admin/map      → { fetchedAt, records }  (live Airtable read,
+                             published + unpublished, Hide? excluded)
+  PATCH /api/admin/map     → body { id, x, y, expected? }
+                             writes ONLY x and y on that record
+
+  Owner-password sessions only (canEditMap). Never revalidates any cache or
+  path: the public /map keeps refreshing on its own schedule.
+*/
+
+import { NextRequest } from 'next/server'
+import { canEditMap } from '@/lib/admin/auth'
+import {
+  getMapPosition,
+  isMapEditorConfigured,
+  listMapRecordsLive,
+  updateMapPosition,
+} from '@/lib/admin/map-editor'
+import {
+  samePosition,
+  validateMoveBody,
+  ValidationError,
+} from '@/lib/admin/map-editor-core'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+async function ensureAuth(): Promise<Response | null> {
+  if (!(await canEditMap())) return json({ error: 'unauthorized' }, 401)
+  if (!isMapEditorConfigured()) {
+    return json({ error: 'AIRTABLE_TOKEN / AIRTABLE_BASE_ID not set' }, 503)
+  }
+  return null
+}
+
+export async function GET() {
+  const auth = await ensureAuth()
+  if (auth) return auth
+  const records = await listMapRecordsLive()
+  return json({ fetchedAt: new Date().toISOString(), records })
+}
+
+export async function PATCH(req: NextRequest) {
+  const auth = await ensureAuth()
+  if (auth) return auth
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return json({ error: 'body must be JSON' }, 400)
+  }
+
+  let move
+  try {
+    move = validateMoveBody(body)
+  } catch (err) {
+    if (err instanceof ValidationError) return json({ error: err.message }, 400)
+    throw err
+  }
+
+  try {
+    const current = await getMapPosition(move.id)
+    if (current === null) return json({ error: 'record not found' }, 404)
+
+    if (move.expected && !samePosition(current, move.expected)) {
+      return json({ error: 'stale', current }, 409)
+    }
+
+    const stored = await updateMapPosition(move.id, move.x, move.y)
+    console.info(
+      `[map-editor] ${move.id}: (${current.x}, ${current.y}) → (${stored.x}, ${stored.y})`
+    )
+    return json({ record: { id: move.id, ...stored } })
+  } catch (err) {
+    // Airtable read/write problems come back to the editor as a visible
+    // error (never swallowed); the details go to the server log too.
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[map-editor] move failed for ${move.id}: ${message}`)
+    return json({ error: message }, 502)
+  }
+}

--- a/src/lib/admin/airtable.ts
+++ b/src/lib/admin/airtable.ts
@@ -69,18 +69,18 @@ function ensureConfig(table: string | undefined): asserts table is string {
   }
 }
 
-interface AirtableRow<F> {
+export interface AirtableRow<F> {
   id: string
   createdTime: string
   fields: F
 }
 
-interface AirtableListResponse<F> {
+export interface AirtableListResponse<F> {
   records: AirtableRow<F>[]
   offset?: string
 }
 
-async function airtableRequest(
+export async function airtableRequest(
   path: string,
   init: RequestInit = {}
 ): Promise<Response> {
@@ -95,7 +95,7 @@ async function airtableRequest(
   })
 }
 
-async function listAll<F>(
+export async function listAll<F>(
   table: string,
   params: URLSearchParams = new URLSearchParams()
 ): Promise<AirtableRow<F>[]> {

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -12,6 +12,9 @@ interface PasswordRole {
   chatbot: boolean
   /** May open the analytics dashboard. */
   analytics: boolean
+  /** May open the map editor and move logos on the Field map (writes x/y to
+   *  Airtable). Owner only for now. */
+  mapEditor: boolean
 }
 
 /** Every password that grants admin access, and the areas each one opens. Each
@@ -20,13 +23,29 @@ interface PasswordRole {
  *  immediately, while the others are untouched. */
 const PASSWORD_ROLES: PasswordRole[] = [
   // Primary owner password: the whole admin.
-  { env: 'ADMIN_PASSWORD', chatbot: true, analytics: true },
+  { env: 'ADMIN_PASSWORD', chatbot: true, analytics: true, mapEditor: true },
   // Partner reviewing chat logs: chat areas only, no analytics.
-  { env: 'ADMIN_PASSWORD_SUCCESSIF', chatbot: true, analytics: false },
-  // Site volunteers: the whole admin.
-  { env: 'ADMIN_PASSWORD_VOLUNTEER', chatbot: true, analytics: true },
+  {
+    env: 'ADMIN_PASSWORD_SUCCESSIF',
+    chatbot: true,
+    analytics: false,
+    mapEditor: false,
+  },
+  // Site volunteers: the whole admin except the map editor (it writes to the
+  // live Airtable base).
+  {
+    env: 'ADMIN_PASSWORD_VOLUNTEER',
+    chatbot: true,
+    analytics: true,
+    mapEditor: false,
+  },
   // Analytics-only volunteers: the dashboard, with the chat areas out of reach.
-  { env: 'ADMIN_PASSWORD_ANALYTICS', chatbot: false, analytics: true },
+  {
+    env: 'ADMIN_PASSWORD_ANALYTICS',
+    chatbot: false,
+    analytics: true,
+    mapEditor: false,
+  },
 ]
 
 /** Configured passwords whose role satisfies `grants`. Roles left unconfigured
@@ -77,6 +96,12 @@ export async function canViewChatbot(): Promise<boolean> {
  *  password is deliberately excluded — that partner reviews chat logs only. */
 export async function canViewAnalytics(): Promise<boolean> {
   return sessionHolds(passwordsWhere(role => role.analytics))
+}
+
+/** True when the session may open the map editor and move logos on the Field
+ *  map. Only the owner password — every save is a write to the live base. */
+export async function canEditMap(): Promise<boolean> {
+  return sessionHolds(passwordsWhere(role => role.mapEditor))
 }
 
 export async function setAdminCookie(password: string): Promise<void> {

--- a/src/lib/admin/map-editor-core.test.ts
+++ b/src/lib/admin/map-editor-core.test.ts
@@ -187,6 +187,7 @@ function rec(over: Partial<EditorRecord>): EditorRecord {
     y: null,
     published: true,
     isMagic: false,
+    createdTime: null,
     order: 0,
     ...over,
   }

--- a/src/lib/admin/map-editor-core.test.ts
+++ b/src/lib/admin/map-editor-core.test.ts
@@ -1,0 +1,245 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  FIELD,
+  buildPositionFields,
+  compareEditorRecords,
+  rowToEditorRecord,
+  samePosition,
+  sortEditorRecords,
+  validateMoveBody,
+  ValidationError,
+  type EditorRecord,
+} from './map-editor-core'
+
+// ─── Field IDs must match the public map's data layer ──────────────────────
+
+describe('FIELD ids mirror src/lib/data/map.ts', () => {
+  const mapTs = readFileSync(join(process.cwd(), 'src/lib/data/map.ts'), 'utf8')
+  it.each(Object.entries(FIELD))('%s → %s', (name, id) => {
+    expect(mapTs).toContain(`${name}: '${id}',`)
+  })
+  it('table id', () => {
+    expect(mapTs).toContain("const TABLE_ID = 'tblvzbGL9q9dOO9Nc'")
+  })
+})
+
+// ─── validateMoveBody ──────────────────────────────────────────────────────
+
+const ID = 'recG0nDieDK49nRr2'
+
+describe('validateMoveBody', () => {
+  it('accepts a minimal move and rounds to 0.1', () => {
+    expect(validateMoveBody({ id: ID, x: 22.24, y: 17.16 })).toEqual({
+      id: ID,
+      x: 22.2,
+      y: 17.2,
+    })
+  })
+  it('accepts expected with numbers or nulls', () => {
+    expect(
+      validateMoveBody({ id: ID, x: 1, y: 2, expected: { x: null, y: null } })
+    ).toEqual({ id: ID, x: 1, y: 2, expected: { x: null, y: null } })
+    expect(
+      validateMoveBody({ id: ID, x: 1, y: 2, expected: { x: 3.3, y: 4 } })
+        .expected
+    ).toEqual({ x: 3.3, y: 4 })
+  })
+  it.each([
+    [null, 'body must be a JSON object'],
+    [[], 'body must be a JSON object'],
+    ['{}', 'body must be a JSON object'],
+    [{ x: 1, y: 2 }, 'id must be an Airtable record id'],
+    [{ id: 'foo', x: 1, y: 2 }, 'id must be an Airtable record id'],
+    [{ id: 'rec123', x: 1, y: 2 }, 'id must be an Airtable record id'],
+    [{ id: ID, x: '12', y: 2 }, 'x must be a finite number'],
+    [{ id: ID, x: NaN, y: 2 }, 'x must be a finite number'],
+    [{ id: ID, x: 1, y: Infinity }, 'y must be a finite number'],
+    [{ id: ID, x: 60.1, y: 2 }, 'x/y outside the map'],
+    [{ id: ID, x: -0.06, y: 2 }, 'x/y outside the map'],
+    [{ id: ID, x: 1, y: 32.75 }, 'x/y outside the map'],
+    [{ id: ID, x: 1, y: 2, fields: {} }, 'unexpected key: fields'],
+    [{ id: ID, x: 1, y: 2, publish: true }, 'unexpected key: publish'],
+    [
+      { id: ID, x: 1, y: 2, [FIELD.hide]: true },
+      `unexpected key: ${FIELD.hide}`,
+    ],
+    [{ id: ID, x: 1, y: 2, typecast: true }, 'unexpected key: typecast'],
+    [{ id: ID, x: 1, y: 2, expected: null }, 'expected must be an object'],
+    [
+      { id: ID, x: 1, y: 2, expected: { x: 1, y: 2, scale: 'Large' } },
+      'unexpected key in expected: scale',
+    ],
+    [
+      { id: ID, x: 1, y: 2, expected: { x: '1', y: 2 } },
+      'expected.x/y must be numbers or null',
+    ],
+  ])('rejects %j', (body, message) => {
+    expect(() => validateMoveBody(body)).toThrow(ValidationError)
+    expect(() => validateMoveBody(body)).toThrow(message)
+  })
+  it('accepts the exact edges', () => {
+    expect(validateMoveBody({ id: ID, x: 0, y: 0 })).toEqual({
+      id: ID,
+      x: 0,
+      y: 0,
+    })
+    expect(validateMoveBody({ id: ID, x: 60, y: 32.7 })).toEqual({
+      id: ID,
+      x: 60,
+      y: 32.7,
+    })
+    // -0.04 rounds to 0, which is inside the map.
+    expect(validateMoveBody({ id: ID, x: -0.04, y: 1 }).x).toBe(0)
+  })
+})
+
+describe('buildPositionFields', () => {
+  it('writes exactly x and y by field id', () => {
+    const fields = buildPositionFields(22.2, 17.2)
+    expect(Object.keys(fields).sort()).toEqual([FIELD.x, FIELD.y].sort())
+    expect(fields[FIELD.x]).toBe(22.2)
+    expect(fields[FIELD.y]).toBe(17.2)
+  })
+})
+
+describe('samePosition', () => {
+  it('compares at Airtable precision and treats null strictly', () => {
+    expect(samePosition({ x: 1.04, y: 2 }, { x: 1, y: 2 })).toBe(true)
+    expect(samePosition({ x: 1.06, y: 2 }, { x: 1, y: 2 })).toBe(false)
+    expect(samePosition({ x: null, y: null }, { x: null, y: null })).toBe(true)
+    expect(samePosition({ x: null, y: 2 }, { x: 0, y: 2 })).toBe(false)
+  })
+})
+
+// ─── rowToEditorRecord + ordering ──────────────────────────────────────────
+
+function row(fields: Record<string, unknown>, id = ID) {
+  return { id, fields }
+}
+
+describe('rowToEditorRecord', () => {
+  it('maps fields by id with the same fallbacks as /map', () => {
+    const r = rowToEditorRecord(
+      row({
+        [FIELD.longName]: 'Center on Long-Term Risk: Fellowship',
+        [FIELD.longNameForCards]: 'Center on Long-Term Risk (CLR): Fellowship',
+        [FIELD.shortName]: 'CLR Fellowship',
+        [FIELD.description]: 'desc',
+        [FIELD.categoryText]: 'Training and education, Governance',
+        [FIELD.status]: 'Active',
+        [FIELD.logoForMap]: [{ url: 'https://x/logo.png' }],
+        [FIELD.x]: 22.2,
+        [FIELD.y]: 17.2,
+        [FIELD.scale]: 'Medium',
+        [FIELD.publish]: true,
+      })
+    )
+    expect(r.title).toBe('Center on Long-Term Risk (CLR): Fellowship')
+    expect(r.tooltipTitle).toBe('Center on Long-Term Risk: Fellowship')
+    expect(r.labelName).toBe('CLR Fellowship')
+    expect(r.area).toBe('Training Town')
+    expect(r.mapLogo).toBe('https://x/logo.png')
+    expect(r.x).toBe(22.2)
+    expect(r.published).toBe(true)
+    expect(r.isMagic).toBe(false)
+  })
+  it('handles sparse drafts instead of dropping them', () => {
+    const r = rowToEditorRecord(
+      row({ [FIELD.category]: ['Governance'] }, 'recAAAAAAAAAAAAAA')
+    )
+    expect(r.title).toBe('Untitled (recAAAAAAAAAAAAAA)')
+    expect(r.labelName).toBe(r.title)
+    expect(r.category).toBe('Governance')
+    expect(r.area).toBe('Governance Grove')
+    expect(r.x).toBeNull()
+    expect(r.published).toBe(false)
+    expect(r.status).toBe('Active')
+    expect(r.description).toBeNull()
+  })
+  it('flags furniture rows and unknown areas', () => {
+    const r = rowToEditorRecord(
+      row({
+        [FIELD.longNameForCards]: 'Last updated',
+        [FIELD.categoryText]: 'Nope',
+      })
+    )
+    expect(r.isMagic).toBe(true)
+    expect(r.area).toBeNull()
+  })
+})
+
+function rec(over: Partial<EditorRecord>): EditorRecord {
+  return {
+    id: 'rec',
+    title: 'T',
+    tooltipTitle: 'T',
+    shortName: null,
+    labelName: 'T',
+    description: null,
+    category: '',
+    area: null,
+    status: 'Active',
+    scale: null,
+    mapLogo: null,
+    x: null,
+    y: null,
+    published: true,
+    isMagic: false,
+    order: 0,
+    ...over,
+  }
+}
+
+describe('ordering (same as /map)', () => {
+  it('magic last, Active first, Large before Small, then category, then title', () => {
+    const magic = rec({
+      id: 'm',
+      title: 'Merch',
+      isMagic: true,
+      scale: 'Large',
+    })
+    const inactive = rec({
+      id: 'i',
+      title: 'A',
+      status: 'Inactive',
+      scale: 'Large',
+    })
+    const small = rec({
+      id: 's',
+      title: 'A',
+      scale: 'Small',
+      category: 'Advocacy',
+    })
+    const largeGov = rec({
+      id: 'lg',
+      title: 'Z',
+      scale: 'Large',
+      category: 'Governance',
+    })
+    const largeAdv = rec({
+      id: 'la',
+      title: 'B',
+      scale: 'Large',
+      category: 'Advocacy',
+    })
+    const largeAdv2 = rec({
+      id: 'la2',
+      title: 'A',
+      scale: 'Large',
+      category: 'Advocacy',
+    })
+    const sorted = sortEditorRecords([
+      magic,
+      inactive,
+      small,
+      largeGov,
+      largeAdv,
+      largeAdv2,
+    ])
+    expect(sorted.map(r => r.id)).toEqual(['la2', 'la', 'lg', 's', 'i', 'm'])
+    expect(sorted.map(r => r.order)).toEqual([0, 1, 2, 3, 4, 5])
+    expect(compareEditorRecords(largeAdv, largeAdv2)).toBeGreaterThan(0)
+  })
+})

--- a/src/lib/admin/map-editor-core.ts
+++ b/src/lib/admin/map-editor-core.ts
@@ -81,6 +81,8 @@ export interface EditorRecord {
   y: number | null
   published: boolean
   isMagic: boolean
+  /** When the record was created in Airtable (ISO), for tray ordering. */
+  createdTime: string | null
   /** Position in /map's stacking order (0 = drawn first / bottom-most). */
   order: number
 }
@@ -113,6 +115,7 @@ function attachmentUrl(value: unknown): string | null {
 
 export interface AirtableRowLike {
   id: string
+  createdTime?: string
   fields: Record<string, unknown>
 }
 
@@ -143,6 +146,7 @@ export function rowToEditorRecord(row: AirtableRowLike): EditorRecord {
     y: num(f[FIELD.y]),
     published: f[FIELD.publish] === true,
     isMagic: MAGIC_ROW_NAMES.includes(title),
+    createdTime: row.createdTime ?? null,
     order: 0,
   }
 }

--- a/src/lib/admin/map-editor-core.ts
+++ b/src/lib/admin/map-editor-core.ts
@@ -178,6 +178,7 @@ function rankIn(value: string | null | undefined, order: string[]): number {
 }
 
 function categoryIndices(category: string): number[] {
+  if (!category) return [CATEGORY_ORDER.length + 1]
   return category
     .split(',')
     .map(c => c.trim())

--- a/src/lib/admin/map-editor-core.ts
+++ b/src/lib/admin/map-editor-core.ts
@@ -1,0 +1,314 @@
+/*
+  Pure logic for the admin map editor: Airtable field IDs for the Map table,
+  the record shape the editor works with, request validation for the move
+  API, and the /map stacking order.
+
+  Deliberately does NOT import src/lib/data/map.ts or src/lib/data/airtable.ts
+  (those are the public /map's data path — cached, publish-filtered, and
+  wired into Blob mirroring). The editor keeps its own copies of the few
+  things it needs so nothing about /map changes. Keep the FIELD ids and the
+  comparator in sync with src/lib/data/map.ts.
+
+  No next/d3/DOM imports — importable from tests, server and client code.
+*/
+
+import { MAP_AREA_BY_CATEGORY } from '@/lib/data/map-areas'
+import { GRID_DECIMALS, inGridBounds, roundGrid } from './map-geometry'
+
+export const MAP_TABLE_ID = 'tblvzbGL9q9dOO9Nc'
+
+/** Permanent field IDs (same values as src/lib/data/map.ts FIELD). Reads use
+ *  returnFieldsByFieldId; the ONLY fields the editor ever writes are x and y. */
+export const FIELD = {
+  longName: 'fldqYJa5li27kVOUW', // Long name
+  longNameForCards: 'fldPEouzOZbCIZr7p', // Long name for cards
+  shortName: 'fldIL5rLAwlbvdhtg', // Short name
+  description: 'fldUZfd5kQQP0DoOS', // Description
+  categoryText: 'fldddK6whfSl9DWNd', // Category (text)
+  category: 'fldhofDtTtJqWXLuf', // Category
+  status: 'fld2OFKbXPhO2NQRx', // Status
+  logoForMap: 'fldua2ISy01Yntwof', // Logo (for map)
+  x: 'fld2FlBMPjxhjGuFO', // x
+  y: 'fldkAQPZaibRGawVw', // y
+  scale: 'fldw2bKsCY0VdTCN6', // Scale
+  publish: 'fldCCQ2OYlQluuarR', // Publish?
+  hide: 'fldKwedEOWPFuWSe7', // Hide?
+} as const
+
+/** Fields the editor reads. Publish? is read so drafts can be marked; Hide?
+ *  is filtered out at the query, so it isn't needed in the response. */
+export const READ_FIELDS: string[] = [
+  FIELD.longName,
+  FIELD.longNameForCards,
+  FIELD.shortName,
+  FIELD.description,
+  FIELD.categoryText,
+  FIELD.category,
+  FIELD.status,
+  FIELD.logoForMap,
+  FIELD.x,
+  FIELD.y,
+  FIELD.scale,
+  FIELD.publish,
+]
+
+/** Rows that are page furniture on /map (Merch, Last updated, Suggest…). They
+ *  are draggable like anything else, but the editor badges them. */
+export const MAGIC_ROW_NAMES = [
+  'Merch',
+  'Last updated',
+  'Suggest correction',
+  'Suggest entry',
+]
+
+export interface EditorRecord {
+  id: string
+  /** Card title: Long name for cards, else Long name, else 'Untitled (rec…)'. */
+  title: string
+  /** Long name (what /map's tooltip shows). */
+  tooltipTitle: string
+  shortName: string | null
+  /** What /map prints under the logo: Short name || title. */
+  labelName: string
+  description: string | null
+  category: string
+  /** Field map region for the FIRST category, or null if unmapped. */
+  area: string | null
+  status: string
+  scale: string | null
+  mapLogo: string | null
+  x: number | null
+  y: number | null
+  published: boolean
+  isMagic: boolean
+  /** Position in /map's stacking order (0 = drawn first / bottom-most). */
+  order: number
+}
+
+// ─── Coercion (same semantics as src/lib/data/airtable.ts helpers) ─────────
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' && value !== '' ? value : null
+}
+
+function strArray(value: unknown): string[] {
+  if (typeof value === 'string') return value ? [value] : []
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === 'string')
+  }
+  return []
+}
+
+export function num(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function attachmentUrl(value: unknown): string | null {
+  if (!Array.isArray(value) || value.length === 0) return null
+  const first = value[0] as { url?: unknown }
+  return typeof first?.url === 'string' ? first.url : null
+}
+
+// ─── Row → record ──────────────────────────────────────────────────────────
+
+export interface AirtableRowLike {
+  id: string
+  fields: Record<string, unknown>
+}
+
+/** Maps a raw Airtable row (fields keyed by ID) to an EditorRecord. `order`
+ *  is filled in by sortEditorRecords. */
+export function rowToEditorRecord(row: AirtableRowLike): EditorRecord {
+  const f = row.fields
+  const longName = str(f[FIELD.longName])
+  const title =
+    str(f[FIELD.longNameForCards]) || longName || `Untitled (${row.id})`
+  const shortName = str(f[FIELD.shortName])
+  const category =
+    str(f[FIELD.categoryText]) || strArray(f[FIELD.category]).join(', ')
+  const firstCategory = category.split(',')[0]?.trim() || ''
+  return {
+    id: row.id,
+    title,
+    tooltipTitle: longName || title,
+    shortName,
+    labelName: shortName || title,
+    description: str(f[FIELD.description]),
+    category,
+    area: (firstCategory && MAP_AREA_BY_CATEGORY[firstCategory]) || null,
+    status: str(f[FIELD.status]) || 'Active',
+    scale: str(f[FIELD.scale]),
+    mapLogo: attachmentUrl(f[FIELD.logoForMap]),
+    x: num(f[FIELD.x]),
+    y: num(f[FIELD.y]),
+    published: f[FIELD.publish] === true,
+    isMagic: MAGIC_ROW_NAMES.includes(title),
+    order: 0,
+  }
+}
+
+// ─── Stacking order (copied from src/lib/data/map.ts getMapData) ───────────
+
+const STATUS_ORDER = ['Active', 'Inactive']
+const SCALE_ORDER_LARGE_FIRST = ['Large', 'Medium', 'Small']
+const CATEGORY_ORDER = [
+  'Advocacy',
+  'Blog',
+  'Capabilities research',
+  'Career support',
+  'Conceptual research',
+  'Empirical research',
+  'Forecasting',
+  'Funding',
+  'Governance',
+  'Newsletter',
+  'Podcast',
+  'Research support',
+  'Resource',
+  'Strategy',
+  'Training and education',
+  'Video',
+  'No longer active',
+]
+
+function rankIn(value: string | null | undefined, order: string[]): number {
+  if (!value) return order.length + 1
+  const idx = order.indexOf(value)
+  return idx === -1 ? order.length : idx
+}
+
+function categoryIndices(category: string): number[] {
+  return category
+    .split(',')
+    .map(c => c.trim())
+    .filter(Boolean)
+    .map(c => rankIn(c, CATEGORY_ORDER))
+}
+
+function compareCategoryIndices(a: number[], b: number[]): number {
+  const n = Math.min(a.length, b.length)
+  for (let i = 0; i < n; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i]
+  }
+  return a.length - b.length
+}
+
+/** Same comparator as /map's data layer, so pins overlap in the same order
+ *  (later in the array = drawn on top). Keep in sync with map.ts. */
+export function compareEditorRecords(a: EditorRecord, b: EditorRecord): number {
+  if (a.isMagic !== b.isMagic) return a.isMagic ? 1 : -1
+  const statusDiff =
+    rankIn(a.status, STATUS_ORDER) - rankIn(b.status, STATUS_ORDER)
+  if (statusDiff !== 0) return statusDiff
+  const scaleDiff =
+    rankIn(a.scale, SCALE_ORDER_LARGE_FIRST) -
+    rankIn(b.scale, SCALE_ORDER_LARGE_FIRST)
+  if (scaleDiff !== 0) return scaleDiff
+  const catDiff = compareCategoryIndices(
+    categoryIndices(a.category),
+    categoryIndices(b.category)
+  )
+  if (catDiff !== 0) return catDiff
+  return a.title.localeCompare(b.title)
+}
+
+/** Sorts in /map order and stamps `order` on each record. */
+export function sortEditorRecords(records: EditorRecord[]): EditorRecord[] {
+  const sorted = [...records].sort(compareEditorRecords)
+  sorted.forEach((r, i) => {
+    r.order = i
+  })
+  return sorted
+}
+
+// ─── Move request validation ───────────────────────────────────────────────
+
+export class ValidationError extends Error {}
+
+export interface MoveRequest {
+  id: string
+  x: number
+  y: number
+  /** What the client last saw for this record; the server refuses the write
+   *  (409) if Airtable now holds something else. */
+  expected?: { x: number | null; y: number | null }
+}
+
+const RECORD_ID_RE = /^rec[A-Za-z0-9]{14}$/
+const ALLOWED_KEYS = new Set(['id', 'x', 'y', 'expected'])
+const ALLOWED_EXPECTED_KEYS = new Set(['x', 'y'])
+
+function coordinate(value: unknown, name: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new ValidationError(`${name} must be a finite number`)
+  }
+  return roundGrid(value)
+}
+
+/** Parses and validates a PATCH body. Rejects anything but id/x/y/expected —
+ *  the request can never smuggle in other fields. Rounds x/y to Airtable's
+ *  precision and requires them to be within the map. */
+export function validateMoveBody(body: unknown): MoveRequest {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw new ValidationError('body must be a JSON object')
+  }
+  const obj = body as Record<string, unknown>
+  for (const key of Object.keys(obj)) {
+    if (!ALLOWED_KEYS.has(key)) {
+      throw new ValidationError(`unexpected key: ${key}`)
+    }
+  }
+  const id = obj.id
+  if (typeof id !== 'string' || !RECORD_ID_RE.test(id)) {
+    throw new ValidationError('id must be an Airtable record id')
+  }
+  const x = coordinate(obj.x, 'x')
+  const y = coordinate(obj.y, 'y')
+  if (!inGridBounds(x, y)) {
+    throw new ValidationError('x/y outside the map')
+  }
+  const out: MoveRequest = { id, x, y }
+  if (obj.expected !== undefined) {
+    const e = obj.expected
+    if (!e || typeof e !== 'object' || Array.isArray(e)) {
+      throw new ValidationError('expected must be an object')
+    }
+    const eo = e as Record<string, unknown>
+    for (const key of Object.keys(eo)) {
+      if (!ALLOWED_EXPECTED_KEYS.has(key)) {
+        throw new ValidationError(`unexpected key in expected: ${key}`)
+      }
+    }
+    const ex = eo.x
+    const ey = eo.y
+    if (
+      !(ex === null || (typeof ex === 'number' && Number.isFinite(ex))) ||
+      !(ey === null || (typeof ey === 'number' && Number.isFinite(ey)))
+    ) {
+      throw new ValidationError('expected.x/y must be numbers or null')
+    }
+    out.expected = { x: ex as number | null, y: ey as number | null }
+  }
+  return out
+}
+
+/** The ONLY builder of an Airtable write body for the Map table. Exactly two
+ *  keys, both by permanent field ID. */
+export function buildPositionFields(
+  x: number,
+  y: number
+): Record<string, number> {
+  return { [FIELD.x]: x, [FIELD.y]: y }
+}
+
+/** True when two stored positions are the same at Airtable precision. */
+export function samePosition(
+  a: { x: number | null; y: number | null },
+  b: { x: number | null; y: number | null }
+): boolean {
+  const eq = (p: number | null, q: number | null) =>
+    p === null || q === null ? p === q : roundGrid(p) === roundGrid(q)
+  return eq(a.x, b.x) && eq(a.y, b.y)
+}
+
+export { GRID_DECIMALS }

--- a/src/lib/admin/map-editor.ts
+++ b/src/lib/admin/map-editor.ts
@@ -1,0 +1,93 @@
+/*
+  Server-side Airtable I/O for the admin map editor.
+
+  Reads the Map table LIVE (cache: 'no-store', no view, unpublished rows
+  included, Hide? rows excluded) and writes exactly two fields (x, y) on one
+  record at a time. It intentionally does not use src/lib/data/airtable.ts:
+  that path is wrapped in unstable_cache (shared with /map, the chatbot
+  catalog, search and the public API), filters to published rows, and mirrors
+  attachments to Vercel Blob. Nothing here touches that cache or those files.
+
+  Logo URLs returned by a live read are Airtable-signed and expire in ~2h.
+  They are only ever sent to the signed-in admin's browser, never persisted.
+*/
+
+import { airtableRequest, listAll } from './airtable'
+import {
+  buildPositionFields,
+  FIELD,
+  MAP_TABLE_ID,
+  num,
+  READ_FIELDS,
+  rowToEditorRecord,
+  sortEditorRecords,
+  type EditorRecord,
+} from './map-editor-core'
+
+export function isMapEditorConfigured(): boolean {
+  return Boolean(process.env.AIRTABLE_TOKEN && process.env.AIRTABLE_BASE_ID)
+}
+
+type RawFields = Record<string, unknown>
+
+/** Every non-hidden Map record, published or not, in /map stacking order. */
+export async function listMapRecordsLive(): Promise<EditorRecord[]> {
+  const params = new URLSearchParams()
+  params.set('filterByFormula', `{${FIELD.hide}} = FALSE()`)
+  params.set('returnFieldsByFieldId', 'true')
+  for (const f of READ_FIELDS) params.append('fields[]', f)
+  const rows = await listAll<RawFields>(MAP_TABLE_ID, params)
+  return sortEditorRecords(rows.map(rowToEditorRecord))
+}
+
+export interface StoredPosition {
+  x: number | null
+  y: number | null
+}
+
+/** Current x/y for one record, or null when the record doesn't exist. Airtable
+ *  answers an unknown record id with 404, or with 403 "model not found" when
+ *  the id doesn't belong to this table — both mean "not here". */
+export async function getMapPosition(
+  id: string
+): Promise<StoredPosition | null> {
+  // The single-record endpoint takes returnFieldsByFieldId but no fields[].
+  const res = await airtableRequest(
+    `${MAP_TABLE_ID}/${id}?returnFieldsByFieldId=true`
+  )
+  if (res.status === 404) return null
+  if (!res.ok) {
+    const text = await res.text()
+    if (res.status === 403 && text.includes('MODEL_NOT_FOUND')) return null
+    throw new Error(`Airtable read failed: ${res.status} ${text}`)
+  }
+  const data = (await res.json()) as { fields: RawFields }
+  return { x: num(data.fields[FIELD.x]), y: num(data.fields[FIELD.y]) }
+}
+
+/** Writes x and y (nothing else) and returns what Airtable stored. */
+export async function updateMapPosition(
+  id: string,
+  x: number,
+  y: number
+): Promise<{ x: number; y: number }> {
+  const res = await airtableRequest(`${MAP_TABLE_ID}/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      fields: buildPositionFields(x, y),
+      returnFieldsByFieldId: true,
+    }),
+  })
+  if (!res.ok) {
+    throw new Error(`Airtable update failed: ${res.status} ${await res.text()}`)
+  }
+  const data = (await res.json()) as { fields: RawFields }
+  const storedX = num(data.fields[FIELD.x])
+  const storedY = num(data.fields[FIELD.y])
+  if (storedX === null || storedY === null) {
+    throw new Error(
+      `Airtable update returned no x/y for ${id}: ${JSON.stringify(data.fields)}`
+    )
+  }
+  return { x: storedX, y: storedY }
+}

--- a/src/lib/admin/map-geometry.test.ts
+++ b/src/lib/admin/map-geometry.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  AREA_LABELS,
+  BACKGROUND_IMAGE_URL,
+  BASE_LOGO_SIZE,
+  GRID_BOUNDS,
+  GRID_SIZE,
+  LOGO_GLOBAL_SCALE,
+  MAP_HEIGHT,
+  MAP_OFFSET_X,
+  MAP_OFFSET_Y,
+  MAP_WIDTH,
+  PADDING_FACTOR,
+  SIZE_TO_SCALE,
+  clampGrid,
+  gridToPx,
+  inGridBounds,
+  logoMetrics,
+  pxToGrid,
+  roundGrid,
+} from './map-geometry'
+
+// ─── Drift guard: the public map's numbers must equal our copy ─────────────
+// D3Map.tsx is never imported by admin code (it is the public /map renderer);
+// instead we read its source and pin the literals we copied.
+
+const d3MapSource = readFileSync(
+  join(process.cwd(), 'src/app/map/D3Map.tsx'),
+  'utf8'
+)
+
+function literal(name: string): string {
+  const m = d3MapSource.match(new RegExp(`const ${name} = ([^\\n]+)`))
+  if (!m) throw new Error(`D3Map.tsx no longer defines ${name}`)
+  return m[1].trim()
+}
+
+describe('map-geometry mirrors src/app/map/D3Map.tsx', () => {
+  it('canvas constants', () => {
+    expect(literal('MAP_WIDTH')).toBe(String(MAP_WIDTH))
+    expect(literal('MAP_HEIGHT')).toBe(String(MAP_HEIGHT))
+    expect(literal('PADDING_FACTOR')).toBe(String(PADDING_FACTOR))
+    expect(literal('GRID_SIZE')).toBe('MAP_WIDTH / 60')
+    expect(literal('BASE_LOGO_SIZE')).toBe(String(BASE_LOGO_SIZE))
+    expect(Number(literal('LOGO_GLOBAL_SCALE'))).toBe(LOGO_GLOBAL_SCALE)
+    expect(d3MapSource).toContain(`'${BACKGROUND_IMAGE_URL}'`)
+  })
+
+  it('offsets (public map: /2 horizontally, /20 vertically)', () => {
+    expect(d3MapSource).toContain(
+      'const offsetX = (PADDED_WIDTH - MAP_WIDTH) / 2'
+    )
+    expect(d3MapSource).toContain(
+      'const offsetY = (PADDED_HEIGHT - MAP_HEIGHT) / 20'
+    )
+    expect(MAP_OFFSET_X).toBeCloseTo(124.25, 6)
+    expect(MAP_OFFSET_Y).toBeCloseTo(6.775, 6)
+  })
+
+  it('scale table', () => {
+    for (const [name, value] of Object.entries(SIZE_TO_SCALE)) {
+      expect(d3MapSource).toMatch(new RegExp(`\\b${name}: ${value},`))
+    }
+  })
+
+  it('area labels', () => {
+    for (const { label, x, y } of AREA_LABELS) {
+      expect(d3MapSource).toContain(`{ label: '${label}', x: ${x}, y: ${y} }`)
+    }
+    const count = (d3MapSource.match(/\{ label: '/g) ?? []).length
+    expect(count).toBe(AREA_LABELS.length)
+  })
+
+  it('glyph metrics formulas', () => {
+    expect(d3MapSource).toContain('const labelOffset = 11 * rawScale * 1.5')
+    expect(d3MapSource).toContain('const fontSize = 6 * rawScale * 1.5')
+    expect(d3MapSource).toContain('const padX = 6 * rawScale * 1.5')
+    expect(d3MapSource).toContain('const padY = 3 * rawScale * 1.5')
+    expect(d3MapSource).toContain('const padding = 2')
+    expect(d3MapSource).toContain(
+      "const rawScale = SIZE_TO_SCALE[org.scale || 'Medium'] || 0.6"
+    )
+  })
+})
+
+// ─── Pure helpers ──────────────────────────────────────────────────────────
+
+describe('logoMetrics', () => {
+  it('matches D3Map arithmetic for each scale', () => {
+    const m = logoMetrics('Large')
+    expect(m.rawScale).toBe(0.8)
+    expect(m.iconSize).toBeCloseTo(51.2)
+    expect(m.contentSize).toBeCloseTo(47.2)
+    expect(m.labelOffset).toBeCloseTo(13.2)
+    expect(m.labelY).toBeCloseTo(25.6 + 13.2)
+    expect(m.fontSize).toBeCloseTo(7.2)
+    expect(m.padX).toBeCloseTo(7.2)
+    expect(m.padY).toBeCloseTo(3.6)
+  })
+  it('defaults to Medium when Scale is unset or unknown', () => {
+    expect(logoMetrics(null).rawScale).toBe(0.6)
+    expect(logoMetrics('Huge').rawScale).toBe(0.6)
+    expect(logoMetrics('small').rawScale).toBe(0.4)
+  })
+})
+
+describe('grid conversions', () => {
+  it('round-trips through pixels', () => {
+    expect(GRID_SIZE).toBeCloseTo(41.4166667, 6)
+    expect(pxToGrid(gridToPx(22.2))).toBeCloseTo(22.2, 9)
+    expect(gridToPx(30)).toBeCloseTo(MAP_WIDTH / 2)
+  })
+  it('rounds to one decimal without -0', () => {
+    expect(roundGrid(12.34)).toBe(12.3)
+    expect(roundGrid(12.36)).toBe(12.4)
+    expect(roundGrid(-0.04)).toBe(0)
+    expect(Object.is(roundGrid(-0.04), 0)).toBe(true)
+    expect(roundGrid(22.2)).toBe(22.2)
+  })
+  it('bounds cover the map and nothing else', () => {
+    expect(GRID_BOUNDS.x).toEqual([0, 60])
+    expect(GRID_BOUNDS.y[0]).toBe(0)
+    expect(GRID_BOUNDS.y[1]).toBe(32.7)
+    expect(inGridBounds(0, 0)).toBe(true)
+    expect(inGridBounds(60, 32.7)).toBe(true)
+    expect(inGridBounds(60.1, 10)).toBe(false)
+    expect(inGridBounds(10, -0.1)).toBe(false)
+    expect(clampGrid(-3, 40)).toEqual({ x: 0, y: 32.7 })
+    expect(clampGrid(61, 5)).toEqual({ x: 60, y: 5 })
+    expect(clampGrid(22.2, 17.2)).toEqual({ x: 22.2, y: 17.2 })
+  })
+})

--- a/src/lib/admin/map-geometry.ts
+++ b/src/lib/admin/map-geometry.ts
@@ -1,0 +1,166 @@
+/*
+  Geometry of the public Field map, for the ADMIN map editor only.
+
+  This is a deliberate COPY of the constants and glyph metrics in
+  src/app/map/D3Map.tsx (lines ~30–72 and ~262–441). The editor must render
+  pins in exactly the places and sizes /map does, but /map is one of the site's
+  most-used pages and must not import from, or be changed for, an admin tool.
+  So the numbers live here twice, and src/lib/admin/map-geometry.test.ts reads
+  D3Map.tsx and fails if the two ever drift apart.
+
+  Pure module: no DOM, no d3, no next — safe to import from tests and from
+  both server and client code.
+*/
+
+// ─── Canvas ─────────────────────────────────────────────────────────────────
+
+export const MAP_WIDTH = 2485
+export const MAP_HEIGHT = 1355
+export const PADDING_FACTOR = 1.1
+export const PADDED_WIDTH = MAP_WIDTH * PADDING_FACTOR
+export const PADDED_HEIGHT = MAP_HEIGHT * PADDING_FACTOR
+/** One grid unit in SVG pixels: the map is 60 grid units wide. Airtable's x/y
+ *  are in these units (e.g. Training Town's label sits at 22.2, 17.2). */
+export const GRID_SIZE = MAP_WIDTH / 60
+export const BACKGROUND_IMAGE_URL =
+  'https://cdn.prod.website-files.com/65380b51b01b69a63d681e04/67e5dce03ad758280cd8367c_Map%201.5.1.svg'
+
+/** The main group's translate inside the padded viewBox (public map values —
+ *  note the /20 vertical offset, which differs from the poster map's /2). */
+export const MAP_OFFSET_X = (PADDED_WIDTH - MAP_WIDTH) / 2
+export const MAP_OFFSET_Y = (PADDED_HEIGHT - MAP_HEIGHT) / 20
+export const VIEWBOX = `0 0 ${PADDED_WIDTH} ${PADDED_HEIGHT}`
+export const PRESERVE_ASPECT_RATIO = 'xMidYMin meet'
+export const ZOOM_EXTENT: [number, number] = [0.5, 8]
+
+// ─── Logos ──────────────────────────────────────────────────────────────────
+
+export const SIZE_TO_SCALE: Record<string, number> = {
+  small: 0.4,
+  Small: 0.4,
+  medium: 0.6,
+  Medium: 0.6,
+  large: 0.8,
+  Large: 0.8,
+}
+export const BASE_LOGO_SIZE = 64
+export const LOGO_GLOBAL_SCALE = 1.0
+export const LOGO_PADDING = 2
+/** Scale /map assumes when a record has no Scale set. */
+export const DEFAULT_SCALE_NAME = 'Medium'
+
+export interface LogoMetrics {
+  rawScale: number
+  iconSize: number
+  contentSize: number
+  labelOffset: number
+  labelY: number
+  fontSize: number
+  padX: number
+  padY: number
+}
+
+/** Same arithmetic as D3Map's per-org block, so a pin drawn from these numbers
+ *  is the same size as its /map counterpart. */
+export function logoMetrics(scale: string | null): LogoMetrics {
+  const rawScale = SIZE_TO_SCALE[scale || DEFAULT_SCALE_NAME] || 0.6
+  const iconSize = BASE_LOGO_SIZE * rawScale * LOGO_GLOBAL_SCALE
+  const contentSize = iconSize - 2 * LOGO_PADDING
+  const labelOffset = 11 * rawScale * 1.5
+  return {
+    rawScale,
+    iconSize,
+    contentSize,
+    labelOffset,
+    labelY: iconSize / 2 + labelOffset,
+    fontSize: 6 * rawScale * 1.5,
+    padX: 6 * rawScale * 1.5,
+    padY: 3 * rawScale * 1.5,
+  }
+}
+
+// ─── Title and area labels ─────────────────────────────────────────────────
+
+export const TITLE = {
+  text: 'Map of AI Existential Safety',
+  gridX: 30,
+  gridY: 2.5,
+  fontSize: 72,
+  fontWeight: 400,
+  letterSpacing: '-2.16px',
+}
+
+export const AREA_LABEL_STYLE = {
+  labelScale: 1.75,
+  baseFontSize: 14,
+  basePadX: 14,
+  basePadY: 7,
+  fontWeight: 600,
+  letterSpacing: '-0.01em',
+  pillFill: 'rgba(27, 43, 62, 0.6)',
+}
+
+export const AREA_LABELS = [
+  { label: 'Conceptual Cliffs', x: 46, y: 5.5 },
+  { label: 'Resource Rock', x: 3.5, y: 8 },
+  { label: 'Support Shoreline', x: 13, y: 6.7 },
+  { label: 'Newsletter Nook', x: 15.8, y: 14.5 },
+  { label: 'Video Vista', x: 23, y: 5.6 },
+  { label: 'Funding Forest', x: 29.2, y: 7 },
+  { label: 'Governance Grove', x: 37.7, y: 5.5 },
+  { label: 'Strategy Summit', x: 34.8, y: 19 },
+  { label: 'Research Range', x: 45.3, y: 15.9 },
+  { label: 'Training Town', x: 22.2, y: 17.2 },
+  { label: 'Empirical Escarpment', x: 53.5, y: 16 },
+  { label: 'Podcast Port', x: 9.5, y: 20.5 },
+  { label: 'Blog Beach', x: 15, y: 25.8 },
+  { label: 'Forecasting Falls', x: 39.2, y: 23.8 },
+  { label: 'Career Castle', x: 30.5, y: 29.4 },
+  { label: 'Advocacy Anchorage', x: 8, y: 31 },
+  { label: 'Capabilities Cove', x: 45, y: 27.1 },
+  { label: 'Gone Graveyard', x: 56, y: 30 },
+]
+
+// ─── Coordinate helpers ────────────────────────────────────────────────────
+
+/** Airtable's x/y fields have precision 1; anything finer is invisible on
+ *  /map and would be displayed rounded in Airtable anyway. */
+export const GRID_DECIMALS = 1
+
+/** Storable range: the map is 60 units wide and MAP_HEIGHT/GRID_SIZE units
+ *  tall (~32.7). Outside this the pin would sit in the blank SVG margin. */
+export const GRID_BOUNDS = {
+  x: [0, 60] as const,
+  y: [0, roundGrid(MAP_HEIGHT / GRID_SIZE)] as const,
+}
+
+export function gridToPx(grid: number): number {
+  return grid * GRID_SIZE
+}
+
+export function pxToGrid(px: number): number {
+  return px / GRID_SIZE
+}
+
+/** Round to Airtable's precision; never returns -0. */
+export function roundGrid(value: number): number {
+  const factor = 10 ** GRID_DECIMALS
+  const rounded = Math.round(value * factor) / factor
+  return rounded === 0 ? 0 : rounded
+}
+
+export function clampGrid(x: number, y: number): { x: number; y: number } {
+  return {
+    x: Math.min(GRID_BOUNDS.x[1], Math.max(GRID_BOUNDS.x[0], x)),
+    y: Math.min(GRID_BOUNDS.y[1], Math.max(GRID_BOUNDS.y[0], y)),
+  }
+}
+
+export function inGridBounds(x: number, y: number): boolean {
+  return (
+    x >= GRID_BOUNDS.x[0] &&
+    x <= GRID_BOUNDS.x[1] &&
+    y >= GRID_BOUNDS.y[0] &&
+    y <= GRID_BOUNDS.y[1]
+  )
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+
+// Unit tests for pure modules only (no DOM, no Next runtime). Files end in
+// .test.ts and live next to what they test.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) },
+  },
+})


### PR DESCRIPTION
- New **Map editor** tab in the admin panel (`/admin/map`), owner password only (new `mapEditor` capability). Shows the Field map exactly as `/map` renders it – including not-yet-published records (amber dashed ring) – and lets you drag a logo to move it. Each drop writes the record's `x`/`y` to Airtable straight away.
- Unplaced tray (published-but-unplaced first, flagged red; then newest first) with click-to-place; selection panel with x/y inputs, arrow-key nudges (0.1 / Shift 1.0) and "Open in Airtable"; Undo/Redo; Refresh; "Preview as public"; `/map`-style hover (1.2× + tooltip); Esc cancels/deselects/resets; live-site warning banner.
- `/api/admin/map`: GET reads the Map table live (no cache, `Hide?` excluded); PATCH writes exactly the `x` and `y` fields of one record – any other key is rejected, so Publish?/Hide?/Scale can never be touched from here. Compare-then-write returns 409 when the record moved in Airtable since load; Airtable 429s pause all saves for ~30 s and retry automatically; moves settle for 400 ms so a held arrow key is one write.
- **Public `/map` is untouched**: nothing under `src/app/map`, `src/app/poster-map`, `src/lib/data` or `src/components` changes; the editor is its own copy of D3Map's geometry (`src/lib/admin/map-geometry.ts`) with a Vitest drift test that reads `D3Map.tsx`; it never uses the shared `fetchAirtableRecords` cache or revalidates anything. `/map` stays static in the build.
- Adds Vitest (`npm test`, 52 tests: geometry, request validation, ordering, field-ID parity with `map.ts`) and a short section in `docs/architecture.md`.
- Verified on localhost end to end: signed-out → 401; bad bodies → 400; unknown record → 404; place/drag/undo/redo write only x/y (Publish?/Scale unchanged); stale edit → 409 with notice; `/map` renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)