### PR TITLE
Admin: separate password for Melissa (everything except the map editor)

### DIFF
--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -46,6 +46,14 @@ const PASSWORD_ROLES: PasswordRole[] = [
     analytics: true,
     mapEditor: false,
   },
+  // Melissa (site designer): the whole admin except the map editor, on her
+  // own password so it can be revoked without touching the volunteers'.
+  {
+    env: 'ADMIN_PASSWORD_MELISSA',
+    chatbot: true,
+    analytics: true,
+    mapEditor: false,
+  },
 ]
 
 /** Configured passwords whose role satisfies `grants`. Roles left unconfigured


### PR DESCRIPTION
- Adds a fifth admin password role, `ADMIN_PASSWORD_MELISSA`: Playground, Conversation Log and Analytics, but not the map editor (which writes to the live Airtable base). Same permissions as the volunteer password, on its own env var so it can be revoked without affecting anyone else.
- Env var already set in Vercel (Production/Preview/Development), so this works as soon as it deploys.
- Verified locally: signs in to the Playground; header shows Playground | Conversation Log | Analytics (no Map editor tab); `/admin/map` redirects to the Playground; `/api/admin/map` → 401; `/api/admin/conversations` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)