### PR TITLE
Map editor: search + jump, Scale editing, fit to window, keyboard & undo fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "vitest run && next build",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -709,7 +709,7 @@ export default function MapEditor() {
       <div className={`${adminStyles.pageHeading} ${styles.heading}`}>
         <h1 className={adminStyles.pageTitle}>Map editor</h1>
         <span className={adminStyles.pageMeta}>
-          Drag a logo to move it · click to select · only x, y and Scale are
+          Drag a listing to move it · click to select · only x, y and Scale are
           written
         </span>
       </div>

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -709,8 +709,8 @@ export default function MapEditor() {
       <div className={`${adminStyles.pageHeading} ${styles.heading}`}>
         <h1 className={adminStyles.pageTitle}>Map editor</h1>
         <span className={adminStyles.pageMeta}>
-          Drag a logo to move it · click to select · saves to Airtable on drop ·{' '}
-          /map updates within a few minutes · only x, y and Scale are written
+          Drag a logo to move it · click to select · only x, y and Scale are
+          written
         </span>
       </div>
 

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -717,7 +717,7 @@ export default function MapEditor() {
       <div className={`${adminStyles.notice} ${styles.liveWarning}`}>
         <strong>This edits the live site.</strong> Every move is saved to
         Airtable straight away and appears on the public /map within a few
-        minutes.
+        minutes. Use with caution.
       </div>
 
       <div className={`${adminStyles.editorToolbar} ${styles.toolbar}`}>

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -727,7 +727,7 @@ export default function MapEditor() {
                 fetchedAt ? new Date(fetchedAt).toLocaleTimeString() : ''
               } · ${counts.total} records · ${counts.placed} placed · ${
                 counts.unplaced
-              } unplaced · ${counts.drafts} unpublished`
+              } unplaced · ${counts.drafts} incoming suggestions`
             : 'Loading…'}
         </span>
         <button
@@ -763,7 +763,7 @@ export default function MapEditor() {
             onChange={e => setShowDrafts(e.target.checked)}
             disabled={previewPublic}
           />
-          Show unpublished
+          Show incoming suggestions
         </label>
         <label className={styles.toggle}>
           <input

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -878,8 +878,7 @@ export default function MapEditor() {
       </div>
 
       <p className={`${adminStyles.sectionHint} ${styles.footnote}`}>
-        Only x, y and Scale are written – publishing and hiding stay in
-        Airtable.
+        Only x, y and Scale are written.
       </p>
     </div>
   )

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -151,7 +151,7 @@ export default function MapEditor() {
 
   // ── Fit to the window ────────────────────────────────────────────────────
   // Size the map + panel to the space between the toolbar and the bottom of
-  // the window (minus the footnote and page padding), so nothing is cut off.
+  // the window (minus the page padding), so nothing is cut off.
   // Re-measured on resize and whenever anything above/below changes height
   // (e.g. the toolbar status wrapping onto a second line).
   useLayoutEffect(() => {
@@ -710,7 +710,7 @@ export default function MapEditor() {
         <h1 className={adminStyles.pageTitle}>Map editor</h1>
         <span className={adminStyles.pageMeta}>
           Drag a logo to move it · click to select · saves to Airtable on drop ·{' '}
-          /map updates within a few minutes
+          /map updates within a few minutes · only x, y and Scale are written
         </span>
       </div>
 
@@ -876,10 +876,6 @@ export default function MapEditor() {
           />
         )}
       </div>
-
-      <p className={`${adminStyles.sectionHint} ${styles.footnote}`}>
-        Only x, y and Scale are written.
-      </p>
     </div>
   )
 }

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -8,8 +8,15 @@
 */
 
 import dynamic from 'next/dynamic'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { EditorRecord } from '@/lib/admin/map-editor-core'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import type { EditorRecord, ScaleName } from '@/lib/admin/map-editor-core'
 import { clampGrid, roundGrid } from '@/lib/admin/map-geometry'
 import type { CanvasControls } from './MapEditorCanvas'
 import SidePanel, { type PanelTab } from './SidePanel'
@@ -27,6 +34,12 @@ const MapEditorCanvas = dynamic(() => import('./MapEditorCanvas'), {
 
 type Position = { x: number | null; y: number | null }
 
+/** What one write changes on a record: where its pin is, or its Scale (logo
+ *  size). Each is saved, retried, undone and redone the same way. */
+type Change =
+  | { field: 'position'; x: number; y: number }
+  | { field: 'scale'; scale: ScaleName }
+
 interface Status {
   kind: 'idle' | 'saving' | 'ok' | 'stale' | 'error'
   text: string
@@ -34,15 +47,14 @@ interface Status {
 
 interface UndoEntry {
   id: string
-  from: { x: number; y: number }
-  to: { x: number; y: number }
+  from: Change
+  to: Change
   at: number
 }
 
 interface QueuedMove {
   id: string
-  x: number
-  y: number
+  change: Change
   /** 'user' moves push an undo entry when confirmed (and clear redo);
    *  'undo' moves hand their entry to the redo stack; 'redo' moves hand it
    *  back to the undo stack. */
@@ -54,6 +66,16 @@ interface QueuedMove {
   at: number
   /** Rate-limit retries so far. */
   attempts: number
+}
+
+/** A pending write of the same record AND the same field supersedes an
+ *  older one; a move and a Scale change of one record can both be queued. */
+function sameSlot(a: { id: string; change: Change }, b: QueuedMove): boolean {
+  return a.id === b.id && a.change.field === b.change.field
+}
+
+function describe(c: Change): string {
+  return c.field === 'position' ? `(${fmt(c.x)}, ${fmt(c.y)})` : c.scale
 }
 
 /** Consecutive nudges/drops of the same pin within this window collapse into
@@ -68,6 +90,9 @@ const SETTLE_MS = 400
 /** After a 429 Airtable refuses everything for ~30 s. Retry then. */
 const RATE_LIMIT_WAIT_MS = 31_000
 const RATE_LIMIT_MAX_ATTEMPTS = 3
+/** The map + panel never shrink below this, even on a short window (the
+ *  page scrolls instead). Matches min-height in map-editor.module.css. */
+const MIN_EDITOR_HEIGHT = 480
 
 function fmt(n: number): string {
   return n.toFixed(1)
@@ -97,10 +122,12 @@ export default function MapEditor() {
     zoomIn: () => {},
     zoomOut: () => {},
     reset: () => {},
+    focusOn: () => {},
   })
   // What Airtable last confirmed for each record — the `expected` value sent
   // with every write, and where a pin goes back to when a save fails.
   const lastConfirmed = useRef<Map<string, Position>>(new Map())
+  const lastConfirmedScale = useRef<Map<string, string | null>>(new Map())
   const queue = useRef<QueuedMove[]>([])
   const inFlight = useRef<QueuedMove | null>(null)
   const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -118,6 +145,37 @@ export default function MapEditor() {
   const redoRef = useRef<UndoEntry[]>([])
   redoRef.current = redoStack
   const lastLoadAt = useRef(0)
+  const splitRef = useRef<HTMLDivElement>(null)
+
+  // ── Fit to the window ────────────────────────────────────────────────────
+  // Size the map + panel to the space between the toolbar and the bottom of
+  // the window (minus the footnote and page padding), so nothing is cut off.
+  // Re-measured on resize and whenever anything above/below changes height
+  // (e.g. the toolbar status wrapping onto a second line).
+  useLayoutEffect(() => {
+    const el = splitRef.current
+    if (!el) return
+    const main = el.closest('main')
+    const apply = () => {
+      const split = el.getBoundingClientRect()
+      const mainBottom = main?.getBoundingClientRect().bottom ?? split.bottom
+      const below = mainBottom - split.bottom
+      const top = split.top + window.scrollY
+      const h = Math.floor(window.innerHeight - top - below)
+      el.style.setProperty(
+        '--editor-height',
+        `${Math.max(MIN_EDITOR_HEIGHT, h)}px`
+      )
+    }
+    apply()
+    window.addEventListener('resize', apply)
+    const ro = new ResizeObserver(apply)
+    if (main) ro.observe(main)
+    return () => {
+      window.removeEventListener('resize', apply)
+      ro.disconnect()
+    }
+  }, [])
 
   // ── Loading ──────────────────────────────────────────────────────────────
 
@@ -139,20 +197,33 @@ export default function MapEditor() {
       fetchedAt: string
       records: EditorRecord[]
     }
-    const busy = new Set<string>(queue.current.map(m => m.id))
-    if (inFlight.current) busy.add(inFlight.current.id)
+    // Records with a write still queued or in flight, per field.
+    const pending = [...queue.current]
+    if (inFlight.current) pending.push(inFlight.current)
+    const busyPos = new Set(
+      pending.filter(m => m.change.field === 'position').map(m => m.id)
+    )
+    const busyScale = new Set(
+      pending.filter(m => m.change.field === 'scale').map(m => m.id)
+    )
     setRecords(prev => {
-      // Keep the local position of anything still being saved.
+      // Keep the local position / Scale of anything still being saved.
       if (!prev) return data.records
       const local = new Map(prev.map(r => [r.id, r]))
-      return data.records.map(r =>
-        busy.has(r.id) && local.has(r.id)
-          ? { ...r, x: local.get(r.id)!.x, y: local.get(r.id)!.y }
-          : r
-      )
+      return data.records.map(r => {
+        const l = local.get(r.id)
+        if (!l) return r
+        return {
+          ...r,
+          ...(busyPos.has(r.id) ? { x: l.x, y: l.y } : {}),
+          ...(busyScale.has(r.id) ? { scale: l.scale } : {}),
+        }
+      })
     })
     for (const r of data.records) {
-      if (!busy.has(r.id)) lastConfirmed.current.set(r.id, { x: r.x, y: r.y })
+      if (!busyPos.has(r.id))
+        lastConfirmed.current.set(r.id, { x: r.x, y: r.y })
+      if (!busyScale.has(r.id)) lastConfirmedScale.current.set(r.id, r.scale)
     }
     setFetchedAt(data.fetchedAt)
     lastLoadAt.current = Date.now()
@@ -184,10 +255,29 @@ export default function MapEditor() {
     )
   }, [])
 
+  const setLocalScale = useCallback((id: string, scale: string | null) => {
+    setRecords(prev =>
+      prev ? prev.map(r => (r.id === id ? { ...r, scale } : r)) : prev
+    )
+  }, [])
+
+  const applyLocal = useCallback(
+    (id: string, change: Change) => {
+      if (change.field === 'position') setLocalPosition(id, change.x, change.y)
+      else setLocalScale(id, change.scale)
+    },
+    [setLocalPosition, setLocalScale]
+  )
+
   const pushUndo = useCallback((entry: UndoEntry) => {
     setUndoStack(prev => {
       const last = prev[prev.length - 1]
-      if (last && last.id === entry.id && entry.at - last.at < UNDO_MERGE_MS) {
+      if (
+        last &&
+        last.id === entry.id &&
+        last.to.field === entry.to.field &&
+        entry.at - last.at < UNDO_MERGE_MS
+      ) {
         // Merge a burst of nudges into one step, keeping the original origin.
         return [...prev.slice(0, -1), { ...entry, from: last.from }]
       }
@@ -220,37 +310,58 @@ export default function MapEditor() {
       return
     }
     inFlight.current = next
-    // A newer move of the same pin waiting behind this one means the pin is
-    // already where the user wants it — don't drag it back to this result.
-    const superseded = () => queue.current.some(m => m.id === next.id)
+    const change = next.change
+    // A newer write of the same field of the same record waiting behind this
+    // one means the record is already how the user wants it — don't drag it
+    // back to this result.
+    const superseded = () => queue.current.some(m => sameSlot(next, m))
     const expected = lastConfirmed.current.get(next.id) ?? { x: null, y: null }
+    const expectedScale = lastConfirmedScale.current.get(next.id) ?? null
     const name =
       recordsRef.current?.find(r => r.id === next.id)?.labelName ?? next.id
     setStatus({
       kind: 'saving',
-      text: `Saving ${name} → (${fmt(next.x)}, ${fmt(next.y)})…`,
+      text: `Saving ${name} → ${describe(change)}…`,
     })
     try {
+      const body =
+        change.field === 'position'
+          ? { id: next.id, x: change.x, y: change.y, expected }
+          : { id: next.id, scale: change.scale, expected: expectedScale }
       const res = await fetch('/api/admin/map', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: next.id, x: next.x, y: next.y, expected }),
+        body: JSON.stringify(body),
       })
       if (res.status === 409) {
-        const data = (await res.json()) as { current: Position }
-        lastConfirmed.current.set(next.id, data.current)
-        // Someone else moved it: show where it really is and drop any of our
-        // follow-up moves rather than silently overwriting theirs.
-        queue.current = queue.current.filter(m => m.id !== next.id)
-        if (data.current.x !== null && data.current.y !== null) {
-          setLocalPosition(next.id, data.current.x, data.current.y)
+        // Someone else changed it in Airtable: show what is really there and
+        // drop any of our follow-up writes rather than silently overwriting.
+        queue.current = queue.current.filter(m => !sameSlot(next, m))
+        if (change.field === 'position') {
+          const data = (await res.json()) as { current: Position }
+          lastConfirmed.current.set(next.id, data.current)
+          if (data.current.x !== null && data.current.y !== null) {
+            setLocalPosition(next.id, data.current.x, data.current.y)
+          }
+          setStatus({
+            kind: 'stale',
+            text: `${name} was moved in Airtable since you loaded – shown at its current position (${
+              data.current.x === null ? '–' : fmt(data.current.x)
+            }, ${data.current.y === null ? '–' : fmt(data.current.y)}). Drag again if you still want to move it.`,
+          })
+        } else {
+          const data = (await res.json()) as {
+            current: { scale: string | null }
+          }
+          lastConfirmedScale.current.set(next.id, data.current.scale)
+          setLocalScale(next.id, data.current.scale)
+          setStatus({
+            kind: 'stale',
+            text: `${name}'s Scale was changed in Airtable since you loaded – now showing ${
+              data.current.scale ?? 'not set'
+            }. Pick a size again if you still want to change it.`,
+          })
         }
-        setStatus({
-          kind: 'stale',
-          text: `${name} was moved in Airtable since you loaded – shown at its current position (${
-            data.current.x === null ? '–' : fmt(data.current.x)
-          }, ${data.current.y === null ? '–' : fmt(data.current.y)}). Drag again if you still want to move it.`,
-        })
       } else if (
         res.status === 429 &&
         next.attempts < RATE_LIMIT_MAX_ATTEMPTS
@@ -279,18 +390,36 @@ export default function MapEditor() {
         }
         throw new Error(message)
       } else {
-        const data = (await res.json()) as {
-          record: { id: string; x: number; y: number }
+        // What Airtable actually stored, as a Change; and what it held before
+        // (null when there was nothing to go back to – a first placement or an
+        // unset Scale – in which case the step is not undoable, same as /map's
+        // first placement today).
+        let stored: Change
+        let from: Change | null
+        if (change.field === 'position') {
+          const data = (await res.json()) as {
+            record: { id: string; x: number; y: number }
+          }
+          stored = { field: 'position', x: data.record.x, y: data.record.y }
+          from =
+            expected.x !== null && expected.y !== null
+              ? { field: 'position', x: expected.x, y: expected.y }
+              : null
+          lastConfirmed.current.set(next.id, { x: stored.x, y: stored.y })
+        } else {
+          const data = (await res.json()) as {
+            record: { id: string; scale: ScaleName }
+          }
+          stored = { field: 'scale', scale: data.record.scale }
+          from =
+            expectedScale !== null
+              ? { field: 'scale', scale: expectedScale as ScaleName }
+              : null
+          lastConfirmedScale.current.set(next.id, stored.scale)
         }
-        const stored = data.record
         if (next.kind === 'user') {
-          if (expected.x !== null && expected.y !== null) {
-            pushUndo({
-              id: next.id,
-              from: { x: expected.x, y: expected.y },
-              to: { x: stored.x, y: stored.y },
-              at: Date.now(),
-            })
+          if (from) {
+            pushUndo({ id: next.id, from, to: stored, at: Date.now() })
           }
         } else if (next.kind === 'undo' && next.entry) {
           const entry = next.entry
@@ -299,19 +428,27 @@ export default function MapEditor() {
           const entry = next.entry
           setUndoStack(prev => [...prev.slice(-49), entry])
         }
-        lastConfirmed.current.set(next.id, { x: stored.x, y: stored.y })
-        if (!superseded()) setLocalPosition(next.id, stored.x, stored.y)
+        if (!superseded()) applyLocal(next.id, stored)
         setStatus({
           kind: 'ok',
-          text: `Saved ${name} at (${fmt(stored.x)}, ${fmt(stored.y)}) · ${new Date().toLocaleTimeString()}`,
+          text: `Saved ${name} ${
+            stored.field === 'position' ? 'at' : 'as'
+          } ${describe(stored)} · ${new Date().toLocaleTimeString()}`,
         })
         setErrorBanner(null)
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      const back = lastConfirmed.current.get(next.id)
-      if (!superseded() && back && back.x !== null && back.y !== null) {
-        setLocalPosition(next.id, back.x, back.y)
+      // Put the record back to what Airtable last confirmed.
+      if (!superseded()) {
+        if (change.field === 'position') {
+          const back = lastConfirmed.current.get(next.id)
+          if (back && back.x !== null && back.y !== null) {
+            setLocalPosition(next.id, back.x, back.y)
+          }
+        } else if (lastConfirmedScale.current.has(next.id)) {
+          setLocalScale(next.id, lastConfirmedScale.current.get(next.id)!)
+        }
       }
       // A failed undo/redo keeps its history entry where it came from.
       if (next.kind === 'undo' && next.entry) {
@@ -328,12 +465,13 @@ export default function MapEditor() {
       if (queue.current.length) void processQueue()
       else setSaving(false)
     }
-  }, [pushUndo, setLocalPosition])
+  }, [pushUndo, setLocalPosition, setLocalScale, applyLocal])
 
   const enqueue = useCallback(
     (move: Omit<QueuedMove, 'at' | 'attempts'>) => {
-      // A newer move of the same pin replaces the one still waiting.
-      queue.current = queue.current.filter(m => m.id !== move.id)
+      // A newer write of the same field of the same record replaces the one
+      // still waiting.
+      queue.current = queue.current.filter(m => !sameSlot(move, m))
       queue.current.push({ ...move, at: Date.now(), attempts: 0 })
       if (settleTimer.current) {
         clearTimeout(settleTimer.current)
@@ -344,22 +482,32 @@ export default function MapEditor() {
     [processQueue]
   )
 
-  const moveRecord = useCallback(
-    (
-      id: string,
-      x: number,
-      y: number,
-      history: { kind: QueuedMove['kind']; entry?: UndoEntry } = {
-        kind: 'user',
-      }
-    ) => {
-      const c = clampGrid(roundGrid(x), roundGrid(y))
-      setLocalPosition(id, c.x, c.y)
-      // A fresh move forks history: nothing to redo any more.
+  type History = { kind: QueuedMove['kind']; entry?: UndoEntry }
+
+  /** Show a change immediately and queue its save. */
+  const applyChange = useCallback(
+    (id: string, change: Change, history: History = { kind: 'user' }) => {
+      applyLocal(id, change)
+      // A fresh change forks history: nothing to redo any more.
       if (history.kind === 'user') setRedoStack([])
-      enqueue({ id, x: c.x, y: c.y, ...history })
+      enqueue({ id, change, ...history })
     },
-    [enqueue, setLocalPosition]
+    [enqueue, applyLocal]
+  )
+
+  const moveRecord = useCallback(
+    (id: string, x: number, y: number, history?: History) => {
+      const c = clampGrid(roundGrid(x), roundGrid(y))
+      applyChange(id, { field: 'position', x: c.x, y: c.y }, history)
+    },
+    [applyChange]
+  )
+
+  const setScale = useCallback(
+    (id: string, scale: ScaleName) => {
+      applyChange(id, { field: 'scale', scale })
+    },
+    [applyChange]
   )
 
   /** History entries only exist once Airtable confirms a move, so replaying
@@ -377,16 +525,16 @@ export default function MapEditor() {
     const last = undoRef.current[undoRef.current.length - 1]
     if (!last) return
     setUndoStack(prev => prev.slice(0, -1))
-    moveRecord(last.id, last.from.x, last.from.y, { kind: 'undo', entry: last })
-  }, [historyBusy, moveRecord])
+    applyChange(last.id, last.from, { kind: 'undo', entry: last })
+  }, [historyBusy, applyChange])
 
   const redo = useCallback(() => {
     if (historyBusy()) return
     const last = redoRef.current[redoRef.current.length - 1]
     if (!last) return
     setRedoStack(prev => prev.slice(0, -1))
-    moveRecord(last.id, last.to.x, last.to.y, { kind: 'redo', entry: last })
-  }, [historyBusy, moveRecord])
+    applyChange(last.id, last.to, { kind: 'redo', entry: last })
+  }, [historyBusy, applyChange])
 
   // ── Canvas callbacks ─────────────────────────────────────────────────────
 
@@ -409,6 +557,19 @@ export default function MapEditor() {
   const onSelect = useCallback((id: string | null) => {
     setSelectedId(id)
     if (id) setPanelTab('selected')
+  }, [])
+
+  // Picking a search result: select it and, if it is on the map, pan/zoom
+  // to it (switching drafts back on if that is what was hiding it).
+  const onPick = useCallback((id: string) => {
+    const rec = recordsRef.current?.find(r => r.id === id)
+    if (!rec) return
+    setSelectedId(id)
+    setPanelTab('selected')
+    if (rec.x !== null && rec.y !== null) {
+      if (!rec.published) setShowDrafts(true)
+      controlsRef.current.focusOn(rec.x, rec.y)
+    }
   }, [])
 
   const onPlaceClick = useCallback(
@@ -591,7 +752,7 @@ export default function MapEditor() {
         </span>
       </div>
 
-      <div className={styles.split}>
+      <div className={styles.split} ref={splitRef}>
         <div className={styles.canvasWrap}>
           {/* Notices float over the map so they never push it around. */}
           <div className={styles.overlays}>
@@ -613,7 +774,7 @@ export default function MapEditor() {
                       onClick={() => {
                         const m = errorBanner.retry!
                         setErrorBanner(null)
-                        moveRecord(m.id, m.x, m.y, {
+                        applyChange(m.id, m.change, {
                           kind: m.kind,
                           entry: m.entry,
                         })
@@ -677,13 +838,15 @@ export default function MapEditor() {
               setPlaceModeId(prev => (prev === id ? null : id))
               setSelectedId(id)
             }}
+            onPick={onPick}
             onSetPosition={(id, x, y) => moveRecord(id, x, y)}
+            onSetScale={setScale}
           />
         )}
       </div>
 
       <p className={`${adminStyles.sectionHint} ${styles.footnote}`}>
-        Only x and y are written – publishing, hiding and Scale stay in
+        Only x, y and Scale are written – publishing and hiding stay in
         Airtable.
       </p>
     </div>

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -144,6 +144,8 @@ export default function MapEditor() {
   undoRef.current = undoStack
   const redoRef = useRef<UndoEntry[]>([])
   redoRef.current = redoStack
+  /** Undo/redo pressed while a save was pending; runs when the queue drains. */
+  const pendingHistory = useRef<'undo' | 'redo' | null>(null)
   const lastLoadAt = useRef(0)
   const splitRef = useRef<HTMLDivElement>(null)
 
@@ -336,7 +338,9 @@ export default function MapEditor() {
       if (res.status === 409) {
         // Someone else changed it in Airtable: show what is really there and
         // drop any of our follow-up writes rather than silently overwriting.
+        // A pending undo would now revert the wrong step, so drop it too.
         queue.current = queue.current.filter(m => !sameSlot(next, m))
+        pendingHistory.current = null
         if (change.field === 'position') {
           const data = (await res.json()) as { current: Position }
           lastConfirmed.current.set(next.id, data.current)
@@ -439,6 +443,9 @@ export default function MapEditor() {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
+      // The write didn't happen, so an undo pressed for it has nothing to
+      // undo – it must not fall through to the previous step.
+      pendingHistory.current = null
       // Put the record back to what Airtable last confirmed.
       if (!superseded()) {
         if (change.field === 'position') {
@@ -510,31 +517,54 @@ export default function MapEditor() {
     [applyChange]
   )
 
-  /** History entries only exist once Airtable confirms a move, so replaying
-   *  one while a save is pending could revert the wrong thing. */
-  const historyBusy = useCallback(() => {
+  /** History entries only exist once Airtable confirms a write, so replaying
+   *  one while a save is pending could revert the wrong thing. An undo/redo
+   *  pressed during a save is remembered and runs the moment the queue is
+   *  empty (see the effect below) – it is never just dropped. */
+  const historyBusy = useCallback((what: 'undo' | 'redo') => {
     if (inFlight.current || queue.current.length) {
-      setStatus({ kind: 'saving', text: 'Finishing the current save first…' })
+      pendingHistory.current = what
+      setStatus({
+        kind: 'saving',
+        text: `Finishing the current save, then ${what}ing…`,
+      })
       return true
     }
     return false
   }, [])
 
   const undo = useCallback(() => {
-    if (historyBusy()) return
+    if (historyBusy('undo')) return
     const last = undoRef.current[undoRef.current.length - 1]
-    if (!last) return
+    if (!last) {
+      setStatus({ kind: 'idle', text: 'Nothing to undo.' })
+      return
+    }
     setUndoStack(prev => prev.slice(0, -1))
     applyChange(last.id, last.from, { kind: 'undo', entry: last })
   }, [historyBusy, applyChange])
 
   const redo = useCallback(() => {
-    if (historyBusy()) return
+    if (historyBusy('redo')) return
     const last = redoRef.current[redoRef.current.length - 1]
-    if (!last) return
+    if (!last) {
+      setStatus({ kind: 'idle', text: 'Nothing to redo.' })
+      return
+    }
     setRedoStack(prev => prev.slice(0, -1))
     applyChange(last.id, last.to, { kind: 'redo', entry: last })
   }, [historyBusy, applyChange])
+
+  // Run the undo/redo that was pressed mid-save once the queue has drained
+  // and the history stacks have caught up (this runs after render, so the
+  // stack refs are current).
+  useEffect(() => {
+    if (saving || !pendingHistory.current) return
+    const what = pendingHistory.current
+    pendingHistory.current = null
+    if (what === 'undo') undo()
+    else redo()
+  }, [saving, undoStack, redoStack, undo, redo])
 
   // ── Canvas callbacks ─────────────────────────────────────────────────────
 
@@ -595,7 +625,9 @@ export default function MapEditor() {
           target.tagName === 'TEXTAREA' ||
           target.tagName === 'SELECT' ||
           target.isContentEditable)
-      if ((e.metaKey || e.ctrlKey) && !typing) {
+      // Undo/redo always mean the map, even with the cursor in the search
+      // box or an x/y field – there is no text history worth keeping there.
+      if (e.metaKey || e.ctrlKey) {
         const k = e.key.toLowerCase()
         if (k === 'z' && e.shiftKey) {
           e.preventDefault()
@@ -674,18 +706,18 @@ export default function MapEditor() {
 
   return (
     <div className={styles.page}>
-      <div className={`${adminStyles.notice} ${styles.liveWarning}`}>
-        <strong>This edits the live site.</strong> Every move is saved to
-        Airtable straight away and appears on the public /map within a few
-        minutes.
-      </div>
-
-      <div className={adminStyles.pageHeading}>
+      <div className={`${adminStyles.pageHeading} ${styles.heading}`}>
         <h1 className={adminStyles.pageTitle}>Map editor</h1>
         <span className={adminStyles.pageMeta}>
           Drag a logo to move it · click to select · saves to Airtable on drop ·{' '}
           /map updates within a few minutes
         </span>
+      </div>
+
+      <div className={`${adminStyles.notice} ${styles.liveWarning}`}>
+        <strong>This edits the live site.</strong> Every move is saved to
+        Airtable straight away and appears on the public /map within a few
+        minutes.
       </div>
 
       <div className={`${adminStyles.editorToolbar} ${styles.toolbar}`}>

--- a/src/app/admin/map/MapEditor.tsx
+++ b/src/app/admin/map/MapEditor.tsx
@@ -730,32 +730,6 @@ export default function MapEditor() {
               } unplaced · ${counts.drafts} incoming suggestions`
             : 'Loading…'}
         </span>
-        <button
-          type="button"
-          className={adminStyles.editorButton}
-          onClick={() => void load()}
-          disabled={dragging || !!inFlight.current}
-        >
-          Refresh
-        </button>
-        <button
-          type="button"
-          className={adminStyles.editorButton}
-          onClick={undo}
-          disabled={undoStack.length === 0 || saving}
-          title="Cmd/Ctrl+Z"
-        >
-          Undo{undoStack.length ? ` (${undoStack.length})` : ''}
-        </button>
-        <button
-          type="button"
-          className={adminStyles.editorButton}
-          onClick={redo}
-          disabled={redoStack.length === 0 || saving}
-          title="Cmd/Ctrl+Shift+Z"
-        >
-          Redo{redoStack.length ? ` (${redoStack.length})` : ''}
-        </button>
         <label className={styles.toggle}>
           <input
             type="checkbox"
@@ -763,7 +737,7 @@ export default function MapEditor() {
             onChange={e => setShowDrafts(e.target.checked)}
             disabled={previewPublic}
           />
-          Show incoming suggestions
+          Show incoming suggestions on map
         </label>
         <label className={styles.toggle}>
           <input
@@ -781,6 +755,34 @@ export default function MapEditor() {
           }`}
         >
           {status.text}
+        </span>
+        <span className={styles.toolbarActions}>
+          <button
+            type="button"
+            className={adminStyles.editorButton}
+            onClick={() => void load()}
+            disabled={dragging || !!inFlight.current}
+          >
+            Refresh
+          </button>
+          <button
+            type="button"
+            className={adminStyles.editorButton}
+            onClick={undo}
+            disabled={undoStack.length === 0 || saving}
+            title="Cmd/Ctrl+Z"
+          >
+            Undo{undoStack.length ? ` (${undoStack.length})` : ''}
+          </button>
+          <button
+            type="button"
+            className={adminStyles.editorButton}
+            onClick={redo}
+            disabled={redoStack.length === 0 || saving}
+            title="Cmd/Ctrl+Shift+Z"
+          >
+            Redo{redoStack.length ? ` (${redoStack.length})` : ''}
+          </button>
         </span>
       </div>
 

--- a/src/app/admin/map/MapEditorCanvas.tsx
+++ b/src/app/admin/map/MapEditorCanvas.tsx
@@ -69,6 +69,9 @@ interface Props {
 
 const LOGO_CLIP_ID = 'editor-logo-circle-clip'
 const RING_GAP = 3
+/** Selection ring: a vivid magenta over a white halo, so it reads on the
+ *  teal land, the orange hills, dark water and white logos alike. */
+const SELECTED_COLOR = '#ff2d95'
 
 type PinSel = d3.Selection<SVGGElement, EditorRecord, SVGGElement, unknown>
 
@@ -93,13 +96,22 @@ function drawGlyph(
     .attr('stroke-width', 2)
     .attr('stroke-dasharray', '6 4')
     .style('pointer-events', 'none')
-  g.append('circle')
+  const ring = g
+    .append('g')
     .attr('class', 'ring-selected')
+    .style('pointer-events', 'none')
+  ring
+    .append('circle')
     .attr('r', m.iconSize / 2 + RING_GAP)
     .attr('fill', 'none')
-    .attr('stroke', '#a6dad9')
+    .attr('stroke', '#fff')
+    .attr('stroke-width', 7)
+  ring
+    .append('circle')
+    .attr('r', m.iconSize / 2 + RING_GAP)
+    .attr('fill', 'none')
+    .attr('stroke', SELECTED_COLOR)
     .attr('stroke-width', 3)
-    .style('pointer-events', 'none')
 
   const glyph = g.append('g').attr('class', 'glyph')
 
@@ -522,7 +534,10 @@ export default function MapEditorCanvas({
         const area = this.getAttribute('data-area')
         d3.select(this)
           .select('rect')
-          .attr('stroke', !previewPublic && area === focus ? '#a6dad9' : null)
+          .attr(
+            'stroke',
+            !previewPublic && area === focus ? SELECTED_COLOR : null
+          )
           .attr('stroke-width', 3)
       })
   }, [records, selectedId, placeModeId, previewPublic])

--- a/src/app/admin/map/MapEditorCanvas.tsx
+++ b/src/app/admin/map/MapEditorCanvas.tsx
@@ -23,6 +23,8 @@ import {
   MAP_OFFSET_X,
   MAP_OFFSET_Y,
   MAP_WIDTH,
+  PADDED_HEIGHT,
+  PADDED_WIDTH,
   PRESERVE_ASPECT_RATIO,
   TITLE,
   VIEWBOX,
@@ -40,7 +42,13 @@ export interface CanvasControls {
   zoomIn: () => void
   zoomOut: () => void
   reset: () => void
+  /** Pan (and zoom in to at least FOCUS_ZOOM) so this grid position is
+   *  centred in the visible canvas. */
+  focusOn: (x: number, y: number) => void
 }
+
+/** Zoom level a "Show on map" jump lands at (kept if already closer). */
+const FOCUS_ZOOM = 2
 
 interface Props {
   /** Records to draw (already filtered by the toolbar toggles). Records with
@@ -338,6 +346,29 @@ export default function MapEditorCanvas({
       },
       reset: () => {
         svg.transition().duration(500).call(zoom.transform, d3.zoomIdentity)
+      },
+      focusOn: (gx, gy) => {
+        const k = Math.max(d3.zoomTransform(svgNode).k, FOCUS_ZOOM)
+        // Centre of what is actually visible: the viewBox is fitted with
+        // xMidYMin meet, so it is horizontally centred but top-aligned – a
+        // canvas taller than the viewBox's aspect ratio shows extra map
+        // below it.
+        const rect = svgNode.getBoundingClientRect()
+        const fit = Math.min(
+          rect.width / PADDED_WIDTH,
+          rect.height / PADDED_HEIGHT
+        )
+        const cx = PADDED_WIDTH / 2
+        const cy = fit > 0 ? rect.height / fit / 2 : PADDED_HEIGHT / 2
+        // The zoom handler draws the scene at translate(t + MAP_OFFSET)
+        // scale(k), so a scene point p lands at t + MAP_OFFSET + k·p.
+        const t = d3.zoomIdentity
+          .translate(
+            cx - MAP_OFFSET_X - k * gridToPx(gx),
+            cy - MAP_OFFSET_Y - k * gridToPx(gy)
+          )
+          .scale(k)
+        svg.transition().duration(500).call(zoom.transform, t)
       },
     }
 

--- a/src/app/admin/map/MapEditorCanvas.tsx
+++ b/src/app/admin/map/MapEditorCanvas.tsx
@@ -69,8 +69,9 @@ interface Props {
 
 const LOGO_CLIP_ID = 'editor-logo-circle-clip'
 const RING_GAP = 3
-/** Selection ring: a vivid magenta over a white halo, so it reads on the
- *  teal land, the orange hills, dark water and white logos alike. */
+/** Selection ring: a vivid magenta that reads on the teal land, the orange
+ *  hills and dark water. No white halo – it looked like a second logo
+ *  circle. */
 const SELECTED_COLOR = '#ff2d95'
 
 type PinSel = d3.Selection<SVGGElement, EditorRecord, SVGGElement, unknown>
@@ -96,22 +97,13 @@ function drawGlyph(
     .attr('stroke-width', 2)
     .attr('stroke-dasharray', '6 4')
     .style('pointer-events', 'none')
-  const ring = g
-    .append('g')
+  g.append('circle')
     .attr('class', 'ring-selected')
-    .style('pointer-events', 'none')
-  ring
-    .append('circle')
-    .attr('r', m.iconSize / 2 + RING_GAP)
-    .attr('fill', 'none')
-    .attr('stroke', '#fff')
-    .attr('stroke-width', 7)
-  ring
-    .append('circle')
     .attr('r', m.iconSize / 2 + RING_GAP)
     .attr('fill', 'none')
     .attr('stroke', SELECTED_COLOR)
-    .attr('stroke-width', 3)
+    .attr('stroke-width', 3.5)
+    .style('pointer-events', 'none')
 
   const glyph = g.append('g').attr('class', 'glyph')
 

--- a/src/app/admin/map/SidePanel.tsx
+++ b/src/app/admin/map/SidePanel.tsx
@@ -1,13 +1,19 @@
 'use client'
 
-import { useMemo, useState } from 'react'
-import type { EditorRecord } from '@/lib/admin/map-editor-core'
-import { MAP_TABLE_ID } from '@/lib/admin/map-editor-core'
-import { GRID_BOUNDS } from '@/lib/admin/map-geometry'
+import { useMemo, useRef, useState } from 'react'
+import type { EditorRecord, ScaleName } from '@/lib/admin/map-editor-core'
+import {
+  isScaleName,
+  MAP_TABLE_ID,
+  SCALE_OPTIONS,
+} from '@/lib/admin/map-editor-core'
+import { DEFAULT_SCALE_NAME, GRID_BOUNDS } from '@/lib/admin/map-geometry'
 import adminStyles from '../admin.module.css'
 import styles from './map-editor.module.css'
 
 const AIRTABLE_BASE_URL = 'https://airtable.com/appF8XfZUGXtfi40E'
+/** Search results shown before asking for a narrower query. */
+const MAX_RESULTS = 50
 
 export type PanelTab = 'unplaced' | 'selected'
 
@@ -18,7 +24,34 @@ interface Props {
   tab: PanelTab
   onTabChange: (tab: PanelTab) => void
   onPlace: (id: string) => void
+  /** A search result was chosen: select it and jump to it if it is placed. */
+  onPick: (id: string) => void
   onSetPosition: (id: string, x: number, y: number) => void
+  /** Change the record's Scale (logo size); saved like a move. */
+  onSetScale: (id: string, scale: ScaleName) => void
+}
+
+/** Case-insensitive match on any name the record goes by, or its category.
+ *  Name-prefix matches sort first, then alphabetical. */
+function searchRecords(records: EditorRecord[], query: string): EditorRecord[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return []
+  const names = (r: EditorRecord) =>
+    [r.title, r.labelName, r.shortName ?? '', r.tooltipTitle].map(s =>
+      s.toLowerCase()
+    )
+  const rank = (r: EditorRecord): number => {
+    const ns = names(r)
+    if (ns.some(n => n.startsWith(q))) return 0
+    if (ns.some(n => n.includes(q))) return 1
+    if (r.category.toLowerCase().includes(q)) return 2
+    return -1
+  }
+  return records
+    .map(r => ({ r, rank: rank(r) }))
+    .filter(x => x.rank >= 0)
+    .sort((a, b) => a.rank - b.rank || a.r.title.localeCompare(b.r.title))
+    .map(x => x.r)
 }
 
 function Badges({ r }: { r: EditorRecord }) {
@@ -50,9 +83,12 @@ export default function SidePanel({
   tab,
   onTabChange,
   onPlace,
+  onPick,
   onSetPosition,
+  onSetScale,
 }: Props) {
   const [search, setSearch] = useState('')
+  const searchRef = useRef<HTMLInputElement>(null)
   // Typed-but-not-yet-applied x/y for the selected record.
   const [draft, setDraft] = useState<{
     id: string
@@ -60,20 +96,35 @@ export default function SidePanel({
     y: string
   } | null>(null)
 
-  const unplaced = useMemo(() => {
-    const q = search.trim().toLowerCase()
-    return (
+  const unplaced = useMemo(
+    () =>
       records
         .filter(r => r.x === null || r.y === null)
-        .filter(r => !q || r.title.toLowerCase().includes(q))
-        // Newest additions to Airtable first (same order as the Incoming
+        // Published-but-unplaced first (they are missing from the live map),
+        // then newest additions to Airtable (same order as the Incoming
         // suggestions view), then by name.
         .sort((a, b) => {
+          if (a.published !== b.published) return a.published ? -1 : 1
           const t = (b.createdTime ?? '').localeCompare(a.createdTime ?? '')
           return t !== 0 ? t : a.title.localeCompare(b.title)
-        })
-    )
-  }, [records, search])
+        }),
+    [records]
+  )
+
+  const results = useMemo(
+    () => searchRecords(records, search),
+    [records, search]
+  )
+  const searching = search.trim() !== ''
+
+  const pick = (id: string) => {
+    onPick(id)
+    setSearch('')
+  }
+  const placeFromSearch = (id: string) => {
+    onPlace(id)
+    setSearch('')
+  }
 
   const shownTab = tab
   const xValue =
@@ -106,34 +157,141 @@ export default function SidePanel({
 
   return (
     <aside className={styles.panel}>
-      <div className={styles.tabs}>
-        <button
-          type="button"
-          className={`${styles.tab} ${shownTab === 'unplaced' ? styles.tabActive : ''}`}
-          onClick={() => onTabChange('unplaced')}
-        >
-          Unplaced ({records.filter(r => r.x === null || r.y === null).length})
-        </button>
-        <button
-          type="button"
-          className={`${styles.tab} ${shownTab === 'selected' ? styles.tabActive : ''}`}
-          onClick={() => onTabChange('selected')}
-        >
-          Selected
-        </button>
+      <div className={styles.searchBar}>
+        <input
+          ref={searchRef}
+          className={`${adminStyles.editorInput} ${styles.search}`}
+          type="search"
+          placeholder="Find a logo (placed or unplaced)…"
+          aria-label="Find a logo"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && results[0]) {
+              e.preventDefault()
+              pick(results[0].id)
+            } else if (e.key === 'Escape') {
+              // First Escape clears; a second one leaves the box so the
+              // editor's own Escape (deselect / reset view) takes over.
+              if (searching) setSearch('')
+              else searchRef.current?.blur()
+            }
+          }}
+        />
       </div>
 
-      {shownTab === 'unplaced' && (
+      {searching && (
         <div className={styles.panelBody}>
-          <input
-            className={`${adminStyles.editorInput} ${styles.search}`}
-            placeholder="Search unplaced…"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-          />
+          {results.length === 0 ? (
+            <p className={adminStyles.sectionHint}>No matches.</p>
+          ) : (
+            <>
+              <p className={adminStyles.sectionHint}>
+                {results.length === 1 ? '1 match' : `${results.length} matches`}{' '}
+                · Enter opens the first · Esc clears
+              </p>
+              <ul className={styles.list}>
+                {results.slice(0, MAX_RESULTS).map(r => {
+                  const placed = r.x !== null && r.y !== null
+                  return (
+                    <li
+                      key={r.id}
+                      className={`${styles.row} ${styles.rowResult} ${
+                        selected?.id === r.id ? styles.rowSelected : ''
+                      }`}
+                    >
+                      <button
+                        type="button"
+                        className={styles.resultPick}
+                        title={
+                          placed
+                            ? 'Show on the map'
+                            : 'Select (not on the map yet)'
+                        }
+                        onClick={() => pick(r.id)}
+                      >
+                        <span className={styles.rowLogo}>
+                          {r.mapLogo ? (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img src={r.mapLogo} alt="" />
+                          ) : (
+                            <span className={styles.rowLogoMissing} />
+                          )}
+                        </span>
+                        <span className={styles.rowMain}>
+                          <span className={styles.rowTitle}>{r.title}</span>
+                          <span className={styles.rowMeta}>
+                            {r.category || '—'}
+                          </span>
+                          <span className={styles.badges}>
+                            <span
+                              className={
+                                r.published
+                                  ? styles.badgeLive
+                                  : styles.badgeDraft
+                              }
+                            >
+                              {r.published ? 'Published' : 'Unpublished'}
+                            </span>
+                          </span>
+                        </span>
+                      </button>
+                      {placed ? (
+                        <span className={styles.rowCoords}>
+                          {r.x!.toFixed(1)}, {r.y!.toFixed(1)}
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          className={
+                            placeModeId === r.id
+                              ? adminStyles.editorButtonPrimary
+                              : adminStyles.editorButton
+                          }
+                          onClick={() => placeFromSearch(r.id)}
+                        >
+                          {placeModeId === r.id ? 'Placing…' : 'Place'}
+                        </button>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+              {results.length > MAX_RESULTS && (
+                <p className={adminStyles.sectionHint}>
+                  Showing the first {MAX_RESULTS} – keep typing to narrow it
+                  down.
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {!searching && (
+        <div className={styles.tabs}>
+          <button
+            type="button"
+            className={`${styles.tab} ${shownTab === 'unplaced' ? styles.tabActive : ''}`}
+            onClick={() => onTabChange('unplaced')}
+          >
+            Unplaced ({unplaced.length})
+          </button>
+          <button
+            type="button"
+            className={`${styles.tab} ${shownTab === 'selected' ? styles.tabActive : ''}`}
+            onClick={() => onTabChange('selected')}
+          >
+            Selected
+          </button>
+        </div>
+      )}
+
+      {!searching && shownTab === 'unplaced' && (
+        <div className={styles.panelBody}>
           {unplaced.length === 0 ? (
             <p className={adminStyles.sectionHint}>
-              {search ? 'No matches.' : 'Everything has coordinates.'}
+              Everything has coordinates.
             </p>
           ) : (
             <ul className={styles.list}>
@@ -183,7 +341,7 @@ export default function SidePanel({
         </div>
       )}
 
-      {shownTab === 'selected' && (
+      {!searching && shownTab === 'selected' && (
         <div className={styles.panelBody}>
           {!selected ? (
             <p className={adminStyles.sectionHint}>
@@ -212,7 +370,32 @@ export default function SidePanel({
                 <dt>Status</dt>
                 <dd>{selected.status}</dd>
                 <dt>Scale</dt>
-                <dd>{selected.scale ?? 'not set – drawn as Medium'}</dd>
+                <dd>
+                  <select
+                    className={`${adminStyles.editorSelect} ${styles.scaleSelect}`}
+                    aria-label="Scale (logo size)"
+                    // An unset Scale shows as a disabled placeholder so the
+                    // first real choice is a deliberate one.
+                    value={isScaleName(selected.scale) ? selected.scale : ''}
+                    onChange={e => {
+                      const v = e.target.value
+                      if (isScaleName(v)) onSetScale(selected.id, v)
+                    }}
+                  >
+                    {!isScaleName(selected.scale) && (
+                      <option value="" disabled>
+                        {selected.scale
+                          ? `${selected.scale} (unknown)`
+                          : `Not set – drawn as ${DEFAULT_SCALE_NAME}`}
+                      </option>
+                    )}
+                    {SCALE_OPTIONS.map(s => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </select>
+                </dd>
                 <dt>Label</dt>
                 <dd>{selected.labelName}</dd>
               </dl>

--- a/src/app/admin/map/SidePanel.tsx
+++ b/src/app/admin/map/SidePanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { EditorRecord, ScaleName } from '@/lib/admin/map-editor-core'
 import {
   isScaleName,
@@ -116,14 +116,56 @@ export default function SidePanel({
     [records, search]
   )
   const searching = search.trim() !== ''
+  const shown = results.slice(0, MAX_RESULTS)
+  // Keyboard cursor in the results (↑/↓ move it, Enter opens it). Reset to
+  // the first row whenever the query changes.
+  const [cursor, setCursor] = useState(0)
+  const active = Math.min(cursor, Math.max(0, shown.length - 1))
+  const listRef = useRef<HTMLUListElement>(null)
+  useEffect(() => {
+    listRef.current
+      ?.querySelector('[data-active="true"]')
+      ?.scrollIntoView({ block: 'nearest' })
+  }, [active, search])
 
+  // "/" anywhere on the page (except while typing in a field) jumps into the
+  // search box, like GitHub. The editor's own shortcuts ignore "/", so the
+  // two never fight.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return
+      const t = e.target as HTMLElement | null
+      if (
+        t &&
+        (t.tagName === 'INPUT' ||
+          t.tagName === 'TEXTAREA' ||
+          t.tagName === 'SELECT' ||
+          t.isContentEditable)
+      )
+        return
+      e.preventDefault()
+      searchRef.current?.focus()
+      searchRef.current?.select()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [])
+
+  const setQuery = (q: string) => {
+    setSearch(q)
+    setCursor(0)
+  }
+  // After a pick the search box lets go of focus so the editor's shortcuts
+  // (arrows, Escape, Cmd+Z) act on the map straight away.
   const pick = (id: string) => {
     onPick(id)
-    setSearch('')
+    setQuery('')
+    searchRef.current?.blur()
   }
   const placeFromSearch = (id: string) => {
     onPlace(id)
-    setSearch('')
+    setQuery('')
+    searchRef.current?.blur()
   }
 
   const shownTab = tab
@@ -165,19 +207,28 @@ export default function SidePanel({
           placeholder="Find a logo (placed or unplaced)…"
           aria-label="Find a logo"
           value={search}
-          onChange={e => setSearch(e.target.value)}
+          onChange={e => setQuery(e.target.value)}
           onKeyDown={e => {
-            if (e.key === 'Enter' && results[0]) {
+            if (e.key === 'ArrowDown') {
               e.preventDefault()
-              pick(results[0].id)
+              setCursor(Math.min(active + 1, shown.length - 1))
+            } else if (e.key === 'ArrowUp') {
+              e.preventDefault()
+              setCursor(Math.max(active - 1, 0))
+            } else if (e.key === 'Enter' && shown[active]) {
+              e.preventDefault()
+              pick(shown[active].id)
             } else if (e.key === 'Escape') {
               // First Escape clears; a second one leaves the box so the
               // editor's own Escape (deselect / reset view) takes over.
-              if (searching) setSearch('')
+              if (searching) setQuery('')
               else searchRef.current?.blur()
             }
           }}
         />
+        <kbd className={styles.searchKey} aria-hidden="true">
+          /
+        </kbd>
       </div>
 
       {searching && (
@@ -188,17 +239,18 @@ export default function SidePanel({
             <>
               <p className={adminStyles.sectionHint}>
                 {results.length === 1 ? '1 match' : `${results.length} matches`}{' '}
-                · Enter opens the first · Esc clears
+                · ↑↓ to move · Enter to open · Esc to clear
               </p>
-              <ul className={styles.list}>
-                {results.slice(0, MAX_RESULTS).map(r => {
+              <ul className={styles.list} ref={listRef}>
+                {shown.map((r, i) => {
                   const placed = r.x !== null && r.y !== null
                   return (
                     <li
                       key={r.id}
+                      data-active={i === active}
                       className={`${styles.row} ${styles.rowResult} ${
-                        selected?.id === r.id ? styles.rowSelected : ''
-                      }`}
+                        i === active ? styles.rowActive : ''
+                      } ${selected?.id === r.id ? styles.rowSelected : ''}`}
                     >
                       <button
                         type="button"

--- a/src/app/admin/map/SidePanel.tsx
+++ b/src/app/admin/map/SidePanel.tsx
@@ -204,8 +204,8 @@ export default function SidePanel({
           ref={searchRef}
           className={`${adminStyles.editorInput} ${styles.search}`}
           type="search"
-          placeholder="Find a logo (placed or unplaced)…"
-          aria-label="Find a logo"
+          placeholder="Find a listing (placed or unplaced)…"
+          aria-label="Find a listing"
           value={search}
           onChange={e => setQuery(e.target.value)}
           onKeyDown={e => {
@@ -399,7 +399,7 @@ export default function SidePanel({
         <div className={styles.panelBody}>
           {!selected ? (
             <p className={adminStyles.sectionHint}>
-              Click a logo on the map to select it.
+              Click a listing on the map to select it.
             </p>
           ) : (
             <div className={styles.detail}>
@@ -501,8 +501,8 @@ export default function SidePanel({
                 </button>
               </div>
               <p className={adminStyles.sectionHint}>
-                Arrow keys nudge the selected logo by 0.1 (Shift: 1.0). Map is
-                0–{GRID_BOUNDS.x[1]} wide, 0–{GRID_BOUNDS.y[1]} tall.
+                Arrow keys nudge the selected listing by 0.1 (Shift: 1.0). Map
+                is 0–{GRID_BOUNDS.x[1]} wide, 0–{GRID_BOUNDS.y[1]} tall.
               </p>
               {(selected.x === null || selected.y === null) && (
                 <button

--- a/src/app/admin/map/SidePanel.tsx
+++ b/src/app/admin/map/SidePanel.tsx
@@ -58,7 +58,7 @@ function Badges({ r }: { r: EditorRecord }) {
   return (
     <span className={styles.badges}>
       <span className={r.published ? styles.badgeLive : styles.badgeDraft}>
-        {r.published ? 'Published' : 'Unpublished'}
+        {r.published ? 'Published' : 'Incoming suggestion'}
       </span>
       {r.isMagic && <span className={styles.badgeWarn}>furniture</span>}
       {!r.mapLogo && <span className={styles.badgeWarn}>no map logo</span>}
@@ -283,7 +283,9 @@ export default function SidePanel({
                                   : styles.badgeDraft
                               }
                             >
-                              {r.published ? 'Published' : 'Unpublished'}
+                              {r.published
+                                ? 'Published'
+                                : 'Incoming suggestion'}
                             </span>
                           </span>
                         </span>

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -522,10 +522,6 @@
   text-decoration: underline;
 }
 
-.footnote {
-  margin-top: 4px;
-}
-
 @media (max-width: 991px) {
   .split {
     grid-template-columns: 1fr;

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -28,6 +28,12 @@
   accent-color: var(--bright-teal-300);
 }
 
+/* Heading sits first, then the live-site warning; the page's own 12px gap
+   spaces them (the shared heading margin would double it). */
+.heading {
+  margin-bottom: 0;
+}
+
 .liveWarning {
   border-color: #f5b942;
   color: #f5b942;
@@ -253,6 +259,7 @@
 
 /* Search sits above the tabs and covers every record, placed or not. */
 .searchBar {
+  position: relative;
   padding: 12px;
   border-bottom: 1px solid var(--teal-800);
   flex-shrink: 0;
@@ -261,39 +268,28 @@
 .search {
   width: 100%;
   height: 36px;
+  padding-right: 34px;
 }
 
-/* A search result: the logo + text is one big button (select / jump to it);
-   the trailing cell is the coordinates or a Place button. */
-.rowResult:hover {
-  border-color: var(--teal-600);
-}
-
-.rowSelected {
-  border-color: var(--bright-teal-300);
-}
-
-.resultPick {
-  grid-column: 1 / 3;
-  display: grid;
-  grid-template-columns: 32px minmax(0, 1fr);
-  gap: 10px;
-  align-items: center;
-  padding: 0;
-  background: none;
-  border: none;
-  text-align: left;
+/* "/" focuses the box; the key cap hint hides once you're typing. */
+.searchKey {
+  position: absolute;
+  right: 22px;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 1px 6px;
+  border: 1px solid var(--teal-700);
+  border-radius: 4px;
   font-family: inherit;
-  color: inherit;
-  cursor: pointer;
-}
-
-.rowCoords {
   font-size: 11px;
   line-height: 1.4;
   color: var(--teal-400);
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+}
+
+.search:focus ~ .searchKey,
+.search:not(:placeholder-shown) ~ .searchKey {
+  display: none;
 }
 
 .list {
@@ -324,6 +320,49 @@
 .rowLiveUnplaced {
   border-color: #ff8b8b;
   background-color: rgba(255, 139, 139, 0.06);
+}
+
+/* A search result: the logo + text is one big button (select / jump to it);
+   the trailing cell is the coordinates or a Place button. The keyboard
+   cursor (↑/↓) highlights one row and Enter opens it; hovering only
+   previews, it does not move the cursor. (These come after .row on purpose:
+   same specificity, later wins.) */
+.rowResult:hover {
+  border-color: var(--teal-500);
+}
+
+.rowActive,
+.rowActive:hover {
+  border-color: var(--bright-teal-300);
+  background-color: rgba(166, 218, 217, 0.12);
+}
+
+/* The record currently selected on the map. */
+.rowSelected .rowTitle {
+  color: var(--bright-teal-300);
+}
+
+.resultPick {
+  grid-column: 1 / 3;
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  padding: 0;
+  background: none;
+  border: none;
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.rowCoords {
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--teal-400);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
 .missingNote {

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -63,7 +63,11 @@
   flex-shrink: 0;
 }
 
+/* Map + side panel. --editor-height is set by MapEditor from the space left
+   under the toolbar so the editor ends at the bottom of the window instead
+   of running past it; the fallback only shows before that first measure. */
 .split {
+  --editor-height: calc(100vh - 400px);
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;
   gap: 16px;
@@ -96,8 +100,8 @@
 
 .canvas {
   width: 100%;
-  height: calc(100vh - 260px);
-  min-height: 560px;
+  height: var(--editor-height);
+  min-height: 480px;
   position: relative;
   overflow: hidden;
   border-radius: 8px;
@@ -197,9 +201,8 @@
 .panel {
   display: flex;
   flex-direction: column;
-  min-height: 0;
-  height: calc(100vh - 260px);
-  min-height: 560px;
+  height: var(--editor-height);
+  min-height: 480px;
   background-color: var(--teal-850);
   border: 1px solid var(--teal-800);
   border-radius: 8px;
@@ -248,9 +251,49 @@
   flex-shrink: 0;
 }
 
+/* Search sits above the tabs and covers every record, placed or not. */
+.searchBar {
+  padding: 12px;
+  border-bottom: 1px solid var(--teal-800);
+  flex-shrink: 0;
+}
+
 .search {
   width: 100%;
   height: 36px;
+}
+
+/* A search result: the logo + text is one big button (select / jump to it);
+   the trailing cell is the coordinates or a Place button. */
+.rowResult:hover {
+  border-color: var(--teal-600);
+}
+
+.rowSelected {
+  border-color: var(--bright-teal-300);
+}
+
+.resultPick {
+  grid-column: 1 / 3;
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  padding: 0;
+  background: none;
+  border: none;
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.rowCoords {
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--teal-400);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
 .list {
@@ -285,6 +328,7 @@
 
 .missingNote {
   font-size: 11px;
+  line-height: 1.4;
   color: #ff8b8b;
 }
 
@@ -395,6 +439,20 @@
 .dl dd {
   margin: 0;
   color: var(--white);
+}
+
+/* The Scale dropdown sits in the details grid: compact, aligned with the
+   text rows around it. */
+.dl dt,
+.dl dd {
+  display: flex;
+  align-items: center;
+}
+
+.scaleSelect {
+  height: 26px;
+  padding: 0 6px;
+  font-size: 12px;
 }
 
 .coords {

--- a/src/app/admin/map/map-editor.module.css
+++ b/src/app/admin/map/map-editor.module.css
@@ -14,6 +14,13 @@
   border-radius: 8px;
 }
 
+/* Refresh / Undo / Redo sit at the right-hand end of the toolbar. */
+.toolbarActions {
+  display: inline-flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
 .toggle {
   display: inline-flex;
   align-items: center;

--- a/src/app/api/admin/map/route.ts
+++ b/src/app/api/admin/map/route.ts
@@ -5,6 +5,8 @@
                              published + unpublished, Hide? excluded)
   PATCH /api/admin/map     → body { id, x, y, expected? }
                              writes ONLY x and y on that record
+                          → body { id, scale, expected? }
+                             writes ONLY Scale (Small/Medium/Large)
 
   Owner-password sessions only (canEditMap). Never revalidates any cache or
   path: the public /map keeps refreshing on its own schedule.
@@ -13,14 +15,17 @@
 import { NextRequest } from 'next/server'
 import { canEditMap } from '@/lib/admin/auth'
 import {
-  getMapPosition,
+  getMapState,
   isMapEditorConfigured,
   listMapRecordsLive,
   updateMapPosition,
+  updateMapScale,
 } from '@/lib/admin/map-editor'
 import {
+  isScaleBody,
   samePosition,
   validateMoveBody,
+  validateScaleBody,
   ValidationError,
 } from '@/lib/admin/map-editor-core'
 
@@ -58,6 +63,17 @@ export async function GET() {
   }
 }
 
+/** Airtable read/write problems come back to the editor as a visible error
+ *  (never swallowed); the details go to the server log too. Airtable's rate
+ *  limit (5 req/s per base, then a ~30 s lockout) comes back as 429 so the
+ *  editor can wait and retry rather than give up. */
+function airtableFailure(id: string, what: string, err: unknown): Response {
+  const message = err instanceof Error ? err.message : String(err)
+  console.error(`[map-editor] ${what} failed for ${id}: ${message}`)
+  const rateLimited = /\b429\b/.test(message) && /RATE_LIMIT/.test(message)
+  return json({ error: message }, rateLimited ? 429 : 502)
+}
+
 export async function PATCH(req: NextRequest) {
   const auth = await ensureAuth()
   if (auth) return auth
@@ -69,6 +85,33 @@ export async function PATCH(req: NextRequest) {
     return json({ error: 'body must be JSON' }, 400)
   }
 
+  // ── Scale change ─────────────────────────────────────────────────────────
+  if (isScaleBody(body)) {
+    let change
+    try {
+      change = validateScaleBody(body)
+    } catch (err) {
+      if (err instanceof ValidationError)
+        return json({ error: err.message }, 400)
+      throw err
+    }
+    try {
+      const current = await getMapState(change.id)
+      if (current === null) return json({ error: 'record not found' }, 404)
+      if (change.expected !== undefined && current.scale !== change.expected) {
+        return json({ error: 'stale', current: { scale: current.scale } }, 409)
+      }
+      const stored = await updateMapScale(change.id, change.scale)
+      console.info(
+        `[map-editor] ${change.id}: Scale ${current.scale ?? '(unset)'} → ${stored.scale}`
+      )
+      return json({ record: { id: change.id, ...stored } })
+    } catch (err) {
+      return airtableFailure(change.id, 'scale change', err)
+    }
+  }
+
+  // ── Move ─────────────────────────────────────────────────────────────────
   let move
   try {
     move = validateMoveBody(body)
@@ -78,11 +121,14 @@ export async function PATCH(req: NextRequest) {
   }
 
   try {
-    const current = await getMapPosition(move.id)
+    const current = await getMapState(move.id)
     if (current === null) return json({ error: 'record not found' }, 404)
 
     if (move.expected && !samePosition(current, move.expected)) {
-      return json({ error: 'stale', current }, 409)
+      return json(
+        { error: 'stale', current: { x: current.x, y: current.y } },
+        409
+      )
     }
 
     const stored = await updateMapPosition(move.id, move.x, move.y)
@@ -91,13 +137,6 @@ export async function PATCH(req: NextRequest) {
     )
     return json({ record: { id: move.id, ...stored } })
   } catch (err) {
-    // Airtable read/write problems come back to the editor as a visible
-    // error (never swallowed); the details go to the server log too.
-    const message = err instanceof Error ? err.message : String(err)
-    console.error(`[map-editor] move failed for ${move.id}: ${message}`)
-    // Airtable's rate limit (5 req/s per base, then a ~30 s lockout) comes
-    // back as 429 so the editor can wait and retry rather than give up.
-    const rateLimited = /\b429\b/.test(message) && /RATE_LIMIT/.test(message)
-    return json({ error: message }, rateLimited ? 429 : 502)
+    return airtableFailure(move.id, 'move', err)
   }
 }

--- a/src/lib/admin/map-editor-core.test.ts
+++ b/src/lib/admin/map-editor-core.test.ts
@@ -4,11 +4,15 @@ import { describe, expect, it } from 'vitest'
 import {
   FIELD,
   buildPositionFields,
+  buildScaleFields,
   compareEditorRecords,
+  isScaleBody,
   rowToEditorRecord,
   samePosition,
+  SCALE_OPTIONS,
   sortEditorRecords,
   validateMoveBody,
+  validateScaleBody,
   ValidationError,
   type EditorRecord,
 } from './map-editor-core'
@@ -101,6 +105,76 @@ describe('buildPositionFields', () => {
     expect(Object.keys(fields).sort()).toEqual([FIELD.x, FIELD.y].sort())
     expect(fields[FIELD.x]).toBe(22.2)
     expect(fields[FIELD.y]).toBe(17.2)
+  })
+})
+
+// ─── Scale change bodies ───────────────────────────────────────────────────
+
+describe('isScaleBody', () => {
+  it('tells a Scale change from a move by the scale key', () => {
+    expect(isScaleBody({ id: ID, scale: 'Large' })).toBe(true)
+    expect(isScaleBody({ id: ID, x: 1, y: 2 })).toBe(false)
+    expect(isScaleBody(null)).toBe(false)
+    expect(isScaleBody([])).toBe(false)
+    expect(isScaleBody('scale')).toBe(false)
+  })
+})
+
+describe('validateScaleBody', () => {
+  it('accepts each Scale option, with or without expected', () => {
+    for (const s of SCALE_OPTIONS) {
+      expect(validateScaleBody({ id: ID, scale: s })).toEqual({
+        id: ID,
+        scale: s,
+      })
+    }
+    expect(
+      validateScaleBody({ id: ID, scale: 'Small', expected: 'Large' })
+    ).toEqual({ id: ID, scale: 'Small', expected: 'Large' })
+    expect(
+      validateScaleBody({ id: ID, scale: 'Small', expected: null })
+    ).toEqual({ id: ID, scale: 'Small', expected: null })
+  })
+  it.each([
+    [null, 'body must be a JSON object'],
+    [{ scale: 'Large' }, 'id must be an Airtable record id'],
+    [{ id: 'foo', scale: 'Large' }, 'id must be an Airtable record id'],
+    [{ id: ID, scale: 'Huge' }, 'scale must be one of Small, Medium, Large'],
+    [{ id: ID, scale: 'large' }, 'scale must be one of Small, Medium, Large'],
+    [{ id: ID, scale: null }, 'scale must be one of Small, Medium, Large'],
+    [{ id: ID, scale: '' }, 'scale must be one of Small, Medium, Large'],
+    // A Scale change can never carry a move, a publish flag or raw fields.
+    [{ id: ID, scale: 'Large', x: 1, y: 2 }, 'unexpected key: x'],
+    [{ id: ID, scale: 'Large', publish: true }, 'unexpected key: publish'],
+    [{ id: ID, scale: 'Large', fields: {} }, 'unexpected key: fields'],
+    [
+      { id: ID, scale: 'Large', [FIELD.hide]: true },
+      `unexpected key: ${FIELD.hide}`,
+    ],
+    [{ id: ID, scale: 'Large', typecast: true }, 'unexpected key: typecast'],
+    [
+      { id: ID, scale: 'Large', expected: { scale: 'Small' } },
+      'expected must be a string or null',
+    ],
+    [
+      { id: ID, scale: 'Large', expected: 1 },
+      'expected must be a string or null',
+    ],
+  ])('rejects %j', (body, message) => {
+    expect(() => validateScaleBody(body)).toThrow(ValidationError)
+    expect(() => validateScaleBody(body)).toThrow(message)
+  })
+})
+
+describe('buildScaleFields', () => {
+  it('writes exactly Scale by field id', () => {
+    const fields = buildScaleFields('Large')
+    expect(Object.keys(fields)).toEqual([FIELD.scale])
+    expect(fields[FIELD.scale]).toBe('Large')
+  })
+  it('refuses anything that is not a Scale option', () => {
+    // @ts-expect-error – guarding the runtime path too
+    expect(() => buildScaleFields('Huge')).toThrow(ValidationError)
   })
 })
 

--- a/src/lib/admin/map-editor-core.ts
+++ b/src/lib/admin/map-editor-core.ts
@@ -18,7 +18,8 @@ import { GRID_DECIMALS, inGridBounds, roundGrid } from './map-geometry'
 export const MAP_TABLE_ID = 'tblvzbGL9q9dOO9Nc'
 
 /** Permanent field IDs (same values as src/lib/data/map.ts FIELD). Reads use
- *  returnFieldsByFieldId; the ONLY fields the editor ever writes are x and y. */
+ *  returnFieldsByFieldId; the ONLY fields the editor ever writes are x, y and
+ *  Scale (see buildPositionFields / buildScaleFields). */
 export const FIELD = {
   longName: 'fldqYJa5li27kVOUW', // Long name
   longNameForCards: 'fldPEouzOZbCIZr7p', // Long name for cards
@@ -297,13 +298,87 @@ export function validateMoveBody(body: unknown): MoveRequest {
   return out
 }
 
-/** The ONLY builder of an Airtable write body for the Map table. Exactly two
- *  keys, both by permanent field ID. */
+/** One of the two builders of an Airtable write body for the Map table (the
+ *  other is buildScaleFields). Exactly two keys, both by permanent field ID. */
 export function buildPositionFields(
   x: number,
   y: number
 ): Record<string, number> {
   return { [FIELD.x]: x, [FIELD.y]: y }
+}
+
+// ─── Scale (logo size) request validation ──────────────────────────────────
+
+/** The Scale single-select's options, exactly as named in Airtable. The
+ *  editor can only ever write one of these – never clear the field. */
+export const SCALE_OPTIONS = ['Small', 'Medium', 'Large'] as const
+export type ScaleName = (typeof SCALE_OPTIONS)[number]
+
+export function isScaleName(value: unknown): value is ScaleName {
+  return (
+    typeof value === 'string' &&
+    (SCALE_OPTIONS as readonly string[]).includes(value)
+  )
+}
+
+export interface ScaleRequest {
+  id: string
+  scale: ScaleName
+  /** The Scale the client last saw (null = not set); the server refuses the
+   *  write (409) if Airtable now holds something else. */
+  expected?: string | null
+}
+
+const ALLOWED_SCALE_KEYS = new Set(['id', 'scale', 'expected'])
+
+/** True when a PATCH body is asking for a Scale change rather than a move
+ *  (the two shapes share the endpoint; each is validated by its own
+ *  allow-list, so a body can never mix them). */
+export function isScaleBody(body: unknown): boolean {
+  return (
+    !!body &&
+    typeof body === 'object' &&
+    !Array.isArray(body) &&
+    'scale' in body
+  )
+}
+
+/** Parses and validates a Scale-change body. Rejects anything but
+ *  id/scale/expected and any scale that is not one of SCALE_OPTIONS. */
+export function validateScaleBody(body: unknown): ScaleRequest {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw new ValidationError('body must be a JSON object')
+  }
+  const obj = body as Record<string, unknown>
+  for (const key of Object.keys(obj)) {
+    if (!ALLOWED_SCALE_KEYS.has(key)) {
+      throw new ValidationError(`unexpected key: ${key}`)
+    }
+  }
+  const id = obj.id
+  if (typeof id !== 'string' || !RECORD_ID_RE.test(id)) {
+    throw new ValidationError('id must be an Airtable record id')
+  }
+  if (!isScaleName(obj.scale)) {
+    throw new ValidationError(
+      `scale must be one of ${SCALE_OPTIONS.join(', ')}`
+    )
+  }
+  const out: ScaleRequest = { id, scale: obj.scale }
+  if (obj.expected !== undefined) {
+    if (obj.expected !== null && typeof obj.expected !== 'string') {
+      throw new ValidationError('expected must be a string or null')
+    }
+    out.expected = obj.expected
+  }
+  return out
+}
+
+/** The other write-body builder for the Map table: exactly one key, the
+ *  Scale field by permanent ID, with a validated option name. */
+export function buildScaleFields(scale: ScaleName): Record<string, string> {
+  if (!isScaleName(scale)) throw new ValidationError(`bad scale: ${scale}`)
+  return { [FIELD.scale]: scale }
 }
 
 /** True when two stored positions are the same at Airtable precision. */

--- a/src/lib/admin/map-editor.ts
+++ b/src/lib/admin/map-editor.ts
@@ -2,8 +2,9 @@
   Server-side Airtable I/O for the admin map editor.
 
   Reads the Map table LIVE (cache: 'no-store', no view, unpublished rows
-  included, Hide? rows excluded) and writes exactly two fields (x, y) on one
-  record at a time. It intentionally does not use src/lib/data/airtable.ts:
+  included, Hide? rows excluded) and writes either x+y or Scale (nothing
+  else, ever) on one record at a time. It intentionally does not use
+  src/lib/data/airtable.ts:
   that path is wrapped in unstable_cache (shared with /map, the chatbot
   catalog, search and the public API), filters to published rows, and mirrors
   attachments to Vercel Blob. Nothing here touches that cache or those files.
@@ -15,13 +16,16 @@
 import { airtableRequest, listAll } from './airtable'
 import {
   buildPositionFields,
+  buildScaleFields,
   FIELD,
+  isScaleName,
   MAP_TABLE_ID,
   num,
   READ_FIELDS,
   rowToEditorRecord,
   sortEditorRecords,
   type EditorRecord,
+  type ScaleName,
 } from './map-editor-core'
 
 export function isMapEditorConfigured(): boolean {
@@ -45,12 +49,15 @@ export interface StoredPosition {
   y: number | null
 }
 
-/** Current x/y for one record, or null when the record doesn't exist. Airtable
- *  answers an unknown record id with 404, or with 403 "model not found" when
- *  the id doesn't belong to this table — both mean "not here". */
-export async function getMapPosition(
-  id: string
-): Promise<StoredPosition | null> {
+export interface StoredState extends StoredPosition {
+  /** Scale option name, or null when the field is empty. */
+  scale: string | null
+}
+
+/** Current x/y/Scale for one record, or null when the record doesn't exist.
+ *  Airtable answers an unknown record id with 404, or with 403 "model not
+ *  found" when the id doesn't belong to this table — both mean "not here". */
+export async function getMapState(id: string): Promise<StoredState | null> {
   // The single-record endpoint takes returnFieldsByFieldId but no fields[].
   const res = await airtableRequest(
     `${MAP_TABLE_ID}/${id}?returnFieldsByFieldId=true`
@@ -62,7 +69,37 @@ export async function getMapPosition(
     throw new Error(`Airtable read failed: ${res.status} ${text}`)
   }
   const data = (await res.json()) as { fields: RawFields }
-  return { x: num(data.fields[FIELD.x]), y: num(data.fields[FIELD.y]) }
+  const scale = data.fields[FIELD.scale]
+  return {
+    x: num(data.fields[FIELD.x]),
+    y: num(data.fields[FIELD.y]),
+    scale: typeof scale === 'string' && scale !== '' ? scale : null,
+  }
+}
+
+/** Writes Scale (nothing else) and returns what Airtable stored. */
+export async function updateMapScale(
+  id: string,
+  scale: ScaleName
+): Promise<{ scale: ScaleName }> {
+  const res = await airtableRequest(`${MAP_TABLE_ID}/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      fields: buildScaleFields(scale),
+      returnFieldsByFieldId: true,
+    }),
+  })
+  if (!res.ok) {
+    throw new Error(`Airtable update failed: ${res.status} ${await res.text()}`)
+  }
+  const data = (await res.json()) as { fields: RawFields }
+  const stored = data.fields[FIELD.scale]
+  if (!isScaleName(stored)) {
+    throw new Error(
+      `Airtable update returned no Scale for ${id}: ${JSON.stringify(data.fields)}`
+    )
+  }
+  return { scale: stored }
 }
 
 /** Writes x and y (nothing else) and returns what Airtable stored. */


### PR DESCRIPTION
Follow-ups to the admin map editor (#540) from Bryce's first day of use. All under `src/app/admin/map`, `src/app/api/admin/map` and `src/lib/admin` – zero diff under the public /map code, `src/lib/data` or `src/components`.

- **Search + jump-to-listing** – a search box above the panel tabs covers placed and unplaced records (name, short name, tooltip name, category; prefix matches first). Picking a result selects it, opens the Selected tab and pans/zooms the canvas to it (`focusOn`, centred on the visible canvas at ≥2×). `/` focuses the box, ↑/↓ move a highlighted cursor, Enter opens it, Esc clears; unplaced results keep a Place button. Replaces the tray-only "Search unplaced…" filter.
- **Scale (listing size) editing** – Small/Medium/Large dropdown in the Selected tab. The save queue is generalised to `Change = position | scale` (a move and a Scale change of one record can both be queued; same 400 ms settle, 429 handling, 409 stale check, error banner, Undo/Redo). `PATCH /api/admin/map` dispatches on body shape: `{id, scale, expected?}` → its own allow-list (`validateScaleBody`, scale ∈ `SCALE_OPTIONS`) → `getMapState` → `updateMapScale`. Still never Publish?/Hide?.
- **Fit to window** – the map + panel are sized from the space under the toolbar (measured, min 480px) instead of `calc(100vh − 260px)`, so nothing runs past the bottom.
- **Undo reliability** – Cmd+Z / Shift+Cmd+Z / Cmd+Y work with focus in any field; the search box blurs after a pick; an undo/redo pressed mid-save runs automatically once the save lands (cleared on 409/failure) instead of being dropped.
- **UI** – magenta selection ring; heading above the live-site warning ("Use with caution."); Refresh/Undo/Redo on the right; "Incoming suggestion" instead of "Unpublished"; "listing" wording; published-but-unplaced rows sort first in the tray; tray note line-height fix; footnote folded into the heading line.
- **Build** – `npm run build` now runs `vitest run` first, so the /map drift test and the write-body validators fail a deploy instead of shipping.

Verified locally with headless Playwright against Airtable (test record Algoverse placed/scaled/undone and restored to unplaced): search/jump/keyboard, Scale Small→Large→undo, nudge + Scale change queued together, Cmd+Z mid-save and from inside the search box, viewport fit at 900/1100px, 70 vitest tests, clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
