### PR TITLE
Preview mode: see Airtable edits on the real pages instantly

### DIFF
--- a/src/app/admin/chatbot/layout.tsx
+++ b/src/app/admin/chatbot/layout.tsx
@@ -1,5 +1,10 @@
 import { redirect } from 'next/navigation'
-import { canEditMap, canViewAnalytics, canViewChatbot } from '@/lib/admin/auth'
+import {
+  canEditMap,
+  canUsePreview,
+  canViewAnalytics,
+  canViewChatbot,
+} from '@/lib/admin/auth'
 import AdminHeader from '../AdminHeader'
 import { adminTabs, adminHomeHref } from '../nav'
 import styles from '../admin.module.css'
@@ -17,7 +22,12 @@ export default async function ChatbotAdminLayout({
   }
   // Chatbot access is guaranteed here; adminTabs() still hides the Analytics tab
   // from sessions that can't reach it (e.g. Successif).
-  const access = { chatbot: true, analytics, mapEditor: await canEditMap() }
+  const access = {
+    chatbot: true,
+    analytics,
+    mapEditor: await canEditMap(),
+    preview: await canUsePreview(),
+  }
   return (
     <>
       <AdminHeader tabs={adminTabs(access)} brandHref={adminHomeHref(access)} />

--- a/src/app/admin/map/layout.tsx
+++ b/src/app/admin/map/layout.tsx
@@ -1,5 +1,10 @@
 import { redirect } from 'next/navigation'
-import { canEditMap, canViewAnalytics, canViewChatbot } from '@/lib/admin/auth'
+import {
+  canEditMap,
+  canUsePreview,
+  canViewAnalytics,
+  canViewChatbot,
+} from '@/lib/admin/auth'
 import AdminHeader from '../AdminHeader'
 import { adminTabs, adminHomeHref } from '../nav'
 import styles from '../admin.module.css'
@@ -19,9 +24,21 @@ export default async function MapEditorLayout({
   // Only the owner password may move logos on the live map. Anyone else who
   // is signed in goes to the area they can use; signed-out sessions to login.
   if (!(await canEditMap())) {
-    redirect(adminHomeHref({ chatbot, analytics, mapEditor: false }))
+    redirect(
+      adminHomeHref({
+        chatbot,
+        analytics,
+        mapEditor: false,
+        preview: await canUsePreview(),
+      })
+    )
   }
-  const access = { chatbot, analytics, mapEditor: true }
+  const access = {
+    chatbot,
+    analytics,
+    mapEditor: true,
+    preview: await canUsePreview(),
+  }
   return (
     <>
       <AdminHeader tabs={adminTabs(access)} brandHref={adminHomeHref(access)} />

--- a/src/app/admin/nav.ts
+++ b/src/app/admin/nav.ts
@@ -6,7 +6,7 @@ export interface AdminNavTab {
   label: string
   /** Tabs are grouped in the header; a divider is drawn where the group changes
    *  (so the two chatbot tabs read as a pair, separate from Analytics). */
-  group: 'chatbot' | 'analytics' | 'map'
+  group: 'chatbot' | 'analytics' | 'map' | 'preview'
 }
 
 export interface AdminAccess {
@@ -16,6 +16,8 @@ export interface AdminAccess {
   analytics: boolean
   /** Session may reach /admin/map (owner password only). */
   mapEditor: boolean
+  /** Session may reach /admin/preview (every listing-editing role). */
+  preview: boolean
 }
 
 /** Tabs shown in the admin header, limited to the areas this session can
@@ -25,6 +27,7 @@ export function adminTabs({
   chatbot,
   analytics,
   mapEditor,
+  preview,
 }: AdminAccess): AdminNavTab[] {
   return [
     ...(chatbot
@@ -59,6 +62,15 @@ export function adminTabs({
           },
         ]
       : []),
+    ...(preview
+      ? [
+          {
+            href: '/admin/preview',
+            label: 'Site preview',
+            group: 'preview' as const,
+          },
+        ]
+      : []),
   ]
 }
 
@@ -69,9 +81,11 @@ export function adminHomeHref({
   chatbot,
   analytics,
   mapEditor,
+  preview,
 }: AdminAccess): string {
   if (chatbot) return '/admin/chatbot/playground'
   if (analytics) return '/admin/analytics'
   if (mapEditor) return '/admin/map'
+  if (preview) return '/admin/preview'
   return '/admin/login'
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,10 @@
 import { redirect } from 'next/navigation'
-import { canEditMap, canViewAnalytics, canViewChatbot } from '@/lib/admin/auth'
+import {
+  canEditMap,
+  canUsePreview,
+  canViewAnalytics,
+  canViewChatbot,
+} from '@/lib/admin/auth'
 import { adminHomeHref } from './nav'
 
 // /admin is an index that bounces to the right place: the first area this
@@ -10,6 +15,7 @@ export default async function AdminIndexPage() {
       chatbot: await canViewChatbot(),
       analytics: await canViewAnalytics(),
       mapEditor: await canEditMap(),
+      preview: await canUsePreview(),
     })
   )
 }

--- a/src/app/admin/preview/PreviewToggle.tsx
+++ b/src/app/admin/preview/PreviewToggle.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState, useTransition } from 'react'
+import styles from './preview.module.css'
+
+/** Master switch: shows or hides the floating switch buttons on this
+ *  browser. Mode changes themselves happen through those buttons. */
+export default function PreviewToggle({ pillsShown }: { pillsShown: boolean }) {
+  const router = useRouter()
+  const [busy, setBusy] = useState(false)
+  const [refreshing, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  async function toggle() {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/admin/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pills: !pillsShown }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      // In-place server re-render with the new cookie state — a full reload
+      // flashes the admin page white.
+      setBusy(false)
+      startTransition(() => router.refresh())
+    } catch (err) {
+      setBusy(false)
+      setError(`Could not switch (${err}). Please try again.`)
+    }
+  }
+
+  return (
+    <span className={styles.toggleWrap}>
+      {error && <span className={styles.toggleError}>{error}</span>}
+      <button
+        type="button"
+        className={pillsShown ? styles.buttonOff : styles.buttonOn}
+        onClick={toggle}
+        disabled={busy || refreshing}
+      >
+        {busy || refreshing
+          ? 'Switching…'
+          : pillsShown
+            ? 'Hide the switch buttons'
+            : 'Show the switch buttons'}
+      </button>
+    </span>
+  )
+}

--- a/src/app/admin/preview/layout.tsx
+++ b/src/app/admin/preview/layout.tsx
@@ -10,28 +10,34 @@ import { adminTabs, adminHomeHref } from '../nav'
 import styles from '../admin.module.css'
 
 export const metadata = {
-  title: 'Analytics – AISafety.com',
+  title: 'Site preview – AISafety.com',
   robots: { index: false, follow: false },
 }
 
-export default async function AnalyticsLayout({
+export default async function PreviewAdminLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
   const chatbot = await canViewChatbot()
-  // A signed-in partner holding the Successif password is sent to the chat area
-  // they're allowed to use; everyone else to the login page.
-  if (!(await canViewAnalytics())) {
-    redirect(chatbot ? '/admin/chatbot/playground' : '/admin/login')
+  const analytics = await canViewAnalytics()
+  // Listing-editing roles only (owner, volunteers, Melissa). Anyone else who
+  // is signed in goes to the area they can use; signed-out sessions to login.
+  if (!(await canUsePreview())) {
+    redirect(
+      adminHomeHref({
+        chatbot,
+        analytics,
+        mapEditor: await canEditMap(),
+        preview: false,
+      })
+    )
   }
-  // Analytics access is guaranteed here, so the Analytics tab is always present;
-  // the chatbot tabs drop out for an analytics-only session.
   const access = {
     chatbot,
-    analytics: true,
+    analytics,
     mapEditor: await canEditMap(),
-    preview: await canUsePreview(),
+    preview: true,
   }
   return (
     <>

--- a/src/app/admin/preview/page.tsx
+++ b/src/app/admin/preview/page.tsx
@@ -1,0 +1,87 @@
+import { previewPillsShown } from '@/lib/admin/auth'
+import { isPreviewRequest } from '@/lib/preview'
+import { formatTimeAgo } from '@/lib/format-date'
+import adminStyles from '../admin.module.css'
+import styles from './preview.module.css'
+import PreviewToggle from './PreviewToggle'
+
+// Never prerendered: the page shows this session's own switch-pill and
+// preview state, which lives in cookies.
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// Every page whose content comes from Airtable. /donation-guide is left out —
+// its content lives in the code, so there is nothing to preview.
+const PAGES: Array<{ href: string; label: string }> = [
+  { href: '/', label: 'Home' },
+  { href: '/events', label: 'Events' },
+  { href: '/training', label: 'Training' },
+  { href: '/map', label: 'Field map' },
+  { href: '/communities', label: 'Communities' },
+  { href: '/self-study', label: 'Self-study' },
+  { href: '/jobs', label: 'Jobs' },
+  { href: '/funding', label: 'Funding' },
+  { href: '/media-channels', label: 'Media channels' },
+  { href: '/advisors', label: 'Advisors' },
+  { href: '/projects', label: 'Volunteer projects' },
+  { href: '/founders', label: 'Founder toolkit' },
+]
+
+export default async function PreviewAdminPage() {
+  const pillsShown = await previewPillsShown()
+  const previewOn = await isPreviewRequest()
+  const buildTime = process.env.BUILD_TIME
+  const rebuilt = buildTime ? formatTimeAgo(buildTime, new Date()) : null
+
+  return (
+    <div className={adminStyles.editorColumn}>
+      <div className={adminStyles.pageHeading}>
+        <h1 className={adminStyles.pageTitle}>Site preview</h1>
+        {rebuilt && (
+          <p className={adminStyles.pageMeta}>
+            Public version built{' '}
+            <span className={adminStyles.pageMetaValue}>{rebuilt}</span>
+          </p>
+        )}
+      </div>
+
+      <div className={adminStyles.editorBlock}>
+        <div className={adminStyles.editorBlockHeader}>
+          <h2 className={adminStyles.editorBlockTitle}>
+            Switch buttons are{' '}
+            <span className={pillsShown ? styles.stateOn : styles.stateOff}>
+              {pillsShown ? 'SHOWN' : 'HIDDEN'}
+            </span>
+            {previewOn && (
+              <span className={styles.previewNote}> · preview mode is on</span>
+            )}
+          </h2>
+          <PreviewToggle pillsShown={pillsShown} />
+        </div>
+        <p className={adminStyles.sectionHint}>
+          The switch buttons sit at the bottom middle of every page, for your
+          browser only. &ldquo;Switch to preview&rdquo; shows the real pages
+          rendered from live Airtable data — open pages notice an edit within a
+          few seconds and update themselves, no reload needed. The pink preview
+          button switches you back, and always stays visible while preview mode
+          is on, even with the switch buttons hidden here. Visitors see none of
+          this: they keep the fast prebuilt pages, which catch up on their own a
+          couple of minutes after each edit.
+        </p>
+      </div>
+
+      <div className={adminStyles.editorBlock}>
+        <div className={adminStyles.editorBlockHeader}>
+          <h2 className={adminStyles.editorBlockTitle}>Resource pages</h2>
+        </div>
+        <div className={styles.pageLinks}>
+          {PAGES.map(page => (
+            <a key={page.href} href={page.href} className={styles.pageLink}>
+              {page.label}
+            </a>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/preview/preview.module.css
+++ b/src/app/admin/preview/preview.module.css
@@ -1,0 +1,78 @@
+.stateOn {
+  color: #ff2d95;
+}
+
+.stateOff {
+  color: var(--teal-400);
+}
+
+.previewNote {
+  color: #ff2d95;
+  font-weight: 400;
+}
+
+.toggleWrap {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.toggleError {
+  font-size: 12px;
+  color: #ff6b6b;
+}
+
+.buttonOn,
+.buttonOff {
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.buttonOn {
+  border: 1px solid #ff2d95;
+  background: rgba(255, 45, 149, 0.12);
+  color: #fff;
+}
+
+.buttonOn:hover:not(:disabled) {
+  background: rgba(255, 45, 149, 0.25);
+}
+
+.buttonOff {
+  border: 1px solid var(--teal-700);
+  background: var(--teal-900);
+  color: #fff;
+}
+
+.buttonOff:hover:not(:disabled) {
+  background: var(--teal-800);
+}
+
+.buttonOn:disabled,
+.buttonOff:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.pageLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pageLink {
+  padding: 6px 12px;
+  border: 1px solid var(--teal-800);
+  border-radius: 999px;
+  background: var(--teal-900);
+  font-size: 13px;
+  color: #fff;
+  text-decoration: none;
+}
+
+.pageLink:hover {
+  border-color: var(--teal-600);
+}

--- a/src/app/api/admin/preview/changed/route.ts
+++ b/src/app/api/admin/preview/changed/route.ts
@@ -1,0 +1,69 @@
+/*
+  Change check for preview mode's auto-refresh.
+
+  GET /api/admin/preview/changed?path=/funding&since=<ISO date>
+    → { changed: boolean, now: <server time, ISO> }
+
+  Asks Airtable whether any record feeding that page was modified after
+  `since`, via LAST_MODIFIED_TIME() — the same mechanism /api/check-rebuild
+  uses to trigger deploys, so preview refreshes exactly when the pipeline
+  would. The preview banner polls this a few times a minute and calls
+  router.refresh() on changed:true; it passes the `now` from each response as
+  the next `since`, so clock skew can't open a gap. Without `since` (the
+  first poll) or for a page with no Airtable content, it reports no change —
+  the caller just takes the baseline.
+*/
+
+import { NextRequest } from 'next/server'
+import { canUsePreview } from '@/lib/admin/auth'
+import { hasChangesSince } from '@/lib/data/changed-since'
+import { resourceTables, validResources } from '@/lib/data/last-updated'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+export async function GET(request: NextRequest) {
+  if (!(await canUsePreview())) return json({ error: 'unauthorized' }, 401)
+
+  // Taken before the Airtable queries: an edit landing while they run falls
+  // after this stamp, so the next poll still reports it.
+  const now = new Date().toISOString()
+
+  const path = request.nextUrl.searchParams.get('path') ?? ''
+  const resource = path.replace(/^\//, '')
+  if (!validResources.includes(resource)) return json({ changed: false, now })
+
+  const sinceParam = request.nextUrl.searchParams.get('since')
+  if (!sinceParam) return json({ changed: false, now })
+  const since = new Date(sinceParam)
+  if (isNaN(since.getTime())) {
+    return json({ error: 'since must be an ISO date' }, 400)
+  }
+
+  const token = process.env.AIRTABLE_TOKEN
+  const baseId = process.env.AIRTABLE_BASE_ID
+  // Contributor mode: no credentials, no live data to poll.
+  if (!token || !baseId) return json({ changed: false, now })
+
+  // Sequential on purpose — same rate-limit care as everywhere else.
+  let changed = false
+  for (const table of resourceTables(resource)) {
+    if (
+      await hasChangesSince(baseId, token, table.tableId, since, table.filter)
+    ) {
+      changed = true
+      break
+    }
+  }
+  return json({ changed, now })
+}

--- a/src/app/api/admin/preview/route.ts
+++ b/src/app/api/admin/preview/route.ts
@@ -1,0 +1,72 @@
+/*
+  Preview mode toggle.
+
+  POST /api/admin/preview  → body { enabled: boolean }
+                             sets or clears the Draft Mode cookie on THIS
+                             browser only, then returns { enabled }
+                           → body { pills: boolean }
+                             shows or hides the floating switch pills on THIS
+                             browser (the /admin/preview master switch), then
+                             returns { pills }
+
+  Turning preview on (and showing the pills) requires a listing-editing
+  password (canUsePreview) — with the draft cookie set, every page this
+  browser loads is rendered on demand from live Airtable data. Turning
+  either off is deliberately unauthenticated: it only clears the caller's
+  own cookie, and a session whose admin login has expired must still be able
+  to leave preview mode.
+*/
+
+import { NextRequest } from 'next/server'
+import { draftMode } from 'next/headers'
+import { canUsePreview, setPreviewPillsCookie } from '@/lib/admin/auth'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return json({ error: 'body must be JSON' }, 400)
+  }
+  const { enabled, pills } = (body ?? {}) as {
+    enabled?: unknown
+    pills?: unknown
+  }
+
+  if (typeof pills === 'boolean') {
+    if (pills && !(await canUsePreview())) {
+      return json({ error: 'unauthorized' }, 401)
+    }
+    await setPreviewPillsCookie(pills)
+    return json({ pills })
+  }
+
+  if (typeof enabled !== 'boolean') {
+    return json(
+      { error: 'body must be { enabled: boolean } or { pills: boolean }' },
+      400
+    )
+  }
+
+  const dm = await draftMode()
+  if (enabled) {
+    if (!(await canUsePreview())) return json({ error: 'unauthorized' }, 401)
+    dm.enable()
+  } else {
+    dm.disable()
+  }
+  return json({ enabled })
+}

--- a/src/app/api/check-rebuild/route.ts
+++ b/src/app/api/check-rebuild/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { revalidateTag } from 'next/cache'
-import { fetchAirtableWithRetry } from '@/lib/data/airtable'
+import { hasChangesSince } from '@/lib/data/changed-since'
 
 // Force dynamic - this endpoint must run fresh on every cron invocation
 export const dynamic = 'force-dynamic'
@@ -78,40 +78,6 @@ let lastRateLimitedAt = 0
 const POST_TRIGGER_COOLDOWN_MS = 10 * 60 * 1000
 // After a 429, back off entirely so we stop adding to Vercel's rate-limit count.
 const RATE_LIMIT_COOLDOWN_MS = 15 * 60 * 1000
-
-// Uses LAST_MODIFIED_TIME() (a formula function) rather than any table's
-// "Last modified" field. The field may be configured as date-only, which
-// collapses intra-day edits to midnight UTC and hides same-day changes from
-// a later-that-day build. LAST_MODIFIED_TIME() always returns a full
-// timestamp regardless of how the field is displayed.
-async function hasChangesSince(
-  baseId: string,
-  token: string,
-  tableId: string,
-  since: Date,
-  filter?: string
-): Promise<boolean> {
-  const sinceIso = since.toISOString()
-  const timeCheck = `IS_AFTER(LAST_MODIFIED_TIME(), DATETIME_PARSE("${sinceIso}"))`
-  const formula = filter ? `AND(${filter}, ${timeCheck})` : timeCheck
-
-  const url = new URL(`https://api.airtable.com/v0/${baseId}/${tableId}`)
-  url.searchParams.set('filterByFormula', formula)
-  url.searchParams.set('maxRecords', '1')
-
-  const response = await fetchAirtableWithRetry(url.toString(), token, {
-    cache: 'no-store',
-  })
-
-  if (!response.ok) {
-    throw new Error(
-      `Airtable fetch failed for ${tableId}: ${response.status} ${response.statusText}`
-    )
-  }
-
-  const data = await response.json()
-  return (data.records?.length ?? 0) > 0
-}
 
 export async function GET(request: Request) {
   // Vercel cron jobs include this auth header automatically

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Suspense } from 'react'
 import './globals.css'
 import LayoutShell from '@/components/LayoutShell'
 import MatomoRouteTracker from '@/components/MatomoRouteTracker'
+import PreviewBanner from '@/components/PreviewBanner'
 import { fetchAllCounts } from '@/lib/data/counts'
 
 const inter = Inter({
@@ -83,6 +84,7 @@ export default async function RootLayout({
           <MatomoRouteTracker />
         </Suspense>
         <LayoutShell counts={counts}>{children}</LayoutShell>
+        <PreviewBanner />
       </body>
     </html>
   )

--- a/src/components/EnterPreviewButton.tsx
+++ b/src/components/EnterPreviewButton.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+import { useEffect, useState, useTransition } from 'react'
+import styles from './PreviewBanner.module.css'
+
+/** Small "Switch to preview" pill on the public pages, so an editor can jump
+ *  into preview mode from wherever they are instead of via /admin/preview.
+ *  Server-side it always renders nothing (public pages stay byte-identical);
+ *  after mounting it shows itself only when the switch pills are turned on
+ *  at /admin/preview, which sets the JS-readable cookie
+ *  aisafety_preview_pills (see setPreviewPillsCookie in
+ *  src/lib/admin/auth.ts). The cookie is cosmetic: enabling still goes
+ *  through the server-side capability check. Hidden on /admin, which has the
+ *  master switch. */
+export default function EnterPreviewButton() {
+  const pathname = usePathname()
+  const router = useRouter()
+  const [visible, setVisible] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [refreshing, startTransition] = useTransition()
+
+  useEffect(() => {
+    setVisible(document.cookie.split('; ').includes('aisafety_preview_pills=1'))
+  }, [])
+
+  if (!visible || pathname.startsWith('/admin')) return null
+
+  async function enterPreview() {
+    setBusy(true)
+    try {
+      const res = await fetch('/api/admin/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: true }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      // In-place server re-render — a full reload here makes the page
+      // flash white while switching.
+      setBusy(false)
+      startTransition(() => router.refresh())
+    } catch {
+      setBusy(false)
+      alert(
+        'Could not switch to preview mode — your admin sign-in may have expired.'
+      )
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={styles.enter}
+      onClick={enterPreview}
+      disabled={busy || refreshing}
+      title="See this page with live Airtable data (only affects your browser)"
+    >
+      {busy || refreshing ? 'Switching…' : 'Switch to preview'}
+    </button>
+  )
+}

--- a/src/components/ExitPreviewButton.tsx
+++ b/src/components/ExitPreviewButton.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+import { useState, useTransition } from 'react'
+import styles from './PreviewBanner.module.css'
+
+/** The preview-side switch pill: shows that this browser is in preview mode
+ *  and, when clicked, returns it to the public view. Hidden in the admin —
+ *  /admin/preview reports the mode itself, and the other admin screens
+ *  aren't part of the site being previewed. */
+export default function ExitPreviewButton({
+  rebuilt,
+}: {
+  rebuilt: string | null
+}) {
+  const pathname = usePathname()
+  const router = useRouter()
+  const [busy, setBusy] = useState(false)
+  const [refreshing, startTransition] = useTransition()
+
+  if (pathname.startsWith('/admin')) return null
+
+  async function exitPreview() {
+    setBusy(true)
+    try {
+      const res = await fetch('/api/admin/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      // In-place server re-render — a full reload here makes the page
+      // flash white while switching.
+      setBusy(false)
+      startTransition(() => router.refresh())
+    } catch {
+      setBusy(false)
+      alert('Could not exit preview mode — please try again.')
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={styles.exit}
+      onClick={exitPreview}
+      disabled={busy || refreshing}
+      title="This browser sees live Airtable data — click to switch back to the public view"
+    >
+      <span className={styles.dot} aria-hidden />
+      {busy || refreshing ? (
+        'Switching…'
+      ) : (
+        <>
+          Preview
+          {rebuilt && (
+            <span className={styles.buildNote}> · public built {rebuilt}</span>
+          )}
+        </>
+      )}
+    </button>
+  )
+}

--- a/src/components/PreviewAutoRefresh.tsx
+++ b/src/components/PreviewAutoRefresh.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+import { useEffect, useRef } from 'react'
+
+const POLL_MS = 5_000
+
+/** While preview mode is on, keeps the page current without manual reloads:
+ *  asks /api/admin/preview/changed a few times a minute whether this page's
+ *  Airtable records moved, and re-renders when they did; also re-renders on
+ *  window focus, catching anything the poll can't see (e.g. deleted
+ *  records). router.refresh() re-runs the server render in place, so scroll
+ *  position and client state (filters, search) survive. Renders nothing. */
+export default function PreviewAutoRefresh() {
+  const router = useRouter()
+  const pathname = usePathname()
+  // Server time of the last poll; null = baseline not yet established.
+  const sinceRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    // Admin screens aren't part of the site being previewed (and are always
+    // rendered fresh) — nothing to poll or refresh there.
+    if (pathname.startsWith('/admin')) return
+
+    sinceRef.current = null
+    let stopped = false
+
+    const tick = async () => {
+      // Don't poll (or pile up refreshes) while the tab isn't being looked at;
+      // the focus listener below catches up the moment it is again.
+      if (document.visibilityState !== 'visible') return
+      try {
+        const since = sinceRef.current
+        const query = `path=${encodeURIComponent(pathname)}${since ? `&since=${encodeURIComponent(since)}` : ''}`
+        const res = await fetch(`/api/admin/preview/changed?${query}`, {
+          cache: 'no-store',
+        })
+        if (!res.ok || stopped) return
+        const data = (await res.json()) as { changed: boolean; now: string }
+        if (stopped) return
+        sinceRef.current = data.now
+        if (data.changed) router.refresh()
+      } catch (err) {
+        // Transient network failure — the next poll will try again.
+        console.warn('preview auto-refresh poll failed:', err)
+      }
+    }
+
+    const interval = setInterval(tick, POLL_MS)
+    tick()
+
+    const onFocus = () => router.refresh()
+    window.addEventListener('focus', onFocus)
+    return () => {
+      stopped = true
+      clearInterval(interval)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [pathname, router])
+
+  return null
+}

--- a/src/components/PreviewBanner.module.css
+++ b/src/components/PreviewBanner.module.css
@@ -1,0 +1,66 @@
+/* The floating switch pills, fixed bottom middle so they overlay the page
+   without shifting any layout (fidelity with the public pages is the whole
+   point of preview mode), clear of the scroll-to-top arrow (bottom-left) and
+   the chatbot (bottom-right). Both states are one compact button. */
+.pill {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2147483000;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: calc(100vw - 32px);
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(8, 27, 38, 0.85);
+  font-size: 13px;
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.pill:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* Preview side: pink accents mark the mode; click returns to public. */
+.exit {
+  composes: pill;
+  border: 1px solid rgba(255, 45, 149, 0.6);
+  color: #fff;
+}
+
+.exit:hover:not(:disabled) {
+  /* Pink tint layered over the dark base — replacing the base color here
+     would make the pill see-through on hover. */
+  background:
+    linear-gradient(rgba(255, 45, 149, 0.15), rgba(255, 45, 149, 0.15)),
+    rgba(8, 27, 38, 0.85);
+}
+
+.buildNote {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #ff2d95;
+}
+
+/* Public side: quiet — it sits on the real site all day for signed-in
+   editors, so it must not compete with page content. */
+.enter {
+  composes: pill;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.enter:hover:not(:disabled) {
+  border-color: rgba(255, 45, 149, 0.6);
+  color: #fff;
+}

--- a/src/components/PreviewBanner.tsx
+++ b/src/components/PreviewBanner.tsx
@@ -1,0 +1,29 @@
+import { isPreviewRequest } from '@/lib/preview'
+import { formatTimeAgo } from '@/lib/format-date'
+import EnterPreviewButton from './EnterPreviewButton'
+import ExitPreviewButton from './ExitPreviewButton'
+import PreviewAutoRefresh from './PreviewAutoRefresh'
+
+/** The floating switch pill, bottom middle of every page. In preview mode it
+ *  always shows (a browser must never be in preview without knowing it, or
+ *  without a way out): "Preview · public built X ago" — click to return to
+ *  the public view. Outside preview it renders the self-hiding "Switch to
+ *  preview" pill, visible only when the switch pills are turned on at
+ *  /admin/preview — and never anything in the static HTML normal visitors
+ *  get. */
+export default async function PreviewBanner() {
+  if (!(await isPreviewRequest())) return <EnterPreviewButton />
+
+  // BUILD_TIME (next.config.ts) is when the running deployment was built =
+  // the newest data a normal visitor can be seeing. A large age here while
+  // edits are pending means the rebuild pipeline is stalled.
+  const buildTime = process.env.BUILD_TIME
+  const rebuilt = buildTime ? formatTimeAgo(buildTime, new Date()) : null
+
+  return (
+    <>
+      <ExitPreviewButton rebuilt={rebuilt} />
+      <PreviewAutoRefresh />
+    </>
+  )
+}

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -2,6 +2,13 @@ import { createHash } from 'node:crypto'
 import { cookies } from 'next/headers'
 
 const COOKIE_NAME = 'aisafety_admin'
+// Not a credential: a JS-readable "1" telling the floating "Switch to
+// preview" pill on the public pages to show itself. Set and cleared by the
+// master switch on /admin/preview (owner and listing editors only). The real
+// gate stays server-side (canUsePreview); forging this cookie only reveals a
+// button whose request would then be rejected. Name is mirrored in
+// EnterPreviewButton.tsx, which reads document.cookie.
+const PREVIEW_PILLS_COOKIE = 'aisafety_preview_pills'
 // 30 days. Re-auth when expired.
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 30
 
@@ -15,6 +22,10 @@ interface PasswordRole {
   /** May open the map editor and move logos on the Field map (writes x/y to
    *  Airtable). Owner only for now. */
   mapEditor: boolean
+  /** May turn on preview mode: the session's own browser sees live Airtable
+   *  data on the real pages instead of the cached build. Reads only, and only
+   *  published records. */
+  preview: boolean
 }
 
 /** Every password that grants admin access, and the areas each one opens. Each
@@ -23,13 +34,20 @@ interface PasswordRole {
  *  immediately, while the others are untouched. */
 const PASSWORD_ROLES: PasswordRole[] = [
   // Primary owner password: the whole admin.
-  { env: 'ADMIN_PASSWORD', chatbot: true, analytics: true, mapEditor: true },
+  {
+    env: 'ADMIN_PASSWORD',
+    chatbot: true,
+    analytics: true,
+    mapEditor: true,
+    preview: true,
+  },
   // Partner reviewing chat logs: chat areas only, no analytics.
   {
     env: 'ADMIN_PASSWORD_SUCCESSIF',
     chatbot: true,
     analytics: false,
     mapEditor: false,
+    preview: false,
   },
   // Site volunteers: the whole admin except the map editor (it writes to the
   // live Airtable base).
@@ -38,6 +56,7 @@ const PASSWORD_ROLES: PasswordRole[] = [
     chatbot: true,
     analytics: true,
     mapEditor: false,
+    preview: true,
   },
   // Analytics-only volunteers: the dashboard, with the chat areas out of reach.
   {
@@ -45,6 +64,7 @@ const PASSWORD_ROLES: PasswordRole[] = [
     chatbot: false,
     analytics: true,
     mapEditor: false,
+    preview: false,
   },
   // Melissa (site designer): the whole admin except the map editor, on her
   // own password so it can be revoked without touching the volunteers'.
@@ -53,6 +73,7 @@ const PASSWORD_ROLES: PasswordRole[] = [
     chatbot: true,
     analytics: true,
     mapEditor: false,
+    preview: true,
   },
 ]
 
@@ -112,9 +133,22 @@ export async function canEditMap(): Promise<boolean> {
   return sessionHolds(passwordsWhere(role => role.mapEditor))
 }
 
+/** True when the session may turn preview mode on: fresh Airtable data on the
+ *  real pages, for this session's browser only. It writes nothing and shows
+ *  only published records, so every listing-editing role has it; the
+ *  Successif and analytics-only passwords are deliberately excluded — those
+ *  sessions don't work on listings. */
+export async function canUsePreview(): Promise<boolean> {
+  return sessionHolds(passwordsWhere(role => role.preview))
+}
+
 export async function setAdminCookie(password: string): Promise<void> {
   // Only mint a cookie for a password we actually accept.
-  if (!validPasswords().includes(password)) return
+  const role = PASSWORD_ROLES.find(r => {
+    const p = process.env[r.env]
+    return typeof p === 'string' && p.length > 0 && p === password
+  })
+  if (!role) return
   const c = await cookies()
   c.set({
     name: COOKIE_NAME,
@@ -125,11 +159,43 @@ export async function setAdminCookie(password: string): Promise<void> {
     path: '/',
     maxAge: COOKIE_MAX_AGE,
   })
+  // Signing in with a non-preview password on a browser that had the switch
+  // pills shown (e.g. owner signed out, partner signed in) must hide them.
+  if (!role.preview) {
+    c.delete(PREVIEW_PILLS_COOKIE)
+  }
+}
+
+/** Show or hide the floating switch pills on this browser — the master
+ *  switch on /admin/preview. Showing them is capability-gated by the caller
+ *  (the route 401s first); hiding is always allowed. */
+export async function setPreviewPillsCookie(visible: boolean): Promise<void> {
+  const c = await cookies()
+  if (visible) {
+    c.set({
+      name: PREVIEW_PILLS_COOKIE,
+      value: '1',
+      httpOnly: false,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      maxAge: COOKIE_MAX_AGE,
+    })
+  } else {
+    c.delete(PREVIEW_PILLS_COOKIE)
+  }
+}
+
+/** Whether this browser has the floating switch pills turned on. */
+export async function previewPillsShown(): Promise<boolean> {
+  const c = await cookies()
+  return c.get(PREVIEW_PILLS_COOKIE)?.value === '1'
 }
 
 export async function clearAdminCookie(): Promise<void> {
   const c = await cookies()
   c.delete(COOKIE_NAME)
+  c.delete(PREVIEW_PILLS_COOKIE)
 }
 
 export function checkAdminPassword(password: unknown): boolean {

--- a/src/lib/data/airtable.ts
+++ b/src/lib/data/airtable.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import { list, put } from '@vercel/blob'
 import { unstable_cache } from 'next/cache'
+import { isPreviewRequest } from '@/lib/preview'
 
 export interface AirtableRawRecord {
   id: string
@@ -460,7 +461,7 @@ async function fetchAirtableRecordsImpl(
 // version segment to force a fresh fetch on deploy after an Airtable schema
 // change (e.g. the self-study Category/Type -> Focus/Format rename), so cached
 // records under the old field shape can't be served to new code.
-export const fetchAirtableRecords = unstable_cache(
+const fetchAirtableRecordsCached = unstable_cache(
   fetchAirtableRecordsImpl,
   // v3: attachment URLs moved from local paths to Vercel Blob.
   ['airtable-records', 'v3'],
@@ -470,3 +471,16 @@ export const fetchAirtableRecords = unstable_cache(
   // bypass via rebuilds.
   { revalidate: 3600, tags: ['airtable-records'] }
 )
+
+// Preview-mode requests (see src/lib/preview.ts) skip the cache and read
+// Airtable live, so an admin sees their edit on the real page immediately.
+// Everyone else gets the cached entry above; Blob mirroring runs either way,
+// so preview pages carry the same permanent image URLs the live site serves.
+// (The explicit branch also documents intent: with Draft Mode enabled, Next
+// bypasses unstable_cache anyway — nothing in a preview request is cached.)
+export async function fetchAirtableRecords(
+  options: FetchOptions
+): Promise<AirtableRawRecord[]> {
+  if (await isPreviewRequest()) return fetchAirtableRecordsImpl(options)
+  return fetchAirtableRecordsCached(options)
+}

--- a/src/lib/data/changed-since.ts
+++ b/src/lib/data/changed-since.ts
@@ -1,0 +1,38 @@
+import { fetchAirtableWithRetry } from './airtable'
+
+// Uses LAST_MODIFIED_TIME() (a formula function) rather than any table's
+// "Last modified" field. The field may be configured as date-only, which
+// collapses intra-day edits to midnight UTC and hides same-day changes from
+// a later-that-day build. LAST_MODIFIED_TIME() always returns a full
+// timestamp regardless of how the field is displayed.
+//
+// Shared by /api/check-rebuild (deploy trigger) and /api/admin/preview/changed
+// (preview mode's auto-refresh), so both detect edits the same way.
+export async function hasChangesSince(
+  baseId: string,
+  token: string,
+  tableId: string,
+  since: Date,
+  filter?: string
+): Promise<boolean> {
+  const sinceIso = since.toISOString()
+  const timeCheck = `IS_AFTER(LAST_MODIFIED_TIME(), DATETIME_PARSE("${sinceIso}"))`
+  const formula = filter ? `AND(${filter}, ${timeCheck})` : timeCheck
+
+  const url = new URL(`https://api.airtable.com/v0/${baseId}/${tableId}`)
+  url.searchParams.set('filterByFormula', formula)
+  url.searchParams.set('maxRecords', '1')
+
+  const response = await fetchAirtableWithRetry(url.toString(), token, {
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Airtable fetch failed for ${tableId}: ${response.status} ${response.statusText}`
+    )
+  }
+
+  const data = await response.json()
+  return (data.records?.length ?? 0) > 0
+}

--- a/src/lib/data/counts.ts
+++ b/src/lib/data/counts.ts
@@ -1,4 +1,5 @@
 import { fetchAirtableRecords } from './airtable'
+import { isPreviewRequest } from '@/lib/preview'
 import { getAdvisors } from './advisors'
 import { getCommunities } from './communities'
 import { getEvents } from './events'
@@ -71,6 +72,18 @@ const resources = [
   },
 ]
 
+// Preview-mode requests can't be served from any Next.js data cache (Draft
+// Mode disables caching for the whole request), so without this memo every
+// preview page view would redo all sixteen serialized Airtable reads below —
+// seconds of waiting for nav badges the admin isn't checking. Held in process
+// memory (one server bundle in production, so it is shared across pages) and
+// never consulted outside preview mode, where the normal caches apply.
+let previewCountsMemo: {
+  at: number
+  counts: Partial<Record<string, number>>
+} | null = null
+const PREVIEW_COUNTS_TTL_MS = 10 * 60_000
+
 // Serialized to avoid hitting Airtable's 5 req/sec rate limit.
 // Called at build time (static generation) so latency doesn't matter.
 export async function fetchAllCounts(): Promise<
@@ -98,6 +111,15 @@ export async function fetchAllCounts(): Promise<
     }
   }
 
+  const preview = await isPreviewRequest()
+  if (
+    preview &&
+    previewCountsMemo &&
+    Date.now() - previewCountsMemo.at < PREVIEW_COUNTS_TTL_MS
+  ) {
+    return previewCountsMemo.counts
+  }
+
   const counts: Partial<Record<string, number>> = {}
   for (const r of resources) {
     const raw = await fetchAirtableRecords({
@@ -116,5 +138,8 @@ export async function fetchAllCounts(): Promise<
   counts['/training'] =
     (await getTrainingPrograms()).length + (await getRecurringPrograms()).length
 
+  if (preview) {
+    previewCountsMemo = { at: Date.now(), counts }
+  }
   return counts
 }

--- a/src/lib/data/last-updated.ts
+++ b/src/lib/data/last-updated.ts
@@ -1,6 +1,7 @@
 import { DONATION_GUIDE_LAST_UPDATED } from '@/lib/donation-guide-date'
 import { formatDate } from '@/lib/format-date'
 import { fetchAirtableWithRetry } from './airtable'
+import { isPreviewRequest } from '@/lib/preview'
 
 // All field references below use permanent field IDs (rename-proof); the
 // requests set returnFieldsByFieldId so responses are keyed the same way.
@@ -123,6 +124,22 @@ const configs: Record<string, ResourceConfig> = {
 
 export const validResources = Object.keys(configs)
 
+/** The table(s) whose records feed this resource's page, with the page's
+ *  publish filter where the config has one — the polling targets for preview
+ *  mode's auto-refresh (see /api/admin/preview/changed). Empty when the
+ *  page's content doesn't live in Airtable (/donation-guide). */
+export function resourceTables(
+  resource: string
+): Array<{ tableId: string; filter?: string }> {
+  const config = configs[resource]
+  if (!config) throw new Error(`Unknown resource: '${resource}'`)
+  if (config.type === 'constant') return []
+  if (config.type === 'record') return [{ tableId: config.tableId }]
+  if (config.type === 'multi')
+    return config.queries.map(q => ({ tableId: q.tableId, filter: q.filter }))
+  return [{ tableId: config.tableId, filter: config.filter }]
+}
+
 interface LastUpdatedResult {
   lastUpdated: string | null
   formattedDate: string | null
@@ -145,11 +162,17 @@ export async function fetchLastUpdated(
   // simply omit their "Updated X ago" line.
   if (!token || !baseId) return { lastUpdated: null, formattedDate: null }
 
+  // Preview mode skips the hourly fetch cache, so the "Updated X ago" line
+  // reflects the edit the admin just made (see src/lib/preview.ts).
+  const requestInit: RequestInit = (await isPreviewRequest())
+    ? { cache: 'no-store' }
+    : { next: { revalidate: 3600 } }
+
   if (config.type === 'record') {
     const response = await fetchAirtableWithRetry(
       `https://api.airtable.com/v0/${baseId}/${config.tableId}/${config.recordId}?returnFieldsByFieldId=true`,
       token,
-      { next: { revalidate: 3600 } }
+      requestInit
     )
     if (!response.ok)
       throw new Error(
@@ -174,7 +197,7 @@ export async function fetchLastUpdated(
   if (config.type === 'multi') {
     const results = await Promise.all(
       config.queries.map(query =>
-        fetchQueryLastUpdated(query, resource, token, baseId)
+        fetchQueryLastUpdated(query, resource, token, baseId, requestInit)
       )
     )
     const dated = results.filter(r => r.lastUpdated !== null)
@@ -182,14 +205,15 @@ export async function fetchLastUpdated(
     return dated.reduce((a, b) => (a.lastUpdated! >= b.lastUpdated! ? a : b))
   }
 
-  return fetchQueryLastUpdated(config, resource, token, baseId)
+  return fetchQueryLastUpdated(config, resource, token, baseId, requestInit)
 }
 
 async function fetchQueryLastUpdated(
   config: Omit<QueryConfig, 'type'>,
   resource: string,
   token: string,
-  baseId: string
+  baseId: string,
+  requestInit: RequestInit
 ): Promise<LastUpdatedResult> {
   const url = new URL(`https://api.airtable.com/v0/${baseId}/${config.tableId}`)
   if (config.viewId) url.searchParams.set('view', config.viewId)
@@ -200,9 +224,11 @@ async function fetchQueryLastUpdated(
   url.searchParams.set('fields[]', config.sortField)
   url.searchParams.set('returnFieldsByFieldId', 'true')
 
-  const response = await fetchAirtableWithRetry(url.toString(), token, {
-    next: { revalidate: 3600 },
-  })
+  const response = await fetchAirtableWithRetry(
+    url.toString(),
+    token,
+    requestInit
+  )
   if (!response.ok)
     throw new Error(
       `Airtable fetch failed for '${resource}': ${response.status} ${response.statusText}`

--- a/src/lib/format-date.test.ts
+++ b/src/lib/format-date.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { formatTimeAgo } from './format-date'
+
+describe('formatTimeAgo', () => {
+  const now = new Date('2026-08-22T12:00:00Z')
+
+  it('reads "just now" under a minute', () => {
+    expect(formatTimeAgo('2026-08-22T11:59:30Z', now)).toBe('just now')
+  })
+
+  it('uses minutes under an hour, singular and plural', () => {
+    expect(formatTimeAgo('2026-08-22T11:58:59Z', now)).toBe('1 minute ago')
+    expect(formatTimeAgo('2026-08-22T11:35:00Z', now)).toBe('25 minutes ago')
+    expect(formatTimeAgo('2026-08-22T11:00:01Z', now)).toBe('59 minutes ago')
+  })
+
+  it('uses hours under a day, singular and plural', () => {
+    expect(formatTimeAgo('2026-08-22T11:00:00Z', now)).toBe('1 hour ago')
+    expect(formatTimeAgo('2026-08-22T01:00:00Z', now)).toBe('11 hours ago')
+  })
+
+  it('uses days from 24 hours on', () => {
+    expect(formatTimeAgo('2026-08-21T12:00:00Z', now)).toBe('1 day ago')
+    expect(formatTimeAgo('2026-08-19T11:00:00Z', now)).toBe('3 days ago')
+  })
+
+  it('rejects an unparseable date instead of rendering garbage', () => {
+    expect(() => formatTimeAgo('not-a-date', now)).toThrow('invalid date')
+  })
+})

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -7,6 +7,27 @@ export function formatDate(date: Date): string {
   }).format(date)
 }
 
+/** Minute-level "x ago" for freshness readouts (the preview-mode banner's
+ *  "site last rebuilt ..."), where formatRelativeDate's day granularity is
+ *  too coarse. `now` is a parameter so the pure logic is testable. */
+export function formatTimeAgo(isoDate: string, now: Date): string {
+  const then = new Date(isoDate)
+  if (isNaN(then.getTime())) {
+    throw new Error(`formatTimeAgo: invalid date "${isoDate}"`)
+  }
+  const diffMinutes = Math.floor((now.getTime() - then.getTime()) / 60_000)
+  if (diffMinutes < 1) return 'just now'
+  if (diffMinutes < 60) {
+    return diffMinutes === 1 ? '1 minute ago' : `${diffMinutes} minutes ago`
+  }
+  const diffHours = Math.floor(diffMinutes / 60)
+  if (diffHours < 24) {
+    return diffHours === 1 ? '1 hour ago' : `${diffHours} hours ago`
+  }
+  const diffDays = Math.floor(diffHours / 24)
+  return diffDays === 1 ? '1 day ago' : `${diffDays} days ago`
+}
+
 export function formatRelativeDate(isoDate: string): string {
   const lastUpdatedDate = new Date(isoDate)
   const now = new Date()

--- a/src/lib/preview.ts
+++ b/src/lib/preview.ts
@@ -1,0 +1,17 @@
+import { draftMode } from 'next/headers'
+
+/** True when this request carries the Draft Mode cookie, i.e. an admin turned
+ *  on preview mode at /admin/preview. Preview requests bypass every data cache
+ *  and read Airtable live, so the admin sees an edit immediately on the real
+ *  pages; requests without the cookie are completely unaffected and keep
+ *  getting the prebuilt static pages. */
+export async function isPreviewRequest(): Promise<boolean> {
+  try {
+    return (await draftMode()).isEnabled
+  } catch {
+    // draftMode() is only usable in request scope. Outside one (`next build`
+    // prerendering pages, generating the sitemap) there is no cookie and so
+    // no preview — never a real error to surface.
+    return false
+  }
+}


### PR DESCRIPTION
- Adds preview mode: a signed-in editor's browser sees the real site pages rendered from live Airtable data, so an edit is visible in seconds instead of waiting ~2–3 minutes for the rebuild pipeline
- Built on Next.js Draft Mode on the real routes — no duplicated page code, so the preview cannot drift from what the live site will show; images use the same permanent Blob URLs either way
- Public pages are untouched: the build output stays fully static (verified byte-for-byte absence of preview UI in anonymous HTML), and all preview reads are per-request for the cookie-holding browser only
- /admin/preview is a master switch that shows/hides compact floating switch pills (bottom center): "Switch to preview" on the public view, "Preview · public built X ago" in preview; the preview pill always shows while preview is on (outside /admin), so preview can never be invisible
- Open preview pages auto-update within ~5 s of an Airtable edit — polling a new /api/admin/preview/changed endpoint that reuses check-rebuild's LAST_MODIFIED_TIME() detection (now shared in src/lib/data/changed-since.ts) — plus a refresh on window focus; mode switches re-render in place (no reload flash)
- New "preview" capability on PASSWORD_ROLES: owner, volunteers, and Melissa; Successif and analytics-only excluded. Enabling preview/pills is server-checked; disabling never requires auth so an expired session can always exit
- Nav-badge counts are memoized per process in preview (Draft Mode bypasses every data cache; the sixteen serialized count reads would otherwise add ~7 s per page view) — badges may lag a few minutes in preview, page content never does
- New unit tests for the banner's time formatting; 22-check end-to-end script exercised auth, cookies, toggles, change detection, and static-output safety against a production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)