### PR TITLE
Jobs: show each location on its own line

### DIFF
--- a/src/app/jobs/JobsClient.tsx
+++ b/src/app/jobs/JobsClient.tsx
@@ -272,7 +272,11 @@ export default function JobsClient({ jobs }: JobsClientProps) {
                 Location
               </p>
               <p className="paragraph-small padding-bottom-16px">
-                {job.location}
+                {job.locations.map(loc => (
+                  <span key={loc} className="block">
+                    {loc}
+                  </span>
+                ))}
               </p>
               <p className="paragraph-xs-bold padding-bottom-4px color-teal-400">
                 Minimum experience

--- a/src/lib/data/jobs.ts
+++ b/src/lib/data/jobs.ts
@@ -17,7 +17,7 @@ const FIELD = {
   org: 'fldG5yHF2GRnwXLcZ', // !Org
   orgLogo: 'fld0HYRj3o8ZPzIpB', // Org's logo
   skillSetText: 'fld7B5GTUR1kEj2wH', // Skill set text
-  locationFormatted: 'fldmUJTIPAi5YIv7P', // Location (formatted)
+  location: 'fldlVhQnyT9FuwXA2', // !Location (raw 80k format)
   minimumExperienceText: 'fldAskPW25nc6R4GZ', // !MinimumExperienceLevel (text)
   roleTypeText: 'fldCXYRLhvZbwf0Pp', // Role type text
   workLocation: 'fldffza4UJBfsjL3v', // Work location
@@ -36,11 +36,55 @@ export interface Job {
   logo: string | null
   skillSet: string
   location: string
+  locations: string[]
   minimumExperience: string
   roleType: string
   workLocation: string
   url: string
   datePublished: string | null
+}
+
+// The 80k !Location field packs every location into one string: locations
+// are comma-separated, a period separates place from country, and places
+// that themselves contain a comma are wrapped in double quotes, e.g.
+//   San Francisco Bay Area.USA, "New York, NY.USA", Remote.Global
+export function parseJobLocations(raw: string): string[] {
+  const tokens: string[] = []
+  let current = ''
+  let inQuotes = false
+  for (const char of raw) {
+    if (char === '"') {
+      inQuotes = !inQuotes
+    } else if (char === ',' && !inQuotes) {
+      tokens.push(current)
+      current = ''
+    } else {
+      current += char
+    }
+  }
+  tokens.push(current)
+
+  const locations: string[] = []
+  for (const token of tokens) {
+    const trimmed = token.trim()
+    if (!trimmed) continue
+    const dot = trimmed.lastIndexOf('.')
+    if (dot === -1) {
+      locations.push(trimmed)
+      continue
+    }
+    // A leading period is 80k's legacy remote marker; drop it.
+    const place = trimmed.slice(0, dot).trim().replace(/^\.+/, '')
+    const country = trimmed.slice(dot + 1).trim()
+    if (!place) {
+      locations.push(country)
+    } else if (place === 'Remote') {
+      locations.push(`Remote (${country})`)
+    } else {
+      locations.push(`${place}, ${country}`)
+    }
+  }
+  return locations
 }
 
 export async function getJobs(): Promise<Job[]> {
@@ -62,6 +106,8 @@ export async function getJobs(): Promise<Job[]> {
     const logoRaw = f[FIELD.orgLogo]
     const logo = fieldString(logoRaw) ?? fieldAttachmentUrl(logoRaw)
 
+    const locations = parseJobLocations(fieldText(f[FIELD.location]))
+
     results.push({
       id: record.id,
       name,
@@ -69,7 +115,8 @@ export async function getJobs(): Promise<Job[]> {
       organization: fieldString(f[FIELD.org]) || '',
       logo,
       skillSet: fieldText(f[FIELD.skillSetText]),
-      location: fieldText(f[FIELD.locationFormatted]),
+      location: locations.join('; '),
+      locations,
       minimumExperience: fieldText(f[FIELD.minimumExperienceText]),
       roleType: fieldText(f[FIELD.roleTypeText]),
       workLocation: fieldText(f[FIELD.workLocation]),


### PR DESCRIPTION
- Multi-location jobs on /jobs displayed as one run-on comma list ("San Francisco Bay Area, USA, London, UK") because the Airtable formula flattened the 80k location string by replacing periods with commas
- Parse the raw `!Location` field in the site code instead: split into individual locations (handling quoted cities that contain commas, like "New York, NY.USA") and render one location per line on the card
- Remote roles now display as "Remote (Global)" / "Remote (USA)" instead of "Remote, Global"
- Search, the chatbot catalog, and the public API keep a joined string, now semicolon-separated so location boundaries stay clear
- No Airtable changes; the "Location (formatted)" formula field is simply no longer used by the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)