### PR TITLE
Add UTM tags to outbound links across resource pages

### DIFF
--- a/src/app/advisors/AdvisorsClient.tsx
+++ b/src/app/advisors/AdvisorsClient.tsx
@@ -8,6 +8,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { Advisor } from '@/lib/data/advisors'
 import { trackListingClick } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
 
 interface AdvisorsClientProps {
@@ -117,7 +118,7 @@ export default function AdvisorsClient({ advisors }: AdvisorsClientProps) {
           {filteredAdvisors.map(advisor => (
             <a
               key={advisor.id}
-              href={advisor.url}
+              href={withUtm(advisor.url, 'Advisors')}
               target="_blank"
               rel="noopener noreferrer"
               className="card"

--- a/src/app/communities/CommunitiesClient.tsx
+++ b/src/app/communities/CommunitiesClient.tsx
@@ -9,6 +9,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { Community } from '@/lib/data/communities'
 import { trackListingClick } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
 
 interface CommunitiesClientProps {
@@ -236,7 +237,7 @@ export default function CommunitiesClient({
               return (
                 <Link
                   key={community.id}
-                  href={community.joinLink}
+                  href={withUtm(community.joinLink, 'Communities')}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="card"

--- a/src/app/communities/CommunitiesMap.tsx
+++ b/src/app/communities/CommunitiesMap.tsx
@@ -8,6 +8,7 @@ import styles from './page.module.css'
 import { Community } from '@/lib/data/communities'
 import { positionTooltip } from '@/lib/mapTooltip'
 import { trackListingClick, trackListingHover } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 
 interface CommunitiesMapProps {
   communities: Community[]
@@ -403,7 +404,7 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
               undefined,
               'map'
             )
-            openInNewTab(link)
+            openInNewTab(withUtm(link, 'Communities'))
           }
           return
         }
@@ -465,7 +466,7 @@ export default function CommunitiesMap({ communities }: CommunitiesMapProps) {
                 undefined,
                 'map'
               )
-            openInNewTab(lnk)
+            openInNewTab(withUtm(lnk, 'Communities'))
           }
           e.stopPropagation()
         }

--- a/src/app/communities/page.tsx
+++ b/src/app/communities/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { withUtm } from '@/lib/utm'
 import { fetchLastUpdated } from '@/lib/data/last-updated'
 import PageHeader from '@/components/PageHeader'
 import FeaturedCard from '@/components/FeaturedCardLegacy'
@@ -89,7 +90,10 @@ export default async function CommunitiesPage() {
               Related resources
             </p>
             <Link
-              href="https://www.lesswrong.com/community"
+              href={withUtm(
+                'https://www.lesswrong.com/community',
+                'Communities'
+              )}
               target="_blank"
               rel="noopener noreferrer"
               className="block padding-bottom-40px hover-opacity-80"
@@ -104,7 +108,10 @@ export default async function CommunitiesPage() {
               </p>
             </Link>
             <Link
-              href="https://forum.effectivealtruism.org/groups"
+              href={withUtm(
+                'https://forum.effectivealtruism.org/groups',
+                'Communities'
+              )}
               target="_blank"
               rel="noopener noreferrer"
               className="block hover-opacity-80"

--- a/src/app/donation-guide/content.tsx
+++ b/src/app/donation-guide/content.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { withUtm } from '@/lib/utm'
 import type { ReactNode } from 'react'
 import styles from './page.module.css'
 
@@ -47,7 +48,7 @@ function Tab1Content() {
         <p>
           Donate to a fund, such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -57,7 +58,10 @@ function Tab1Content() {
           projects they think are most effective to fund. Alternatively, you can
           donate to a{' '}
           <Link
-            href="https://www.givingwhatwecan.org/donor-lottery"
+            href={withUtm(
+              'https://www.givingwhatwecan.org/donor-lottery',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -77,7 +81,7 @@ function Tab1Content() {
         <p className="padding-bottom-12px">
           Either donate to a fund, such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -88,7 +92,10 @@ function Tab1Content() {
           your network if you know someone whose opinion in this area you trust,
           or send money via a{' '}
           <Link
-            href="https://www.givingwhatwecan.org/donor-lottery"
+            href={withUtm(
+              'https://www.givingwhatwecan.org/donor-lottery',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -100,7 +107,7 @@ function Tab1Content() {
         <p>
           We recommend exploring{' '}
           <Link
-            href="https://manifund.org/"
+            href={withUtm('https://manifund.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -109,7 +116,7 @@ function Tab1Content() {
           , which allows you to &quot;invest&quot; in projects you think will be
           impactful, or nominate regrantors to decide on your behalf.{' '}
           <Link
-            href="https://givewiki.org/"
+            href={withUtm('https://givewiki.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -117,7 +124,10 @@ function Tab1Content() {
           </Link>{' '}
           and the{' '}
           <Link
-            href="https://www.nonlinear.org/network.html"
+            href={withUtm(
+              'https://www.nonlinear.org/network.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -137,7 +147,7 @@ function Tab1Content() {
         </p>
         <p className="padding-bottom-12px">
           <Link
-            href="https://aisafety.info/"
+            href={withUtm('https://aisafety.info/', 'Donation guide')}
             target="_blank"
             className="display-inline color-white"
           >
@@ -154,7 +164,7 @@ function Tab1Content() {
           Consider engaging with researchers in the comments sections of their
           research posts on{' '}
           <Link
-            href="https://www.lesswrong.com/w/ai"
+            href={withUtm('https://www.lesswrong.com/w/ai', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -168,7 +178,10 @@ function Tab1Content() {
           in your network if you know someone whose opinions in this area you
           trust, or send money via a{' '}
           <Link
-            href="https://www.givingwhatwecan.org/donor-lottery"
+            href={withUtm(
+              'https://www.givingwhatwecan.org/donor-lottery',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -180,7 +193,7 @@ function Tab1Content() {
         <p className="padding-bottom-12px">
           We recommend exploring{' '}
           <Link
-            href="https://manifund.org/"
+            href={withUtm('https://manifund.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -189,7 +202,7 @@ function Tab1Content() {
           , which allows you to &quot;invest&quot; in projects you think will be
           impactful, or nominate regrantors to decide on your behalf.{' '}
           <Link
-            href="https://givewiki.org/"
+            href={withUtm('https://givewiki.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -197,7 +210,10 @@ function Tab1Content() {
           </Link>{' '}
           and the{' '}
           <Link
-            href="https://www.nonlinear.org/network.html"
+            href={withUtm(
+              'https://www.nonlinear.org/network.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -208,7 +224,7 @@ function Tab1Content() {
         <p>
           Donating to a fund such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -228,7 +244,7 @@ function Tab1Content() {
         </p>
         <p className="padding-bottom-12px">
           <Link
-            href="https://aisafety.info/"
+            href={withUtm('https://aisafety.info/', 'Donation guide')}
             target="_blank"
             className="display-inline color-white"
           >
@@ -244,7 +260,10 @@ function Tab1Content() {
         <p className="padding-bottom-12px">
           Consider self-funding to try and{' '}
           <Link
-            href="https://aisafety.info/how-can-i-help"
+            href={withUtm(
+              'https://aisafety.info/how-can-i-help',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -259,7 +278,10 @@ function Tab1Content() {
           in your network if you know someone whose opinions in this area you
           trust, or send money via a{' '}
           <Link
-            href="https://www.givingwhatwecan.org/donor-lottery"
+            href={withUtm(
+              'https://www.givingwhatwecan.org/donor-lottery',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -271,7 +293,7 @@ function Tab1Content() {
         <p className="padding-bottom-12px">
           We recommend exploring{' '}
           <Link
-            href="https://manifund.org/"
+            href={withUtm('https://manifund.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -280,7 +302,7 @@ function Tab1Content() {
           , which allows you to &quot;invest&quot; in projects you think will be
           impactful, or nominate regrantors to decide on your behalf.{' '}
           <Link
-            href="https://givewiki.org/"
+            href={withUtm('https://givewiki.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -288,7 +310,10 @@ function Tab1Content() {
           </Link>{' '}
           and the{' '}
           <Link
-            href="https://www.nonlinear.org/network.html"
+            href={withUtm(
+              'https://www.nonlinear.org/network.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -299,7 +324,7 @@ function Tab1Content() {
         <p>
           Donating to a fund such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -329,7 +354,7 @@ function Tab2Content() {
         <p>
           Donate to a fund, such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -350,7 +375,7 @@ function Tab2Content() {
         <p className="padding-bottom-12px">
           Either donate to a fund, such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -361,7 +386,10 @@ function Tab2Content() {
           your network if you know someone whose opinions in this area you
           trust, or send money via a{' '}
           <Link
-            href="https://www.givingwhatwecan.org/donor-lottery"
+            href={withUtm(
+              'https://www.givingwhatwecan.org/donor-lottery',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -373,7 +401,7 @@ function Tab2Content() {
         <p>
           We recommend exploring{' '}
           <Link
-            href="https://manifund.org/"
+            href={withUtm('https://manifund.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -382,7 +410,7 @@ function Tab2Content() {
           , which allows you to &quot;invest&quot; in projects you think will be
           impactful, or nominate regrantors to decide on your behalf.{' '}
           <Link
-            href="https://givewiki.org/"
+            href={withUtm('https://givewiki.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -390,7 +418,10 @@ function Tab2Content() {
           </Link>{' '}
           and the{' '}
           <Link
-            href="https://www.nonlinear.org/network.html"
+            href={withUtm(
+              'https://www.nonlinear.org/network.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -410,7 +441,7 @@ function Tab2Content() {
         </p>
         <p className="padding-bottom-12px">
           <Link
-            href="https://aisafety.info/"
+            href={withUtm('https://aisafety.info/', 'Donation guide')}
             target="_blank"
             className="display-inline color-white"
           >
@@ -427,7 +458,7 @@ function Tab2Content() {
           Consider engaging with researchers in the comments sections of their
           research posts on{' '}
           <Link
-            href="https://www.lesswrong.com/w/ai"
+            href={withUtm('https://www.lesswrong.com/w/ai', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -441,7 +472,10 @@ function Tab2Content() {
           in your network if you know someone whose opinions in this area you
           trust, or send money via a{' '}
           <Link
-            href="https://www.givingwhatwecan.org/donor-lottery"
+            href={withUtm(
+              'https://www.givingwhatwecan.org/donor-lottery',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -453,7 +487,7 @@ function Tab2Content() {
         <p className="padding-bottom-12px">
           We recommend exploring{' '}
           <Link
-            href="https://manifund.org/"
+            href={withUtm('https://manifund.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -462,7 +496,7 @@ function Tab2Content() {
           , which allows you to &quot;invest&quot; in projects you think will be
           impactful, or nominate regrantors to decide on your behalf.{' '}
           <Link
-            href="https://givewiki.org/"
+            href={withUtm('https://givewiki.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -470,7 +504,10 @@ function Tab2Content() {
           </Link>{' '}
           and the{' '}
           <Link
-            href="https://www.nonlinear.org/network.html"
+            href={withUtm(
+              'https://www.nonlinear.org/network.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -481,7 +518,7 @@ function Tab2Content() {
         <p>
           Donating to a fund such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -501,7 +538,7 @@ function Tab2Content() {
         </p>
         <p className="padding-bottom-12px">
           <Link
-            href="https://aisafety.info/"
+            href={withUtm('https://aisafety.info/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -517,7 +554,10 @@ function Tab2Content() {
         <p className="padding-bottom-12px">
           Consider self-funding to try and{' '}
           <Link
-            href="https://aisafety.info/how-can-i-help"
+            href={withUtm(
+              'https://aisafety.info/how-can-i-help',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-white"
           >
@@ -532,7 +572,10 @@ function Tab2Content() {
           in your network if you know someone whose opinions in this area you
           trust, or send money via a{' '}
           <Link
-            href="https://www.givingwhatwecan.org/donor-lottery"
+            href={withUtm(
+              'https://www.givingwhatwecan.org/donor-lottery',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -544,7 +587,7 @@ function Tab2Content() {
         <p className="padding-bottom-12px">
           We recommend exploring{' '}
           <Link
-            href="https://manifund.org/"
+            href={withUtm('https://manifund.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -553,7 +596,7 @@ function Tab2Content() {
           , which allows you to &quot;invest&quot; in projects you think will be
           impactful, or nominate regrantors to decide on your behalf.{' '}
           <Link
-            href="https://givewiki.org/"
+            href={withUtm('https://givewiki.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -561,7 +604,10 @@ function Tab2Content() {
           </Link>{' '}
           and the{' '}
           <Link
-            href="https://www.nonlinear.org/network.html"
+            href={withUtm(
+              'https://www.nonlinear.org/network.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -572,7 +618,7 @@ function Tab2Content() {
         <p>
           Donating to a fund such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -599,7 +645,7 @@ function Tab3Content() {
         <p>
           Donate to a fund, such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -616,7 +662,7 @@ function Tab3Content() {
         <p className="padding-bottom-12px">
           Either donate to a fund, such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -627,7 +673,10 @@ function Tab3Content() {
           your network if you know someone whose opinions in this area you
           trust, or send money via a{' '}
           <Link
-            href="https://www.givingwhatwecan.org/donor-lottery"
+            href={withUtm(
+              'https://www.givingwhatwecan.org/donor-lottery',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -639,7 +688,7 @@ function Tab3Content() {
         <p>
           We recommend exploring{' '}
           <Link
-            href="https://manifund.org/"
+            href={withUtm('https://manifund.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -648,7 +697,7 @@ function Tab3Content() {
           , which allows you to &quot;invest&quot; in projects you think will be
           impactful, or nominate regrantors to decide on your behalf.{' '}
           <Link
-            href="https://givewiki.org/"
+            href={withUtm('https://givewiki.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -656,7 +705,10 @@ function Tab3Content() {
           </Link>{' '}
           and the{' '}
           <Link
-            href="https://www.nonlinear.org/network.html"
+            href={withUtm(
+              'https://www.nonlinear.org/network.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -671,7 +723,7 @@ function Tab3Content() {
       <TimeSection time="Ongoing commitment">
         <p className="padding-bottom-12px">
           <Link
-            href="https://aisafety.info/"
+            href={withUtm('https://aisafety.info/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -688,7 +740,7 @@ function Tab3Content() {
           Consider engaging with researchers in the comments sections of their
           research posts on{' '}
           <Link
-            href="https://www.lesswrong.com/w/ai"
+            href={withUtm('https://www.lesswrong.com/w/ai', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -699,7 +751,7 @@ function Tab3Content() {
         <p>
           Donating to a fund such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -714,7 +766,7 @@ function Tab3Content() {
       <TimeSection time="Major focus" last>
         <p className="padding-bottom-12px">
           <Link
-            href="https://aisafety.info/"
+            href={withUtm('https://aisafety.info/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -735,7 +787,7 @@ function Tab3Content() {
         <p>
           Donating to a fund such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -764,7 +816,10 @@ function Tab4Content() {
           Either delegate to someone in your network who you think has a good
           understanding of the challenge (possibly by sponsoring them as an{' '}
           <Link
-            href="https://survivalandflourishing.fund/s-process.html"
+            href={withUtm(
+              'https://survivalandflourishing.fund/s-process.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -773,7 +828,7 @@ function Tab4Content() {
           , which will give them infrastructure and a menu of applications), or
           donate to a fund such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -789,7 +844,10 @@ function Tab4Content() {
         <p className="padding-bottom-12px">
           Some high impact ideas include sponsoring an{' '}
           <Link
-            href="https://survivalandflourishing.fund/s-process.html"
+            href={withUtm(
+              'https://survivalandflourishing.fund/s-process.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -798,7 +856,10 @@ function Tab4Content() {
           whose judgment you trust, which will give them infrastructure and a
           menu of applications, or donate to a{' '}
           <Link
-            href="https://www.givingwhatwecan.org/donor-lottery"
+            href={withUtm(
+              'https://www.givingwhatwecan.org/donor-lottery',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -809,7 +870,7 @@ function Tab4Content() {
         <p>
           Alternatively, either donate to a fund – such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -819,7 +880,7 @@ function Tab4Content() {
           of AI safety, or select individuals to donate to directly. We
           recommend exploring{' '}
           <Link
-            href="https://manifund.org/"
+            href={withUtm('https://manifund.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -828,7 +889,7 @@ function Tab4Content() {
           , which allows you to &quot;invest&quot; in projects you think will be
           impactful, or nominate regrantors to decide on your behalf.{' '}
           <Link
-            href="https://givewiki.org/"
+            href={withUtm('https://givewiki.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -836,7 +897,10 @@ function Tab4Content() {
           </Link>{' '}
           and the{' '}
           <Link
-            href="https://www.nonlinear.org/network.html"
+            href={withUtm(
+              'https://www.nonlinear.org/network.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -851,7 +915,7 @@ function Tab4Content() {
       <TimeSection time="Ongoing commitment">
         <p className="padding-bottom-12px">
           <Link
-            href="https://aisafety.info/"
+            href={withUtm('https://aisafety.info/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -868,7 +932,7 @@ function Tab4Content() {
           Consider engaging with researchers in the comments sections of their
           research posts on{' '}
           <Link
-            href="https://www.lesswrong.com/w/ai"
+            href={withUtm('https://www.lesswrong.com/w/ai', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -879,7 +943,7 @@ function Tab4Content() {
         <p>
           Alternatively, either donate to a fund – such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -889,7 +953,7 @@ function Tab4Content() {
           of AI safety, or select individuals to donate to directly. We
           recommend exploring{' '}
           <Link
-            href="https://manifund.org/"
+            href={withUtm('https://manifund.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -905,7 +969,7 @@ function Tab4Content() {
       <TimeSection time="Major focus" last>
         <p className="padding-bottom-12px">
           <Link
-            href="https://aisafety.info/"
+            href={withUtm('https://aisafety.info/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -928,7 +992,7 @@ function Tab4Content() {
           Consider engaging with researchers in the comments sections of their
           research posts on{' '}
           <Link
-            href="https://www.lesswrong.com/w/ai"
+            href={withUtm('https://www.lesswrong.com/w/ai', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -939,7 +1003,10 @@ function Tab4Content() {
         <p className="padding-bottom-12px">
           Some high impact ideas for donating include sponsoring an{' '}
           <Link
-            href="https://survivalandflourishing.fund/s-process.html"
+            href={withUtm(
+              'https://survivalandflourishing.fund/s-process.html',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -948,7 +1015,10 @@ function Tab4Content() {
           whose judgment you trust, which will give them infrastructure and a
           menu of applications, or donate to a{' '}
           <Link
-            href="https://www.givingwhatwecan.org/donor-lottery"
+            href={withUtm(
+              'https://www.givingwhatwecan.org/donor-lottery',
+              'Donation guide'
+            )}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -959,7 +1029,7 @@ function Tab4Content() {
         <p>
           Alternatively, either donate to a fund – such as the{' '}
           <Link
-            href="https://www.airiskfund.com/"
+            href={withUtm('https://www.airiskfund.com/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >
@@ -969,7 +1039,7 @@ function Tab4Content() {
           of AI safety, or select individuals to donate to directly. We
           recommend exploring{' '}
           <Link
-            href="https://manifund.org/"
+            href={withUtm('https://manifund.org/', 'Donation guide')}
             target="_blank"
             className="display-inline color-teal"
           >

--- a/src/app/founders/FoundersClient.tsx
+++ b/src/app/founders/FoundersClient.tsx
@@ -8,6 +8,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { FounderResource } from '@/lib/data/founders'
 import { trackListingClick } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
 
 interface FoundersClientProps {
@@ -99,7 +100,7 @@ export default function FoundersClient({ resources }: FoundersClientProps) {
           {filteredResources.map(resource => (
             <a
               key={resource.id}
-              href={resource.website}
+              href={withUtm(resource.website, 'Founders')}
               target="_blank"
               rel="noopener noreferrer"
               className="card"

--- a/src/app/funding/FundingClient.tsx
+++ b/src/app/funding/FundingClient.tsx
@@ -8,6 +8,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { Funder } from '@/lib/data/funding'
 import { trackListingClick } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
 
 interface FundingClientProps {
@@ -125,7 +126,7 @@ export default function FundingClient({ funders }: FundingClientProps) {
           {filteredFunders.map(funder => (
             <a
               key={funder.id}
-              href={funder.url}
+              href={withUtm(funder.url, 'Funding')}
               target="_blank"
               rel="noopener noreferrer"
               className="card"

--- a/src/app/jobs/JobsClient.tsx
+++ b/src/app/jobs/JobsClient.tsx
@@ -7,6 +7,7 @@ import FilterSidebar from '@/components/FilterSidebar'
 import SearchBar from '@/components/SearchBar'
 import { Job } from '@/lib/data/jobs'
 import { trackListingClick } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
 import { setPageContext } from '@/lib/assistant/page-context'
 
@@ -224,7 +225,7 @@ export default function JobsClient({ jobs }: JobsClientProps) {
           {filteredJobs.map(job => (
             <a
               key={job.id}
-              href={job.url}
+              href={withUtm(job.url, 'Jobs')}
               target="_blank"
               rel="noopener noreferrer"
               className="card"
@@ -353,7 +354,7 @@ export default function JobsClient({ jobs }: JobsClientProps) {
             Source:
           </p>
           <a
-            href="https://jobs.80000hours.org/"
+            href={withUtm('https://jobs.80000hours.org/', 'Jobs')}
             target="_blank"
             rel="noopener noreferrer"
             className="color-light-teal"

--- a/src/app/map/D3Map.tsx
+++ b/src/app/map/D3Map.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef } from 'react'
 import * as d3 from 'd3'
 import MapControls from '@/components/MapControls'
 import { trackListingClick, trackListingHover } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 import { positionTooltip } from '@/lib/mapTooltip'
 import styles from './page.module.css'
 
@@ -288,7 +289,7 @@ export default function D3Map({ orgs }: D3MapProps) {
         .attr('class', 'mapItem')
       if (hasLink) {
         linkEl
-          .attr('xlink:href', org.link)
+          .attr('xlink:href', withUtm(org.link, 'Map'))
           .attr('target', '_blank')
           .attr('rel', 'noopener noreferrer')
           .style('cursor', 'pointer')
@@ -539,7 +540,7 @@ export default function D3Map({ orgs }: D3MapProps) {
             tt.getAttribute('data-area') || undefined
           )
         hideTooltip()
-        window.open(link, '_blank')
+        window.open(withUtm(link, 'Map'), '_blank')
       }
       e.stopPropagation()
     }

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -9,6 +9,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import RelativeDate from '@/components/RelativeDate'
 import SearchBar from '@/components/SearchBar'
 import { trackListingClick } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
 import styles from './page.module.css'
 
@@ -246,7 +247,7 @@ export default function MapClient({
               {filteredOrgs.map(org => (
                 <a
                   key={org.id}
-                  href={org.link}
+                  href={withUtm(org.link, 'Map')}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="card"

--- a/src/app/media-channels/MediaChannelsClient.tsx
+++ b/src/app/media-channels/MediaChannelsClient.tsx
@@ -8,6 +8,7 @@ import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { MediaChannel } from '@/lib/data/media-channels'
 import { trackListingClick } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
 
 interface MediaChannelsClientProps {
@@ -105,7 +106,7 @@ export default function MediaChannelsClient({
           {filteredChannels.map(channel => (
             <a
               key={channel.id}
-              href={channel.url}
+              href={withUtm(channel.url, 'Media channels')}
               target="_blank"
               rel="noopener noreferrer"
               className="card"

--- a/src/app/media-channels/page.tsx
+++ b/src/app/media-channels/page.tsx
@@ -1,4 +1,5 @@
 import { fetchLastUpdated } from '@/lib/data/last-updated'
+import { withUtm } from '@/lib/utm'
 import PageHeader from '@/components/PageHeader'
 import FeaturedCard from '@/components/FeaturedCardLegacy'
 import MediaChannelsClient from './MediaChannelsClient'
@@ -62,7 +63,7 @@ export default async function MediaChannelsPage() {
             Related resource
           </p>
           <a
-            href="https://aisafety.info"
+            href={withUtm('https://aisafety.info', 'Media channels')}
             target="_blank"
             rel="noopener noreferrer"
             className="block hover-opacity-80"

--- a/src/app/poster-map/D3PosterMap.tsx
+++ b/src/app/poster-map/D3PosterMap.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react'
 import * as d3 from 'd3'
 import QRCode from 'qrcode'
+import { withUtm } from '@/lib/utm'
 import styles from './page.module.css'
 import { MapOrg } from '@/lib/data/map'
 
@@ -197,7 +198,7 @@ export default function D3PosterMap({ orgs }: D3PosterMapProps) {
 
       const linkEl = itemGroup
         .append('a')
-        .attr('xlink:href', org.link)
+        .attr('xlink:href', withUtm(org.link, 'Poster map'))
         .attr('target', '_blank')
 
       // White circle background

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { trackListingClick } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 import styles from './ListingCard.module.css'
 
 export interface ListingCardMeta {
@@ -68,7 +69,7 @@ export default function ListingCard({
 }: ListingCardProps) {
   return (
     <a
-      href={href}
+      href={withUtm(href, trackingPage)}
       target="_blank"
       rel="noopener noreferrer"
       className="card"

--- a/src/components/TrackedLink.tsx
+++ b/src/components/TrackedLink.tsx
@@ -2,6 +2,7 @@
 
 import { AnchorHTMLAttributes, ReactNode } from 'react'
 import { trackListingClick } from '@/lib/analytics'
+import { withUtm } from '@/lib/utm'
 
 interface TrackedLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   trackingPage: string
@@ -36,7 +37,7 @@ export default function TrackedLink({
 }: TrackedLinkProps) {
   return (
     <a
-      href={href}
+      href={withUtm(href, trackingPage)}
       onClick={e => {
         trackListingClick(
           trackingPage,

--- a/src/lib/utm.test.ts
+++ b/src/lib/utm.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { withUtm } from './utm'
+
+describe('withUtm', () => {
+  it('tags a plain external URL', () => {
+    expect(withUtm('https://example.org/jobs', 'Jobs')).toBe(
+      'https://example.org/jobs?utm_source=aisafety.com&utm_medium=referral&utm_campaign=jobs'
+    )
+  })
+
+  it('hyphenates multi-word page names in utm_campaign', () => {
+    expect(withUtm('https://example.org/', 'Media channels')).toContain(
+      'utm_campaign=media-channels'
+    )
+    expect(withUtm('https://example.org/', 'Donation guide')).toContain(
+      'utm_campaign=donation-guide'
+    )
+  })
+
+  it('appends to an existing query string instead of clobbering it', () => {
+    expect(withUtm('https://example.org/apply?id=42', 'Funding')).toBe(
+      'https://example.org/apply?id=42&utm_source=aisafety.com&utm_medium=referral&utm_campaign=funding'
+    )
+  })
+
+  it('keeps the #fragment after the query', () => {
+    const tagged = withUtm('https://example.org/page#section', 'Events')
+    expect(tagged).toBe(
+      'https://example.org/page?utm_source=aisafety.com&utm_medium=referral&utm_campaign=events#section'
+    )
+  })
+
+  it("replaces a stored URL's own utm_ tags with ours", () => {
+    const tagged = withUtm(
+      'https://example.org/?utm_source=twitter&utm_content=ad&ref=keepme',
+      'Training'
+    )
+    expect(tagged).toContain('ref=keepme')
+    expect(tagged).toContain('utm_source=aisafety.com')
+    expect(tagged).not.toContain('twitter')
+    expect(tagged).not.toContain('utm_content')
+  })
+
+  it('leaves internal links, relative paths, and other schemes untouched', () => {
+    expect(withUtm('https://aisafety.com/events', 'Home')).toBe(
+      'https://aisafety.com/events'
+    )
+    expect(withUtm('https://www.aisafety.com/', 'Home')).toBe(
+      'https://www.aisafety.com/'
+    )
+    expect(withUtm('/events', 'Home')).toBe('/events')
+    expect(withUtm('#', 'Communities')).toBe('#')
+    expect(withUtm('mailto:hello@example.org', 'Advisors')).toBe(
+      'mailto:hello@example.org'
+    )
+  })
+})

--- a/src/lib/utm.ts
+++ b/src/lib/utm.ts
@@ -1,0 +1,36 @@
+/**
+ * Append the site's UTM tags to an outbound link at render time, so the
+ * destination org's analytics shows aisafety.com as the traffic source.
+ * Stored URLs stay clean in Airtable — the tags exist only in the rendered
+ * href. Matomo click events also keep recording the clean URL: call sites
+ * tag the href but pass the original URL to the tracking call.
+ *
+ * Only absolute http(s) URLs to other sites are tagged. Internal links,
+ * relative paths, and other schemes (mailto: etc.) pass through unchanged.
+ * Any utm_* tags already on a stored URL are replaced with ours, so the
+ * destination sees a single, consistent source (mirrors how 80,000 Hours
+ * handles their job board links).
+ *
+ * @param page The page's tracking name (e.g. 'Media channels'), lowercased
+ *   and hyphenated into the utm_campaign value (media-channels).
+ */
+export function withUtm(url: string, page: string): string {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    // Relative path (an internal link) or a placeholder like '#'.
+    return url
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return url
+  const host = parsed.hostname.replace(/^www\./, '')
+  if (host === 'aisafety.com' || host === 'localhost') return url
+
+  for (const key of [...parsed.searchParams.keys()]) {
+    if (key.toLowerCase().startsWith('utm_')) parsed.searchParams.delete(key)
+  }
+  parsed.searchParams.set('utm_source', 'aisafety.com')
+  parsed.searchParams.set('utm_medium', 'referral')
+  parsed.searchParams.set('utm_campaign', page.toLowerCase().replace(/ /g, '-'))
+  return parsed.toString()
+}


### PR DESCRIPTION
Outbound links across the site now carry UTM tags, so destination orgs see aisafety.com as the traffic source in their analytics.

- New `withUtm()` helper appends `utm_source=aisafety.com&utm_medium=referral&utm_campaign=<page>` at render time — stored Airtable URLs stay clean
- Applied via the shared `TrackedLink` and `ListingCard` components (homepage, featured cards, listing grids) and the pages that render their own links: jobs, funding, communities (cards + map pins), advisors, media channels, founders, field map (cards + pins + mobile tooltip), poster map
- Static outbound links tagged too: donation guide, communities and media-channels sidebars, the jobs page's 80k source link
- Only external http(s) links are tagged; internal links, suggestion forms, mailto, and the footer pass through unchanged. Any pre-existing `utm_*` tags on a stored URL are replaced
- Matomo click events keep recording the clean URL, so the analytics dashboard is unaffected
- Unit tests for the helper in `src/lib/utm.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)