### PR TITLE
Jobs: richer cards and new filters from unused 80k data

### DIFF
--- a/src/app/jobs/JobsClient.tsx
+++ b/src/app/jobs/JobsClient.tsx
@@ -1,6 +1,13 @@
 'use client'
 
-import { useState, useMemo, useRef, useLayoutEffect, useEffect } from 'react'
+import {
+  useState,
+  useMemo,
+  useRef,
+  useLayoutEffect,
+  useEffect,
+  useCallback,
+} from 'react'
 import Image from 'next/image'
 import FilterGroup from '@/components/FilterGroup'
 import FilterSidebar from '@/components/FilterSidebar'
@@ -46,127 +53,314 @@ const roleTypeOptions = [
 
 const workLocationOptions = ['Remote', 'On-site']
 
+// 80k sometimes lists a region instead of a country ("Europe", "Various,
+// Europe", "Remote (Europe)"). Those roles are available from any country
+// in the region, so they match every member country in the filter. Only
+// "Europe" appears in the data today; the other regions are listed so the
+// same behavior kicks in automatically if 80k ever uses them.
+const REGION_MEMBERS: Record<string, Set<string>> = {
+  Europe: new Set([
+    'UK',
+    'Ireland',
+    'France',
+    'Germany',
+    'Netherlands',
+    'Belgium',
+    'Luxembourg',
+    'Switzerland',
+    'Austria',
+    'Denmark',
+    'Norway',
+    'Sweden',
+    'Finland',
+    'Iceland',
+    'Spain',
+    'Portugal',
+    'Italy',
+    'Greece',
+    'Poland',
+    'Czechia',
+    'Czech Republic',
+    'Slovakia',
+    'Hungary',
+    'Romania',
+    'Bulgaria',
+    'Croatia',
+    'Serbia',
+    'Slovenia',
+    'Estonia',
+    'Latvia',
+    'Lithuania',
+    'Ukraine',
+  ]),
+  Asia: new Set([
+    'China',
+    'India',
+    'Japan',
+    'Singapore',
+    'South Korea',
+    'Taiwan',
+    'Hong Kong',
+    'Indonesia',
+    'Malaysia',
+    'Thailand',
+    'Vietnam',
+    'Philippines',
+    'Israel',
+    'United Arab Emirates',
+    'UAE',
+    'Saudi Arabia',
+    'Turkey',
+  ]),
+  'Middle East': new Set([
+    'Israel',
+    'United Arab Emirates',
+    'UAE',
+    'Saudi Arabia',
+    'Qatar',
+    'Turkey',
+    'Jordan',
+    'Egypt',
+  ]),
+  'North America': new Set(['USA', 'Canada', 'Mexico']),
+  'Latin America': new Set([
+    'Mexico',
+    'Brazil',
+    'Argentina',
+    'Chile',
+    'Colombia',
+    'Peru',
+    'Uruguay',
+    'Costa Rica',
+  ]),
+  'South America': new Set([
+    'Brazil',
+    'Argentina',
+    'Chile',
+    'Colombia',
+    'Peru',
+    'Uruguay',
+  ]),
+  Africa: new Set([
+    'South Africa',
+    'Nigeria',
+    'Kenya',
+    'Ghana',
+    'Egypt',
+    'Morocco',
+    'Rwanda',
+    'Uganda',
+  ]),
+  Oceania: new Set(['Australia', 'New Zealand']),
+}
+
+const REGION_NAMES = Object.keys(REGION_MEMBERS)
+
+const jobMatchesCountry = (job: Job, country: string) =>
+  job.countries.includes(country) ||
+  REGION_NAMES.some(
+    region =>
+      REGION_MEMBERS[region].has(country) && job.countries.includes(region)
+  )
+
+const degreeOptions = [
+  'Undergraduate degree or less',
+  "Master's degree",
+  'Doctoral degree',
+]
+
 export default function JobsClient({ jobs }: JobsClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedSkills, setSelectedSkills] = useState<string[]>([])
   const [selectedExperience, setSelectedExperience] = useState<string[]>([])
   const [selectedRoles, setSelectedRoles] = useState<string[]>([])
   const [selectedWorkLocation, setSelectedWorkLocation] = useState<string[]>([])
+  const [selectedCountries, setSelectedCountries] = useState<string[]>([])
+  const [selectedDegrees, setSelectedDegrees] = useState<string[]>([])
   const savedScrollY = useRef<number | null>(null)
 
   // Each job's slot in the full page order, stamped onto a click so the
   // dashboard can tie clicks to page position even after later reordering.
   const placements = useMemo(() => placementsById(jobs), [jobs])
 
-  const filteredJobs = useMemo(() => {
-    return jobs.filter(job => {
+  // Countries come from the data itself; only those with a meaningful
+  // number of jobs get a checkbox, ordered by overall job count (the
+  // order stays put while filtering). "Other" collects jobs in the
+  // remaining countries.
+  const countryOptions = useMemo(() => {
+    const raw: Record<string, number> = {}
+    for (const job of jobs) {
+      for (const country of job.countries) {
+        raw[country] = (raw[country] || 0) + 1
+      }
+    }
+    const options = Object.keys(raw).filter(
+      c => !(c in REGION_MEMBERS) && raw[c] >= 5
+    )
+    const totals: Record<string, number> = {}
+    for (const option of options) {
+      totals[option] = jobs.filter(job => jobMatchesCountry(job, option)).length
+    }
+    options.sort((a, b) => totals[b] - totals[a])
+    options.push('Other')
+    return options
+  }, [jobs])
+
+  // One predicate drives both the visible list and the sidebar counts.
+  // Passing `skip` leaves one filter group out, so each group's counts
+  // reflect the search box and every OTHER group — "what would I get if
+  // I also ticked this".
+  const jobPasses = useCallback(
+    (job: Job, skip?: string): boolean => {
       if (searchQuery) {
         const query = searchQuery.toLowerCase()
         if (
           !job.name.toLowerCase().includes(query) &&
           !job.organization.toLowerCase().includes(query) &&
-          !job.location.toLowerCase().includes(query)
+          !job.location.toLowerCase().includes(query) &&
+          !job.description.toLowerCase().includes(query)
         ) {
           return false
         }
       }
 
-      if (selectedSkills.length > 0) {
+      if (skip !== 'skill' && selectedSkills.length > 0) {
         const jobSkills = job.skillSet.split(',').map(s => s.trim())
-        const hasMatch = selectedSkills.some(s => jobSkills.includes(s))
-        if (!hasMatch) return false
+        if (!selectedSkills.some(s => jobSkills.includes(s))) return false
       }
 
-      if (selectedExperience.length > 0) {
+      if (skip !== 'experience' && selectedExperience.length > 0) {
         const jobExperience = job.minimumExperience
           .split(',')
           .map(e => e.trim())
-        const hasMatch = selectedExperience.some(e => jobExperience.includes(e))
-        if (!hasMatch) return false
+        if (!selectedExperience.some(e => jobExperience.includes(e))) {
+          return false
+        }
       }
 
-      if (selectedRoles.length > 0) {
+      if (skip !== 'role' && selectedRoles.length > 0) {
         const jobRoles = job.roleType.split(',').map(r => r.trim())
-        const hasMatch = selectedRoles.some(r => jobRoles.includes(r))
-        if (!hasMatch) return false
+        if (!selectedRoles.some(r => jobRoles.includes(r))) return false
       }
 
-      if (selectedWorkLocation.length > 0) {
+      if (skip !== 'workLocation' && selectedWorkLocation.length > 0) {
         if (!selectedWorkLocation.includes(job.workLocation)) return false
       }
 
+      if (skip !== 'country' && selectedCountries.length > 0) {
+        const named = new Set(countryOptions.filter(c => c !== 'Other'))
+        const hasMatch = selectedCountries.some(c =>
+          c === 'Other'
+            ? job.countries.some(jc => !named.has(jc))
+            : jobMatchesCountry(job, c)
+        )
+        if (!hasMatch) return false
+      }
+
+      if (skip !== 'degree' && selectedDegrees.length > 0) {
+        if (!selectedDegrees.includes(job.requiredDegree)) return false
+      }
+
       return true
-    })
-  }, [
-    jobs,
-    searchQuery,
-    selectedSkills,
-    selectedExperience,
-    selectedRoles,
-    selectedWorkLocation,
-  ])
+    },
+    [
+      searchQuery,
+      selectedSkills,
+      selectedExperience,
+      selectedRoles,
+      selectedWorkLocation,
+      selectedCountries,
+      selectedDegrees,
+      countryOptions,
+    ]
+  )
+
+  const filteredJobs = useMemo(
+    () => jobs.filter(job => jobPasses(job)),
+    [jobs, jobPasses]
+  )
 
   const skillCounts = useMemo(() => {
-    return jobs.reduce(
-      (counts, job) => {
-        const skills = job.skillSet.split(',').map(s => s.trim())
-        for (const option of skillSetOptions) {
-          if (skills.includes(option)) {
-            counts[option] = (counts[option] || 0) + 1
-          }
-        }
-        return counts
-      },
-      {} as Record<string, number>
-    )
-  }, [jobs])
+    const counts: Record<string, number> = {}
+    for (const job of jobs) {
+      if (!jobPasses(job, 'skill')) continue
+      const skills = job.skillSet.split(',').map(s => s.trim())
+      for (const option of skillSetOptions) {
+        if (skills.includes(option)) counts[option] = (counts[option] || 0) + 1
+      }
+    }
+    return counts
+  }, [jobs, jobPasses])
 
   const experienceCounts = useMemo(() => {
-    return jobs.reduce(
-      (counts, job) => {
-        const jobExperience = job.minimumExperience
-          .split(',')
-          .map(e => e.trim())
-        for (const option of experienceOptions) {
-          if (jobExperience.includes(option)) {
-            counts[option] = (counts[option] || 0) + 1
-          }
+    const counts: Record<string, number> = {}
+    for (const job of jobs) {
+      if (!jobPasses(job, 'experience')) continue
+      const jobExperience = job.minimumExperience.split(',').map(e => e.trim())
+      for (const option of experienceOptions) {
+        if (jobExperience.includes(option)) {
+          counts[option] = (counts[option] || 0) + 1
         }
-        return counts
-      },
-      {} as Record<string, number>
-    )
-  }, [jobs])
+      }
+    }
+    return counts
+  }, [jobs, jobPasses])
 
   const roleCounts = useMemo(() => {
-    return jobs.reduce(
-      (counts, job) => {
-        const roles = job.roleType.split(',').map(r => r.trim())
-        for (const option of roleTypeOptions) {
-          if (roles.includes(option)) {
-            counts[option] = (counts[option] || 0) + 1
-          }
-        }
-        return counts
-      },
-      {} as Record<string, number>
-    )
-  }, [jobs])
+    const counts: Record<string, number> = {}
+    for (const job of jobs) {
+      if (!jobPasses(job, 'role')) continue
+      const roles = job.roleType.split(',').map(r => r.trim())
+      for (const option of roleTypeOptions) {
+        if (roles.includes(option)) counts[option] = (counts[option] || 0) + 1
+      }
+    }
+    return counts
+  }, [jobs, jobPasses])
 
   const workLocationCounts = useMemo(() => {
-    return jobs.reduce(
-      (counts, job) => {
-        for (const option of workLocationOptions) {
-          if (job.workLocation === option) {
-            counts[option] = (counts[option] || 0) + 1
-            break
-          }
+    const counts: Record<string, number> = {}
+    for (const job of jobs) {
+      if (!jobPasses(job, 'workLocation')) continue
+      for (const option of workLocationOptions) {
+        if (job.workLocation === option) {
+          counts[option] = (counts[option] || 0) + 1
+          break
         }
-        return counts
-      },
-      {} as Record<string, number>
-    )
-  }, [jobs])
+      }
+    }
+    return counts
+  }, [jobs, jobPasses])
+
+  const countryCounts = useMemo(() => {
+    const named = new Set(countryOptions.filter(c => c !== 'Other'))
+    const counts: Record<string, number> = {}
+    for (const job of jobs) {
+      if (!jobPasses(job, 'country')) continue
+      for (const option of countryOptions) {
+        const matches =
+          option === 'Other'
+            ? job.countries.some(c => !named.has(c))
+            : jobMatchesCountry(job, option)
+        if (matches) counts[option] = (counts[option] || 0) + 1
+      }
+    }
+    return counts
+  }, [jobs, jobPasses, countryOptions])
+
+  const degreeCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const job of jobs) {
+      if (!jobPasses(job, 'degree')) continue
+      for (const option of degreeOptions) {
+        if (job.requiredDegree === option) {
+          counts[option] = (counts[option] || 0) + 1
+          break
+        }
+      }
+    }
+    return counts
+  }, [jobs, jobPasses])
 
   const toggleFilter = (
     value: string,
@@ -195,6 +389,8 @@ export default function JobsClient({ jobs }: JobsClientProps) {
     if (selectedExperience.length) state.experience = selectedExperience
     if (selectedRoles.length) state.roleTypes = selectedRoles
     if (selectedWorkLocation.length) state.workLocation = selectedWorkLocation
+    if (selectedCountries.length) state.countries = selectedCountries
+    if (selectedDegrees.length) state.requiredDegree = selectedDegrees
     if (searchQuery) state.search = searchQuery
     setPageContext({
       page: '/jobs',
@@ -206,6 +402,8 @@ export default function JobsClient({ jobs }: JobsClientProps) {
     selectedExperience,
     selectedRoles,
     selectedWorkLocation,
+    selectedCountries,
+    selectedDegrees,
     searchQuery,
   ])
 
@@ -216,7 +414,7 @@ export default function JobsClient({ jobs }: JobsClientProps) {
           <SearchBar
             value={searchQuery}
             onChange={setSearchQuery}
-            placeholder="Search jobs by title, organization, or location"
+            placeholder="Search jobs by title, organization, location, or description"
           />
         </div>
 
@@ -262,6 +460,11 @@ export default function JobsClient({ jobs }: JobsClientProps) {
                   </p>
                 </div>
               </div>
+              {job.summary && (
+                <p className="paragraph-small padding-bottom-16px">
+                  {job.summary}
+                </p>
+              )}
               <p className="paragraph-xs-bold padding-bottom-4px color-teal-400">
                 Skill set
               </p>
@@ -284,6 +487,26 @@ export default function JobsClient({ jobs }: JobsClientProps) {
               <p className="paragraph-small padding-bottom-16px">
                 {job.minimumExperience}
               </p>
+              {job.requiredDegree && (
+                <>
+                  <p className="paragraph-xs-bold padding-bottom-4px color-teal-400">
+                    Required degree
+                  </p>
+                  <p className="paragraph-small padding-bottom-16px">
+                    {job.requiredDegree}
+                  </p>
+                </>
+              )}
+              {job.salary && (
+                <>
+                  <p className="paragraph-xs-bold padding-bottom-4px color-teal-400">
+                    Salary
+                  </p>
+                  <p className="paragraph-small padding-bottom-16px">
+                    {job.salary}
+                  </p>
+                </>
+              )}
               <p className="paragraph-xs-bold padding-bottom-4px color-teal-400">
                 Role type
               </p>
@@ -300,7 +523,11 @@ export default function JobsClient({ jobs }: JobsClientProps) {
                     Posted:{' '}
                     {(() => {
                       const d = new Date(job.datePublished + 'T00:00:00')
-                      return `${d.getDate()}/${d.getMonth() + 1}/${d.getFullYear()}`
+                      return d.toLocaleDateString('en-GB', {
+                        day: 'numeric',
+                        month: 'long',
+                        year: 'numeric',
+                      })
                     })()}
                   </span>
                 </div>
@@ -335,6 +562,14 @@ export default function JobsClient({ jobs }: JobsClientProps) {
           />
           <FilterGroup
             trackingPage="Jobs"
+            title="Required degree"
+            options={degreeOptions}
+            selected={selectedDegrees}
+            counts={degreeCounts}
+            onToggle={v => toggleFilter(v, selectedDegrees, setSelectedDegrees)}
+          />
+          <FilterGroup
+            trackingPage="Jobs"
             title="Role type"
             options={roleTypeOptions}
             selected={selectedRoles}
@@ -343,7 +578,18 @@ export default function JobsClient({ jobs }: JobsClientProps) {
           />
           <FilterGroup
             trackingPage="Jobs"
-            title="Work location"
+            title="Location"
+            options={countryOptions}
+            selected={selectedCountries}
+            counts={countryCounts}
+            onToggle={v =>
+              toggleFilter(v, selectedCountries, setSelectedCountries)
+            }
+          />
+          <FilterGroup
+            trackingPage="Jobs"
+            title="Remote or on-site"
+            trackingTitle="Work location"
             options={workLocationOptions}
             selected={selectedWorkLocation}
             counts={workLocationCounts}

--- a/src/components/FilterGroup.tsx
+++ b/src/components/FilterGroup.tsx
@@ -14,6 +14,7 @@ interface FilterGroupProps {
   /** Analytics page name (e.g. 'Jobs'). When set, turning a value on records
    *  a filter_apply event under this page and the group's title. */
   trackingPage?: string
+  trackingTitle?: string
 }
 
 export default function FilterGroup({
@@ -24,6 +25,7 @@ export default function FilterGroup({
   onToggle,
   labels,
   trackingPage,
+  trackingTitle,
 }: FilterGroupProps) {
   return (
     <div className="padding-bottom-40px">
@@ -38,7 +40,7 @@ export default function FilterGroup({
               checked={selected.includes(option)}
               onChange={() => {
                 if (trackingPage && !selected.includes(option))
-                  trackFilterApply(trackingPage, title, option)
+                  trackFilterApply(trackingPage, trackingTitle ?? title, option)
                 onToggle(option)
               }}
               className="checkbox"

--- a/src/lib/data/jobs.ts
+++ b/src/lib/data/jobs.ts
@@ -19,6 +19,8 @@ const FIELD = {
   skillSetText: 'fld7B5GTUR1kEj2wH', // Skill set text
   location: 'fldlVhQnyT9FuwXA2', // !Location (raw 80k format)
   minimumExperienceText: 'fldAskPW25nc6R4GZ', // !MinimumExperienceLevel (text)
+  requiredDegree: 'fldYWMoWdoz4ouo36', // !Required degree
+  salary: 'fldgrtlDR72nactSX', // !Salary (display)
   roleTypeText: 'fldCXYRLhvZbwf0Pp', // Role type text
   workLocation: 'fldffza4UJBfsjL3v', // Work location
   orgVacanciesPage: 'fldw33cUFdvqcOz64', // Org's vacancies page
@@ -32,23 +34,32 @@ export interface Job {
   id: string
   name: string
   description: string
+  summary: string
   organization: string
   logo: string | null
   skillSet: string
   location: string
   locations: string[]
+  countries: string[]
   minimumExperience: string
+  requiredDegree: string
+  salary: string
   roleType: string
   workLocation: string
   url: string
   datePublished: string | null
 }
 
+interface ParsedLocation {
+  label: string
+  country: string | null
+}
+
 // The 80k !Location field packs every location into one string: locations
 // are comma-separated, a period separates place from country, and places
 // that themselves contain a comma are wrapped in double quotes, e.g.
 //   San Francisco Bay Area.USA, "New York, NY.USA", Remote.Global
-export function parseJobLocations(raw: string): string[] {
+export function parseJobLocations(raw: string): ParsedLocation[] {
   const tokens: string[] = []
   let current = ''
   let inQuotes = false
@@ -64,27 +75,59 @@ export function parseJobLocations(raw: string): string[] {
   }
   tokens.push(current)
 
-  const locations: string[] = []
+  const locations: ParsedLocation[] = []
   for (const token of tokens) {
     const trimmed = token.trim()
     if (!trimmed) continue
     const dot = trimmed.lastIndexOf('.')
     if (dot === -1) {
-      locations.push(trimmed)
+      locations.push({ label: trimmed, country: null })
       continue
     }
     // A leading period is 80k's legacy remote marker; drop it.
     const place = trimmed.slice(0, dot).trim().replace(/^\.+/, '')
     const country = trimmed.slice(dot + 1).trim()
     if (!place) {
-      locations.push(country)
+      locations.push({ label: country, country })
     } else if (place === 'Remote') {
-      locations.push(`Remote (${country})`)
+      locations.push({ label: `Remote (${country})`, country })
     } else {
-      locations.push(`${place}, ${country}`)
+      locations.push({ label: `${place}, ${country}`, country })
     }
   }
   return locations
+}
+
+// One-sentence summary for the card. 80k descriptions are usually bullet
+// lists whose first bullet is a summary sentence; a minority are quoted
+// free text, where we cut at the first sentence boundary instead.
+// Most bullets open with the stock phrase "In this role, you'll …" —
+// dropping it leaves a natural sentence ("Lead …", "Build …").
+export function jobSummary(description: string): string {
+  let line = description
+    .split('\n', 1)[0]
+    .replace(/^[\s*\-–"]+/, '')
+    .replace(/["\s]+$/, '')
+    .trim()
+  const stripped = line.replace(
+    /^in this [a-z]+,\s+(?:you'll\s+|you will\s+)?/i,
+    ''
+  )
+  if (stripped !== line && stripped.length > 0) {
+    line = stripped.charAt(0).toUpperCase() + stripped.slice(1)
+  }
+  if (line.length <= 220) return line
+  const sentence = line.match(/^(.{40,220}?[.!?])(?:\s|$)/)
+  if (sentence) return sentence[1]
+  return line.slice(0, 200).trimEnd() + '…'
+}
+
+// 80k writes "Not Found" when a posting lists no salary; treat it as empty.
+// Ranges arrive hyphenated ("$100,000 - $150,000") and are shown with an
+// en dash.
+export function jobSalary(raw: string): string {
+  if (!raw || raw.toLowerCase() === 'not found') return ''
+  return raw.replace(/\s+-\s+/g, ' – ')
 }
 
 export async function getJobs(): Promise<Job[]> {
@@ -106,18 +149,34 @@ export async function getJobs(): Promise<Job[]> {
     const logoRaw = f[FIELD.orgLogo]
     const logo = fieldString(logoRaw) ?? fieldAttachmentUrl(logoRaw)
 
-    const locations = parseJobLocations(fieldText(f[FIELD.location]))
+    const parsedLocations = parseJobLocations(fieldText(f[FIELD.location]))
+    const locations = parsedLocations.map(l => l.label)
+    // "Global" marks worldwide-remote roles, not a country; the Work
+    // location filter covers those.
+    const countries = [
+      ...new Set(
+        parsedLocations
+          .map(l => l.country)
+          .filter((c): c is string => c !== null && c !== 'Global')
+      ),
+    ]
+
+    const description = fieldString(f[FIELD.description]) || ''
 
     results.push({
       id: record.id,
       name,
-      description: fieldString(f[FIELD.description]) || '',
+      description,
+      summary: jobSummary(description),
       organization: fieldString(f[FIELD.org]) || '',
       logo,
       skillSet: fieldText(f[FIELD.skillSetText]),
       location: locations.join('; '),
       locations,
+      countries,
       minimumExperience: fieldText(f[FIELD.minimumExperienceText]),
+      requiredDegree: fieldString(f[FIELD.requiredDegree]) || '',
+      salary: jobSalary(fieldString(f[FIELD.salary]) || ''),
       roleType: fieldText(f[FIELD.roleTypeText]),
       workLocation: fieldText(f[FIELD.workLocation]),
       url:


### PR DESCRIPTION
- One-sentence summary under each job title, taken from the 80k description (the stock "In this role, you'll" opener is stripped and the next word capitalized)
- Salary row whenever 80k has a figure (about two thirds of jobs); their "Not Found" placeholder is hidden
- Required degree row on every card, plus a Required degree filter (Undergraduate or less / Master's / Doctoral)
- New Location filter listing countries with five or more jobs plus an "Other" option; region-wide listings ("Europe" today, other continents automatically if 80k ever uses them) match their member countries, e.g. ticking France includes "Remote (Europe)" roles
- All sidebar counts are live: each group's numbers reflect the search box and every other active filter, ignoring the group's own ticks
- "Work location" renamed on screen to "Remote or on-site"; a new `trackingTitle` prop on FilterGroup keeps sending "Work location" to analytics so the dashboard history stays in one series
- The /jobs search bar also matches description text (site-wide search unchanged)
- Posted date now reads "21 August 2026" instead of "21/8/2026"

🤖 Generated with [Claude Code](https://claude.com/claude-code)