### PR TITLE
Preview mode: live-ticking build age and stable map zoom

### DIFF
--- a/src/app/map/D3Map.tsx
+++ b/src/app/map/D3Map.tsx
@@ -82,6 +82,11 @@ export default function D3Map({ orgs }: D3MapProps) {
     zoomOut: () => {},
     reset: () => {},
   })
+  // The d3 pipeline below tears down and rebuilds whenever `orgs` changes
+  // identity — which preview mode's auto-refresh does on every data change
+  // and tab focus. Keeping the last zoom transform here lets the rebuild
+  // restore the viewport instead of jumping back to the zoomed-out default.
+  const savedTransformRef = useRef<d3.ZoomTransform | null>(null)
 
   useEffect(() => {
     if (!containerRef.current || orgs.length === 0) return
@@ -164,12 +169,17 @@ export default function D3Map({ orgs }: D3MapProps) {
           'transform',
           `translate(${newX}, ${newY}) scale(${event.transform.k})`
         )
+        savedTransformRef.current = event.transform
       })
       .on('end', () => {
         isZooming = false
       })
 
     svg.call(zoom)
+
+    if (savedTransformRef.current) {
+      svg.call(zoom.transform, savedTransformRef.current)
+    }
 
     // Prevent wheel events over the map from zooming the whole page
     // (once D3's zoom hits its scaleExtent limit, the browser would

--- a/src/components/ExitPreviewButton.tsx
+++ b/src/components/ExitPreviewButton.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { usePathname, useRouter } from 'next/navigation'
-import { useState, useTransition } from 'react'
+import { useEffect, useState, useTransition } from 'react'
+import { formatTimeAgo } from '@/lib/format-date'
 import styles from './PreviewBanner.module.css'
 
 /** The preview-side switch pill: shows that this browser is in preview mode
@@ -9,14 +10,25 @@ import styles from './PreviewBanner.module.css'
  *  /admin/preview reports the mode itself, and the other admin screens
  *  aren't part of the site being previewed. */
 export default function ExitPreviewButton({
-  rebuilt,
+  buildTime,
 }: {
-  rebuilt: string | null
+  buildTime: string | null
 }) {
   const pathname = usePathname()
   const router = useRouter()
   const [busy, setBusy] = useState(false)
   const [refreshing, startTransition] = useTransition()
+  const [rebuilt, setRebuilt] = useState(() =>
+    buildTime ? formatTimeAgo(buildTime, new Date()) : null
+  )
+
+  useEffect(() => {
+    if (!buildTime) return
+    const tick = () => setRebuilt(formatTimeAgo(buildTime, new Date()))
+    tick()
+    const id = setInterval(tick, 30_000)
+    return () => clearInterval(id)
+  }, [buildTime])
 
   if (pathname.startsWith('/admin')) return null
 
@@ -54,7 +66,12 @@ export default function ExitPreviewButton({
         <>
           Preview
           {rebuilt && (
-            <span className={styles.buildNote}> · public built {rebuilt}</span>
+            // The age is recomputed on the client clock every 30 s, so the
+            // server-rendered text can be a minute behind at hydration.
+            <span className={styles.buildNote} suppressHydrationWarning>
+              {' '}
+              · public built {rebuilt}
+            </span>
           )}
         </>
       )}

--- a/src/components/PreviewBanner.tsx
+++ b/src/components/PreviewBanner.tsx
@@ -1,5 +1,4 @@
 import { isPreviewRequest } from '@/lib/preview'
-import { formatTimeAgo } from '@/lib/format-date'
 import EnterPreviewButton from './EnterPreviewButton'
 import ExitPreviewButton from './ExitPreviewButton'
 import PreviewAutoRefresh from './PreviewAutoRefresh'
@@ -17,12 +16,11 @@ export default async function PreviewBanner() {
   // BUILD_TIME (next.config.ts) is when the running deployment was built =
   // the newest data a normal visitor can be seeing. A large age here while
   // edits are pending means the rebuild pipeline is stalled.
-  const buildTime = process.env.BUILD_TIME
-  const rebuilt = buildTime ? formatTimeAgo(buildTime, new Date()) : null
+  const buildTime = process.env.BUILD_TIME ?? null
 
   return (
     <>
-      <ExitPreviewButton rebuilt={rebuilt} />
+      <ExitPreviewButton buildTime={buildTime} />
       <PreviewAutoRefresh />
     </>
   )


### PR DESCRIPTION
- The preview pill's "public built X ago" now recalculates itself every 30 seconds in the browser, so the age stays current without a refresh.
- The Field map keeps its zoom and position across preview auto-refreshes: the d3 pipeline rebuilds whenever the page data refreshes, so the current zoom transform is saved and re-applied after each rebuild. Previously every refresh (data change or tab focus) snapped the map back to the zoomed-out default.
- No change for normal visitors — both fixes only affect behavior already gated to preview mode, except the zoom restore, which is inert outside preview since the map otherwise rebuilds only on a fresh visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)