### PR TITLE
Live filter counts on every resource page

### DIFF
--- a/src/app/advisors/AdvisorsClient.tsx
+++ b/src/app/advisors/AdvisorsClient.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useState, useMemo, useRef, useLayoutEffect } from 'react'
+import { useState, useMemo, useRef, useLayoutEffect, useCallback } from 'react'
 import Image from 'next/image'
 import FilterGroup from '@/components/FilterGroup'
 import FilterSidebar from '@/components/FilterSidebar'
 import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { Advisor } from '@/lib/data/advisors'
+import { filterItems, optionCounts } from '@/lib/filter-counts'
 import { trackListingClick } from '@/lib/analytics'
 import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
@@ -27,59 +28,56 @@ export default function AdvisorsClient({ advisors }: AdvisorsClientProps) {
   // dashboard can tie clicks to page position even after later reordering.
   const placements = useMemo(() => placementsById(advisors), [advisors])
 
-  const filteredAdvisors = useMemo(() => {
-    return advisors.filter(advisor => {
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase()
-        if (
-          !advisor.name.toLowerCase().includes(query) &&
-          !advisor.description.toLowerCase().includes(query)
-        ) {
-          return false
-        }
-      }
+  const searchPass = useCallback(
+    (advisor: Advisor) => {
+      if (!searchQuery) return true
+      const query = searchQuery.toLowerCase()
+      return (
+        advisor.name.toLowerCase().includes(query) ||
+        advisor.description.toLowerCase().includes(query)
+      )
+    },
+    [searchQuery]
+  )
 
-      if (selectedFocus.length > 0) {
-        if (!selectedFocus.includes(advisor.focus)) return false
-      }
-
-      if (selectedStatus.length > 0) {
-        if (!selectedStatus.includes(advisor.status)) return false
-      }
-
-      return true
-    })
-  }, [advisors, searchQuery, selectedFocus, selectedStatus])
-
-  const focusCounts = useMemo(() => {
-    return advisors.reduce(
-      (counts, advisor) => {
-        for (const option of focusOptions) {
-          if (advisor.focus === option) {
-            counts[option] = (counts[option] || 0) + 1
-            break
-          }
-        }
-        return counts
+  const groups = useMemo(
+    () => ({
+      focus: {
+        selected: selectedFocus,
+        matches: (advisor: Advisor, value: string) => advisor.focus === value,
       },
-      {} as Record<string, number>
-    )
-  }, [advisors])
-
-  const statusCounts = useMemo(() => {
-    return advisors.reduce(
-      (counts, advisor) => {
-        for (const option of statusOptions) {
-          if (advisor.status === option) {
-            counts[option] = (counts[option] || 0) + 1
-            break
-          }
-        }
-        return counts
+      status: {
+        selected: selectedStatus,
+        matches: (advisor: Advisor, value: string) => advisor.status === value,
       },
-      {} as Record<string, number>
-    )
-  }, [advisors])
+    }),
+    [selectedFocus, selectedStatus]
+  )
+
+  const filteredAdvisors = useMemo(
+    () => filterItems(advisors, searchPass, groups),
+    [advisors, searchPass, groups]
+  )
+
+  const focusCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(advisors, searchPass, groups, 'focus'),
+        focusOptions,
+        groups.focus.matches
+      ),
+    [advisors, searchPass, groups]
+  )
+
+  const statusCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(advisors, searchPass, groups, 'status'),
+        statusOptions,
+        groups.status.matches
+      ),
+    [advisors, searchPass, groups]
+  )
 
   const savedScrollY = useRef<number | null>(null)
 

--- a/src/app/communities/CommunitiesClient.tsx
+++ b/src/app/communities/CommunitiesClient.tsx
@@ -1,6 +1,13 @@
 'use client'
 
-import { useState, useMemo, useRef, useLayoutEffect, useEffect } from 'react'
+import {
+  useState,
+  useMemo,
+  useRef,
+  useLayoutEffect,
+  useEffect,
+  useCallback,
+} from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import FilterGroup from '@/components/FilterGroup'
@@ -8,6 +15,7 @@ import FilterSidebar from '@/components/FilterSidebar'
 import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { Community } from '@/lib/data/communities'
+import { filterItems, optionCounts } from '@/lib/filter-counts'
 import { trackListingClick } from '@/lib/analytics'
 import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
@@ -45,80 +53,77 @@ export default function CommunitiesClient({
   // dashboard can tie clicks to page position even after later reordering.
   const placements = useMemo(() => placementsById(communities), [communities])
 
-  const filteredCommunities = useMemo(() => {
-    return communities.filter(community => {
-      // Text search
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase()
-        const matchesSearch =
-          community.name.toLowerCase().includes(query) ||
-          community.description.toLowerCase().includes(query) ||
-          (community.location &&
-            community.location.toLowerCase().includes(query))
-        if (!matchesSearch) return false
-      }
-
-      // Type filter
-      if (typeFilters.length > 0) {
-        const hasMatchingType = community.type.some(t =>
-          typeFilters.includes(t)
+  const searchPass = useCallback(
+    (community: Community) => {
+      if (!searchQuery) return true
+      const query = searchQuery.toLowerCase()
+      return (
+        community.name.toLowerCase().includes(query) ||
+        community.description.toLowerCase().includes(query) ||
+        Boolean(
+          community.location && community.location.toLowerCase().includes(query)
         )
-        if (!hasMatchingType) return false
-      }
+      )
+    },
+    [searchQuery]
+  )
 
-      // Platform filter
-      if (platformFilters.length > 0) {
-        const hasMatchingPlatform = community.platform.some(p =>
-          platformFilters.includes(p)
-        )
-        if (!hasMatchingPlatform) return false
-      }
+  const groups = useMemo(
+    () => ({
+      type: {
+        selected: typeFilters,
+        matches: (community: Community, value: string) =>
+          community.type.includes(value),
+      },
+      platform: {
+        selected: platformFilters,
+        matches: (community: Community, value: string) =>
+          community.platform.includes(value),
+      },
+      activity: {
+        selected: activityFilters,
+        matches: (community: Community, value: string) =>
+          community.activityLevel === value,
+      },
+      focus: {
+        selected: focusFilters,
+        matches: (community: Community, value: string) =>
+          community.focus === value,
+      },
+    }),
+    [typeFilters, platformFilters, activityFilters, focusFilters]
+  )
 
-      // Activity level filter
-      if (activityFilters.length > 0) {
-        if (!activityFilters.includes(community.activityLevel)) return false
-      }
+  const filteredCommunities = useMemo(
+    () => filterItems(communities, searchPass, groups),
+    [communities, searchPass, groups]
+  )
 
-      // Focus filter
-      if (focusFilters.length > 0) {
-        if (!focusFilters.includes(community.focus)) return false
-      }
-
-      return true
-    })
-  }, [
-    communities,
-    searchQuery,
-    typeFilters,
-    platformFilters,
-    activityFilters,
-    focusFilters,
-  ])
-
-  const filterCounts = useMemo(() => {
-    const counts = {
-      type: {} as Record<string, number>,
-      platform: {} as Record<string, number>,
-      activity: {} as Record<string, number>,
-      focus: {} as Record<string, number>,
-    }
-    for (const community of communities) {
-      for (const t of community.type) {
-        counts.type[t] = (counts.type[t] || 0) + 1
-      }
-      for (const p of community.platform) {
-        counts.platform[p] = (counts.platform[p] || 0) + 1
-      }
-      if (community.activityLevel) {
-        counts.activity[community.activityLevel] =
-          (counts.activity[community.activityLevel] || 0) + 1
-      }
-      if (community.focus) {
-        counts.focus[community.focus] = (counts.focus[community.focus] || 0) + 1
-      }
-    }
-    return counts
-  }, [communities])
+  const filterCounts = useMemo(
+    () => ({
+      type: optionCounts(
+        filterItems(communities, searchPass, groups, 'type'),
+        typeOptions,
+        groups.type.matches
+      ),
+      platform: optionCounts(
+        filterItems(communities, searchPass, groups, 'platform'),
+        platformOptions,
+        groups.platform.matches
+      ),
+      activity: optionCounts(
+        filterItems(communities, searchPass, groups, 'activity'),
+        activityOptions,
+        groups.activity.matches
+      ),
+      focus: optionCounts(
+        filterItems(communities, searchPass, groups, 'focus'),
+        focusOptions,
+        groups.focus.matches
+      ),
+    }),
+    [communities, searchPass, groups]
+  )
 
   const savedScrollY = useRef<number | null>(null)
 

--- a/src/app/founders/FoundersClient.tsx
+++ b/src/app/founders/FoundersClient.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useState, useMemo, useRef, useLayoutEffect } from 'react'
+import { useState, useMemo, useRef, useLayoutEffect, useCallback } from 'react'
 import Image from 'next/image'
 import FilterGroup from '@/components/FilterGroup'
 import FilterSidebar from '@/components/FilterSidebar'
 import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { FounderResource } from '@/lib/data/founders'
+import { filterItems, optionCounts } from '@/lib/filter-counts'
 import { trackListingClick } from '@/lib/analytics'
 import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
@@ -30,42 +31,46 @@ export default function FoundersClient({ resources }: FoundersClientProps) {
   // dashboard can tie clicks to page position even after later reordering.
   const placements = useMemo(() => placementsById(resources), [resources])
 
-  const filteredResources = useMemo(() => {
-    return resources.filter(resource => {
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase()
-        if (
-          !resource.name.toLowerCase().includes(query) &&
-          !resource.description.toLowerCase().includes(query)
-        ) {
-          return false
-        }
-      }
+  const searchPass = useCallback(
+    (resource: FounderResource) => {
+      if (!searchQuery) return true
+      const query = searchQuery.toLowerCase()
+      return (
+        resource.name.toLowerCase().includes(query) ||
+        resource.description.toLowerCase().includes(query)
+      )
+    },
+    [searchQuery]
+  )
 
-      if (selectedTypes.length > 0) {
-        const resourceTypes = resource.type.split(',').map(t => t.trim())
-        const hasMatch = selectedTypes.some(t => resourceTypes.includes(t))
-        if (!hasMatch) return false
-      }
-
-      return true
-    })
-  }, [resources, searchQuery, selectedTypes])
-
-  const typeCounts = useMemo(() => {
-    return resources.reduce(
-      (counts, resource) => {
-        const resourceTypes = resource.type.split(',').map(t => t.trim())
-        for (const option of typeOptions) {
-          if (resourceTypes.includes(option)) {
-            counts[option] = (counts[option] || 0) + 1
-          }
-        }
-        return counts
+  const groups = useMemo(
+    () => ({
+      type: {
+        selected: selectedTypes,
+        matches: (resource: FounderResource, value: string) =>
+          resource.type
+            .split(',')
+            .map(t => t.trim())
+            .includes(value),
       },
-      {} as Record<string, number>
-    )
-  }, [resources])
+    }),
+    [selectedTypes]
+  )
+
+  const filteredResources = useMemo(
+    () => filterItems(resources, searchPass, groups),
+    [resources, searchPass, groups]
+  )
+
+  const typeCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(resources, searchPass, groups, 'type'),
+        typeOptions,
+        groups.type.matches
+      ),
+    [resources, searchPass, groups]
+  )
 
   const savedScrollY = useRef<number | null>(null)
 

--- a/src/app/funding/FundingClient.tsx
+++ b/src/app/funding/FundingClient.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useState, useMemo, useRef, useLayoutEffect } from 'react'
+import { useState, useMemo, useRef, useLayoutEffect, useCallback } from 'react'
 import Image from 'next/image'
 import FilterGroup from '@/components/FilterGroup'
 import FilterSidebar from '@/components/FilterSidebar'
 import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { Funder } from '@/lib/data/funding'
+import { filterItems, optionCounts } from '@/lib/filter-counts'
 import { trackListingClick } from '@/lib/analytics'
 import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
@@ -28,66 +29,64 @@ export default function FundingClient({ funders }: FundingClientProps) {
   // tagged with the rank Bryce set — not its position within an active filter.
   const placements = useMemo(() => placementsById(funders), [funders])
 
-  const filteredFunders = useMemo(() => {
-    return funders.filter(funder => {
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase()
-        if (
-          !funder.name.toLowerCase().includes(query) &&
-          !funder.description.toLowerCase().includes(query)
-        ) {
-          return false
-        }
-      }
+  const searchPass = useCallback(
+    (funder: Funder) => {
+      if (!searchQuery) return true
+      const query = searchQuery.toLowerCase()
+      return (
+        funder.name.toLowerCase().includes(query) ||
+        funder.description.toLowerCase().includes(query)
+      )
+    },
+    [searchQuery]
+  )
 
-      if (selectedAccepting.length > 0) {
-        // Airtable values are prefixed: "Yes – rolling basis", "Yes – closes …", or "No".
-        // Match on the prefix so the Yes/No filter catches all variants.
-        const accepting = funder.acceptingApplications || ''
-        const hasMatch = selectedAccepting.some(a => accepting.startsWith(a))
-        if (!hasMatch) return false
-      }
-
-      if (selectedTypes.length > 0) {
-        const funderTypes = (funder.type || '').split(',').map(t => t.trim())
-        const hasMatch = selectedTypes.some(t => funderTypes.includes(t))
-        if (!hasMatch) return false
-      }
-
-      return true
-    })
-  }, [funders, searchQuery, selectedAccepting, selectedTypes])
-
-  const acceptingCounts = useMemo(() => {
-    return funders.reduce(
-      (counts, funder) => {
-        const accepting = funder.acceptingApplications || ''
-        for (const option of acceptingOptions) {
-          if (accepting.startsWith(option)) {
-            counts[option] = (counts[option] || 0) + 1
-            break
-          }
-        }
-        return counts
+  const groups = useMemo(
+    () => ({
+      accepting: {
+        selected: selectedAccepting,
+        // Airtable values are prefixed: "Yes – rolling basis", "Yes –
+        // closes …", or "No". Match on the prefix so the Yes/No filter
+        // catches all variants.
+        matches: (funder: Funder, value: string) =>
+          (funder.acceptingApplications || '').startsWith(value),
       },
-      {} as Record<string, number>
-    )
-  }, [funders])
-
-  const typeCounts = useMemo(() => {
-    return funders.reduce(
-      (counts, funder) => {
-        const types = (funder.type || '').split(',').map(t => t.trim())
-        for (const option of typeOptions) {
-          if (types.includes(option)) {
-            counts[option] = (counts[option] || 0) + 1
-          }
-        }
-        return counts
+      type: {
+        selected: selectedTypes,
+        matches: (funder: Funder, value: string) =>
+          (funder.type || '')
+            .split(',')
+            .map(t => t.trim())
+            .includes(value),
       },
-      {} as Record<string, number>
-    )
-  }, [funders])
+    }),
+    [selectedAccepting, selectedTypes]
+  )
+
+  const filteredFunders = useMemo(
+    () => filterItems(funders, searchPass, groups),
+    [funders, searchPass, groups]
+  )
+
+  const acceptingCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(funders, searchPass, groups, 'accepting'),
+        acceptingOptions,
+        groups.accepting.matches
+      ),
+    [funders, searchPass, groups]
+  )
+
+  const typeCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(funders, searchPass, groups, 'type'),
+        typeOptions,
+        groups.type.matches
+      ),
+    [funders, searchPass, groups]
+  )
 
   const savedScrollY = useRef<number | null>(null)
 

--- a/src/app/jobs/JobsClient.tsx
+++ b/src/app/jobs/JobsClient.tsx
@@ -17,6 +17,7 @@ import { trackListingClick } from '@/lib/analytics'
 import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
 import { setPageContext } from '@/lib/assistant/page-context'
+import { filterItems, optionCounts } from '@/lib/filter-counts'
 
 interface JobsClientProps {
   jobs: Job[]
@@ -207,161 +208,137 @@ export default function JobsClient({ jobs }: JobsClientProps) {
     return options
   }, [jobs])
 
-  // One predicate drives both the visible list and the sidebar counts.
-  // Passing `skip` leaves one filter group out, so each group's counts
-  // reflect the search box and every OTHER group — "what would I get if
-  // I also ticked this".
-  const jobPasses = useCallback(
-    (job: Job, skip?: string): boolean => {
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase()
-        if (
-          !job.name.toLowerCase().includes(query) &&
-          !job.organization.toLowerCase().includes(query) &&
-          !job.location.toLowerCase().includes(query) &&
-          !job.description.toLowerCase().includes(query)
-        ) {
-          return false
-        }
-      }
-
-      if (skip !== 'skill' && selectedSkills.length > 0) {
-        const jobSkills = job.skillSet.split(',').map(s => s.trim())
-        if (!selectedSkills.some(s => jobSkills.includes(s))) return false
-      }
-
-      if (skip !== 'experience' && selectedExperience.length > 0) {
-        const jobExperience = job.minimumExperience
-          .split(',')
-          .map(e => e.trim())
-        if (!selectedExperience.some(e => jobExperience.includes(e))) {
-          return false
-        }
-      }
-
-      if (skip !== 'role' && selectedRoles.length > 0) {
-        const jobRoles = job.roleType.split(',').map(r => r.trim())
-        if (!selectedRoles.some(r => jobRoles.includes(r))) return false
-      }
-
-      if (skip !== 'workLocation' && selectedWorkLocation.length > 0) {
-        if (!selectedWorkLocation.includes(job.workLocation)) return false
-      }
-
-      if (skip !== 'country' && selectedCountries.length > 0) {
-        const named = new Set(countryOptions.filter(c => c !== 'Other'))
-        const hasMatch = selectedCountries.some(c =>
-          c === 'Other'
-            ? job.countries.some(jc => !named.has(jc))
-            : jobMatchesCountry(job, c)
-        )
-        if (!hasMatch) return false
-      }
-
-      if (skip !== 'degree' && selectedDegrees.length > 0) {
-        if (!selectedDegrees.includes(job.requiredDegree)) return false
-      }
-
-      return true
+  const searchPass = useCallback(
+    (job: Job) => {
+      if (!searchQuery) return true
+      const query = searchQuery.toLowerCase()
+      return (
+        job.name.toLowerCase().includes(query) ||
+        job.organization.toLowerCase().includes(query) ||
+        job.location.toLowerCase().includes(query) ||
+        job.description.toLowerCase().includes(query)
+      )
     },
-    [
-      searchQuery,
-      selectedSkills,
-      selectedExperience,
-      selectedRoles,
-      selectedWorkLocation,
-      selectedCountries,
-      selectedDegrees,
-      countryOptions,
-    ]
+    [searchQuery]
   )
+
+  const groups = useMemo(() => {
+    const named = new Set(countryOptions.filter(c => c !== 'Other'))
+    return {
+      skill: {
+        selected: selectedSkills,
+        matches: (job: Job, value: string) =>
+          job.skillSet
+            .split(',')
+            .map(s => s.trim())
+            .includes(value),
+      },
+      experience: {
+        selected: selectedExperience,
+        matches: (job: Job, value: string) =>
+          job.minimumExperience
+            .split(',')
+            .map(e => e.trim())
+            .includes(value),
+      },
+      role: {
+        selected: selectedRoles,
+        matches: (job: Job, value: string) =>
+          job.roleType
+            .split(',')
+            .map(r => r.trim())
+            .includes(value),
+      },
+      workLocation: {
+        selected: selectedWorkLocation,
+        matches: (job: Job, value: string) => job.workLocation === value,
+      },
+      country: {
+        selected: selectedCountries,
+        matches: (job: Job, value: string) =>
+          value === 'Other'
+            ? job.countries.some(c => !named.has(c))
+            : jobMatchesCountry(job, value),
+      },
+      degree: {
+        selected: selectedDegrees,
+        matches: (job: Job, value: string) => job.requiredDegree === value,
+      },
+    }
+  }, [
+    selectedSkills,
+    selectedExperience,
+    selectedRoles,
+    selectedWorkLocation,
+    selectedCountries,
+    selectedDegrees,
+    countryOptions,
+  ])
 
   const filteredJobs = useMemo(
-    () => jobs.filter(job => jobPasses(job)),
-    [jobs, jobPasses]
+    () => filterItems(jobs, searchPass, groups),
+    [jobs, searchPass, groups]
   )
 
-  const skillCounts = useMemo(() => {
-    const counts: Record<string, number> = {}
-    for (const job of jobs) {
-      if (!jobPasses(job, 'skill')) continue
-      const skills = job.skillSet.split(',').map(s => s.trim())
-      for (const option of skillSetOptions) {
-        if (skills.includes(option)) counts[option] = (counts[option] || 0) + 1
-      }
-    }
-    return counts
-  }, [jobs, jobPasses])
+  const skillCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(jobs, searchPass, groups, 'skill'),
+        skillSetOptions,
+        groups.skill.matches
+      ),
+    [jobs, searchPass, groups]
+  )
 
-  const experienceCounts = useMemo(() => {
-    const counts: Record<string, number> = {}
-    for (const job of jobs) {
-      if (!jobPasses(job, 'experience')) continue
-      const jobExperience = job.minimumExperience.split(',').map(e => e.trim())
-      for (const option of experienceOptions) {
-        if (jobExperience.includes(option)) {
-          counts[option] = (counts[option] || 0) + 1
-        }
-      }
-    }
-    return counts
-  }, [jobs, jobPasses])
+  const experienceCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(jobs, searchPass, groups, 'experience'),
+        experienceOptions,
+        groups.experience.matches
+      ),
+    [jobs, searchPass, groups]
+  )
 
-  const roleCounts = useMemo(() => {
-    const counts: Record<string, number> = {}
-    for (const job of jobs) {
-      if (!jobPasses(job, 'role')) continue
-      const roles = job.roleType.split(',').map(r => r.trim())
-      for (const option of roleTypeOptions) {
-        if (roles.includes(option)) counts[option] = (counts[option] || 0) + 1
-      }
-    }
-    return counts
-  }, [jobs, jobPasses])
+  const roleCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(jobs, searchPass, groups, 'role'),
+        roleTypeOptions,
+        groups.role.matches
+      ),
+    [jobs, searchPass, groups]
+  )
 
-  const workLocationCounts = useMemo(() => {
-    const counts: Record<string, number> = {}
-    for (const job of jobs) {
-      if (!jobPasses(job, 'workLocation')) continue
-      for (const option of workLocationOptions) {
-        if (job.workLocation === option) {
-          counts[option] = (counts[option] || 0) + 1
-          break
-        }
-      }
-    }
-    return counts
-  }, [jobs, jobPasses])
+  const workLocationCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(jobs, searchPass, groups, 'workLocation'),
+        workLocationOptions,
+        groups.workLocation.matches
+      ),
+    [jobs, searchPass, groups]
+  )
 
-  const countryCounts = useMemo(() => {
-    const named = new Set(countryOptions.filter(c => c !== 'Other'))
-    const counts: Record<string, number> = {}
-    for (const job of jobs) {
-      if (!jobPasses(job, 'country')) continue
-      for (const option of countryOptions) {
-        const matches =
-          option === 'Other'
-            ? job.countries.some(c => !named.has(c))
-            : jobMatchesCountry(job, option)
-        if (matches) counts[option] = (counts[option] || 0) + 1
-      }
-    }
-    return counts
-  }, [jobs, jobPasses, countryOptions])
+  const countryCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(jobs, searchPass, groups, 'country'),
+        countryOptions,
+        groups.country.matches
+      ),
+    [jobs, searchPass, groups, countryOptions]
+  )
 
-  const degreeCounts = useMemo(() => {
-    const counts: Record<string, number> = {}
-    for (const job of jobs) {
-      if (!jobPasses(job, 'degree')) continue
-      for (const option of degreeOptions) {
-        if (job.requiredDegree === option) {
-          counts[option] = (counts[option] || 0) + 1
-          break
-        }
-      }
-    }
-    return counts
-  }, [jobs, jobPasses])
+  const degreeCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(jobs, searchPass, groups, 'degree'),
+        degreeOptions,
+        groups.degree.matches
+      ),
+    [jobs, searchPass, groups]
+  )
 
   const toggleFilter = (
     value: string,

--- a/src/app/map/MapClient.tsx
+++ b/src/app/map/MapClient.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
-import { useState, useMemo, useRef, useLayoutEffect } from 'react'
+import { useState, useMemo, useRef, useLayoutEffect, useCallback } from 'react'
 import FilterGroup from '@/components/FilterGroup'
 import FilterSidebar from '@/components/FilterSidebar'
 import ContributeButtons from '@/components/ContributeButtons'
@@ -11,6 +11,7 @@ import SearchBar from '@/components/SearchBar'
 import { trackListingClick } from '@/lib/analytics'
 import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
+import { filterItems, optionCounts } from '@/lib/filter-counts'
 import styles from './page.module.css'
 
 const D3Map = dynamic(() => import('./D3Map'), {
@@ -125,65 +126,72 @@ export default function MapClient({
     requestAnimationFrame(step)
   }
 
-  const filteredOrgs = useMemo(() => {
-    return orgs.filter(org => {
+  // Magic-map decorations are never listed; search applies on top.
+  const basePass = useCallback(
+    (org: MapOrg) => {
       if (org.isMagic) return false
+      if (!searchQuery) return true
+      const query = searchQuery.toLowerCase()
+      return (
+        org.title.toLowerCase().includes(query) ||
+        org.description.toLowerCase().includes(query)
+      )
+    },
+    [searchQuery]
+  )
 
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase()
-        if (
-          !org.title.toLowerCase().includes(query) &&
-          !org.description.toLowerCase().includes(query)
-        ) {
-          return false
-        }
-      }
+  const groups = useMemo(
+    () => ({
+      category: {
+        selected: selectedCategories,
+        matches: (org: MapOrg, value: string) =>
+          org.category
+            .split(',')
+            .map(c => c.trim())
+            .includes(value),
+      },
+      status: {
+        selected: [
+          ...(showActive ? ['Active'] : []),
+          ...(showInactive ? ['No longer active'] : []),
+        ],
+        matches: (org: MapOrg, value: string) =>
+          value === 'Active'
+            ? org.status === 'Active'
+            : org.status !== 'Active',
+      },
+    }),
+    [selectedCategories, showActive, showInactive]
+  )
 
-      if (selectedCategories.length > 0) {
-        const orgCategories = org.category.split(',').map(c => c.trim())
-        const hasMatchingCategory = selectedCategories.some(cat =>
-          orgCategories.includes(cat)
-        )
-        if (!hasMatchingCategory) return false
-      }
-
-      if (showActive || showInactive) {
-        const isActive = org.status === 'Active'
-        if (isActive && !showActive) return false
-        if (!isActive && !showInactive) return false
-      }
-
-      return true
-    })
-  }, [orgs, searchQuery, selectedCategories, showActive, showInactive])
+  const filteredOrgs = useMemo(
+    () => filterItems(orgs, basePass, groups),
+    [orgs, basePass, groups]
+  )
 
   const mapOrgs = useMemo(() => {
     return orgs.filter(org => org.x !== null && org.y !== null)
   }, [orgs])
 
-  const categoryCounts = useMemo(() => {
-    return orgs.reduce(
-      (counts, org) => {
-        if (org.isMagic) return counts
-        const orgCategories = org.category.split(',').map(c => c.trim())
-        for (const category of categories) {
-          if (orgCategories.includes(category)) {
-            counts[category] = (counts[category] || 0) + 1
-          }
-        }
-        return counts
-      },
-      {} as Record<string, number>
-    )
-  }, [orgs])
+  const categoryCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(orgs, basePass, groups, 'category'),
+        categories,
+        groups.category.matches
+      ),
+    [orgs, basePass, groups]
+  )
 
-  const activeCount = useMemo(() => {
-    return orgs.filter(org => !org.isMagic && org.status === 'Active').length
-  }, [orgs])
-
-  const inactiveCount = useMemo(() => {
-    return orgs.filter(org => !org.isMagic && org.status !== 'Active').length
-  }, [orgs])
+  const statusCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(orgs, basePass, groups, 'status'),
+        ['Active', 'No longer active'],
+        groups.status.matches
+      ),
+    [orgs, basePass, groups]
+  )
 
   const savedScrollY = useRef<number | null>(null)
 
@@ -317,10 +325,7 @@ export default function MapClient({
                   ...(showActive ? ['Active'] : []),
                   ...(showInactive ? ['No longer active'] : []),
                 ]}
-                counts={{
-                  Active: activeCount,
-                  'No longer active': inactiveCount,
-                }}
+                counts={statusCounts}
                 onToggle={status => {
                   savedScrollY.current = window.scrollY
                   if (status === 'Active') setShowActive(!showActive)

--- a/src/app/media-channels/MediaChannelsClient.tsx
+++ b/src/app/media-channels/MediaChannelsClient.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useState, useMemo, useRef, useLayoutEffect } from 'react'
+import { useState, useMemo, useRef, useLayoutEffect, useCallback } from 'react'
 import Image from 'next/image'
 import FilterGroup from '@/components/FilterGroup'
 import FilterSidebar from '@/components/FilterSidebar'
 import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { MediaChannel } from '@/lib/data/media-channels'
+import { filterItems, optionCounts } from '@/lib/filter-counts'
 import { trackListingClick } from '@/lib/analytics'
 import { withUtm } from '@/lib/utm'
 import { placementsById } from '@/lib/placements'
@@ -36,42 +37,46 @@ export default function MediaChannelsClient({
   // dashboard can tie clicks to page position even after later reordering.
   const placements = useMemo(() => placementsById(channels), [channels])
 
-  const filteredChannels = useMemo(() => {
-    return channels.filter(channel => {
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase()
-        if (
-          !channel.name.toLowerCase().includes(query) &&
-          !channel.description.toLowerCase().includes(query)
-        ) {
-          return false
-        }
-      }
+  const searchPass = useCallback(
+    (channel: MediaChannel) => {
+      if (!searchQuery) return true
+      const query = searchQuery.toLowerCase()
+      return (
+        channel.name.toLowerCase().includes(query) ||
+        channel.description.toLowerCase().includes(query)
+      )
+    },
+    [searchQuery]
+  )
 
-      if (selectedTypes.length > 0) {
-        const channelTypes = channel.type.split(',').map(t => t.trim())
-        const hasMatch = selectedTypes.some(t => channelTypes.includes(t))
-        if (!hasMatch) return false
-      }
-
-      return true
-    })
-  }, [channels, searchQuery, selectedTypes])
-
-  const typeCounts = useMemo(() => {
-    return channels.reduce(
-      (counts, channel) => {
-        const channelTypes = channel.type.split(',').map(t => t.trim())
-        for (const option of typeOptions) {
-          if (channelTypes.includes(option)) {
-            counts[option] = (counts[option] || 0) + 1
-          }
-        }
-        return counts
+  const groups = useMemo(
+    () => ({
+      type: {
+        selected: selectedTypes,
+        matches: (channel: MediaChannel, value: string) =>
+          channel.type
+            .split(',')
+            .map(t => t.trim())
+            .includes(value),
       },
-      {} as Record<string, number>
-    )
-  }, [channels])
+    }),
+    [selectedTypes]
+  )
+
+  const filteredChannels = useMemo(
+    () => filterItems(channels, searchPass, groups),
+    [channels, searchPass, groups]
+  )
+
+  const typeCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(channels, searchPass, groups, 'type'),
+        typeOptions,
+        groups.type.matches
+      ),
+    [channels, searchPass, groups]
+  )
 
   const savedScrollY = useRef<number | null>(null)
 

--- a/src/app/projects/ProjectsClient.tsx
+++ b/src/app/projects/ProjectsClient.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { useState, useMemo, useRef, useLayoutEffect } from 'react'
+import { useState, useMemo, useRef, useLayoutEffect, useCallback } from 'react'
 import FilterGroup from '@/components/FilterGroup'
 import FilterSidebar from '@/components/FilterSidebar'
 import ContributeButtons from '@/components/ContributeButtons'
 import SearchBar from '@/components/SearchBar'
 import { Project } from '@/lib/data/projects'
+import { filterItems, optionCounts } from '@/lib/filter-counts'
 
 interface ProjectsClientProps {
   projects: Project[]
@@ -17,40 +18,42 @@ export default function ProjectsClient({ projects }: ProjectsClientProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedStatus, setSelectedStatus] = useState<string[]>([])
 
-  const filteredProjects = useMemo(() => {
-    return projects.filter(project => {
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase()
-        if (
-          !project.name.toLowerCase().includes(query) &&
-          !project.description.toLowerCase().includes(query)
-        ) {
-          return false
-        }
-      }
+  const searchPass = useCallback(
+    (project: Project) => {
+      if (!searchQuery) return true
+      const query = searchQuery.toLowerCase()
+      return (
+        project.name.toLowerCase().includes(query) ||
+        project.description.toLowerCase().includes(query)
+      )
+    },
+    [searchQuery]
+  )
 
-      if (selectedStatus.length > 0) {
-        if (!selectedStatus.includes(project.status)) return false
-      }
-
-      return true
-    })
-  }, [projects, searchQuery, selectedStatus])
-
-  const statusCounts = useMemo(() => {
-    return projects.reduce(
-      (counts, project) => {
-        for (const option of statusOptions) {
-          if (project.status === option) {
-            counts[option] = (counts[option] || 0) + 1
-            break
-          }
-        }
-        return counts
+  const groups = useMemo(
+    () => ({
+      status: {
+        selected: selectedStatus,
+        matches: (project: Project, value: string) => project.status === value,
       },
-      {} as Record<string, number>
-    )
-  }, [projects])
+    }),
+    [selectedStatus]
+  )
+
+  const filteredProjects = useMemo(
+    () => filterItems(projects, searchPass, groups),
+    [projects, searchPass, groups]
+  )
+
+  const statusCounts = useMemo(
+    () =>
+      optionCounts(
+        filterItems(projects, searchPass, groups, 'status'),
+        statusOptions,
+        groups.status.matches
+      ),
+    [projects, searchPass, groups]
+  )
 
   const savedScrollY = useRef<number | null>(null)
 

--- a/src/app/self-study/SelfStudyClient.tsx
+++ b/src/app/self-study/SelfStudyClient.tsx
@@ -30,55 +30,44 @@ export default function SelfStudyClient({ courses }: SelfStudyClientProps) {
   // dashboard can tie clicks to page position even after later reordering.
   const placements = useMemo(() => placementsById(courses), [courses])
 
-  const filteredCourses = useMemo(() => {
-    return courses.filter(course => {
-      if (selectedCategories.length > 0) {
-        const courseCategories = course.category.split(',').map(c => c.trim())
-        if (!selectedCategories.some(cat => courseCategories.includes(cat))) {
-          return false
-        }
-      }
+  // Each dropdown's counts are faceted (same system as /events and
+  // /training): an option's number is how many courses would show if you
+  // picked it, i.e. it respects the OTHER dropdown but not the dropdown's
+  // own, so multi-selecting within one dropdown stays possible.
+  const { filteredCourses, categoryCounts, typeCounts } = useMemo(() => {
+    const facets = (value: string) => value.split(',').map(v => v.trim())
 
-      if (selectedTypes.length > 0) {
-        const courseTypes = course.courseType.split(',').map(t => t.trim())
-        if (!selectedTypes.some(t => courseTypes.includes(t))) {
-          return false
-        }
-      }
-
+    const matchesFilters = (course: Course, skip?: string) => {
+      if (
+        skip !== 'category' &&
+        selectedCategories.length > 0 &&
+        !facets(course.category).some(c => selectedCategories.includes(c))
+      )
+        return false
+      if (
+        skip !== 'type' &&
+        selectedTypes.length > 0 &&
+        !facets(course.courseType).some(t => selectedTypes.includes(t))
+      )
+        return false
       return true
-    })
+    }
+
+    const countBy = (skip: string, extract: (c: Course) => string[]) => {
+      const counts: Record<string, number> = {}
+      for (const course of courses) {
+        if (!matchesFilters(course, skip)) continue
+        for (const key of extract(course)) counts[key] = (counts[key] || 0) + 1
+      }
+      return counts
+    }
+
+    return {
+      filteredCourses: courses.filter(c => matchesFilters(c)),
+      categoryCounts: countBy('category', c => facets(c.category)),
+      typeCounts: countBy('type', c => facets(c.courseType)),
+    }
   }, [courses, selectedCategories, selectedTypes])
-
-  const categoryCounts = useMemo(() => {
-    return courses.reduce(
-      (counts, course) => {
-        const courseCategories = course.category.split(',').map(c => c.trim())
-        for (const category of categoryOptions) {
-          if (courseCategories.includes(category)) {
-            counts[category] = (counts[category] || 0) + 1
-          }
-        }
-        return counts
-      },
-      {} as Record<string, number>
-    )
-  }, [courses])
-
-  const typeCounts = useMemo(() => {
-    return courses.reduce(
-      (counts, course) => {
-        const courseTypes = course.courseType.split(',').map(t => t.trim())
-        for (const type of typeOptions) {
-          if (courseTypes.includes(type)) {
-            counts[type] = (counts[type] || 0) + 1
-          }
-        }
-        return counts
-      },
-      {} as Record<string, number>
-    )
-  }, [courses])
 
   // Preserve scroll position when toggling a filter re-renders the list.
   const savedScrollY = useRef<number | null>(null)

--- a/src/lib/filter-counts.ts
+++ b/src/lib/filter-counts.ts
@@ -1,0 +1,53 @@
+// Shared machinery for the resource pages' filter sidebars. Each page
+// declares its filter groups once; the same declaration then drives both
+// the visible list and the sidebar counts.
+//
+// Counts are "live": a group's numbers are computed over the items that
+// pass the search box and every OTHER group, ignoring the group's own
+// ticks — so each number answers "what would I get if I also ticked
+// this?", and ticking one option never zeroes out its siblings.
+
+export interface FilterGroupSpec<T> {
+  selected: string[]
+  matches: (item: T, value: string) => boolean
+}
+
+/**
+ * Items that pass `base` (search plus any always-on conditions) and every
+ * group's selections. Pass `skip` to leave one group's selections out —
+ * used to compute that group's counts.
+ */
+export function filterItems<T>(
+  items: T[],
+  base: (item: T) => boolean,
+  groups: Record<string, FilterGroupSpec<T>>,
+  skip?: string
+): T[] {
+  return items.filter(item => {
+    if (!base(item)) return false
+    for (const [key, group] of Object.entries(groups)) {
+      if (key === skip || group.selected.length === 0) continue
+      if (!group.selected.some(value => group.matches(item, value))) {
+        return false
+      }
+    }
+    return true
+  })
+}
+
+/** How many of `items` match each option. */
+export function optionCounts<T>(
+  items: T[],
+  options: string[],
+  matches: (item: T, value: string) => boolean
+): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const item of items) {
+    for (const option of options) {
+      if (matches(item, option)) {
+        counts[option] = (counts[option] || 0) + 1
+      }
+    }
+  }
+  return counts
+}


### PR DESCRIPTION
- Filter counts across the resource pages now update live: a group's numbers reflect the search box and every other active filter, ignoring the group's own ticks — each number answers "what would I get if I also ticked this?"
- This is the same faceted-count system the redesigned /events and /training pages already use; those two pages are unchanged
- The eight sidebar-style pages — jobs (migrated off its own one-page version of this logic), communities, funding, map, advisors, founders, media channels, and projects — share one new helper, `src/lib/filter-counts.ts`
- /self-study, which uses the /events-style dropdowns, is implemented in the same idiom as /events and /training
- Filtering behavior everywhere is unchanged — only the displayed numbers are new
- Verified in the browser on all nine pages; production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)